### PR TITLE
fix: grep 全角冒号字符类匹配失败 (Issue #22)

### DIFF
--- a/skills/story-setup/references/templates/hooks/validate-story-commit.sh
+++ b/skills/story-setup/references/templates/hooks/validate-story-commit.sh
@@ -18,7 +18,7 @@ while IFS= read -r -d '' file; do
   # 检查正文文件是否包含硬编码的情节值
   case "$file" in
     */正文/*)
-      HARDCODED=$(grep -nE "(身高|体重|年龄)[：:][0-9]+" "$file" 2>/dev/null || true)
+      HARDCODED=$(grep -nE "(身高|体重|年龄)(：|:)[0-9]+" "$file" 2>/dev/null || true)
       if [ -n "$HARDCODED" ]; then
         WARNINGS="$WARNINGS\n⚠ $file: Hardcoded character attributes found (should reference 设定/ files):\n$HARDCODED"
       fi


### PR DESCRIPTION
## Summary
- 修复 `validate-story-commit.sh` 第 21 行 grep 正则 `[：:]` 在 macOS BSD grep 下对多字节 UTF-8 字符处理不一致的问题
- 改为 POSIX 兼容的交替分组 `(：|:)`，同时匹配全角和半角冒号

## Test plan
- [x] `echo '身高：180' | grep -E '(身高|体重|年龄)(：|:)[0-9]+'` 有输出
- [x] `echo '身高:180' | grep -E '(身高|体重|年龄)(：|:)[0-9]+'` 有输出
- [x] `bash scripts/static-check.sh` 全部 PASS
- [ ] CI 三平台通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)