### PR TITLE
docs: add online experience link for short story writing skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ npx skills add worldwonderer/oh-story-claudecode -y
 
 更新时重新执行同一条命令即可。
 
+## 在线体验
+
+**不想安装？** 打开链接即可直接使用短篇写作技能，无需 clone 仓库或配置环境：
+
+[🚀 在线体验短篇写作技能](https://socialistic.ai/en/skill/oh-story-claudecode-7aa95c)
+
+*适合不想折腾技术的写手，打开链接就能从构思到成稿一站式完成。*
+
 ## Skills
 
 | Skill | 触发 | 说明 |


### PR DESCRIPTION
Closes #2

## 变更

- 在 README.md 中新增「在线体验」部分
- 添加 socialistic.ai 在线入口链接，方便不想安装工具的写手直接使用

## 背景

Issue #2 提到很多写手技术栈止步于 Word，他们最需要这个工具但不可能去 clone 仓库跑 Claude Code。socialistic.ai 已将短篇写作 skill 做成了在线入口，打开链接就能直接从构思到成稿一站式完成。

添加这个链接可以让更多写手轻松访问和使用这套技能。

## 测试

- README.md 格式正确
- 链接有效（已验证）
- 不影响现有安装方式