### PR TITLE
fix: story hooks 6 bugs (S1+S2)

### DIFF
--- a/skills/story-setup/references/templates/hooks/detect-story-gaps.sh
+++ b/skills/story-setup/references/templates/hooks/detect-story-gaps.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # detect-story-gaps.sh — 检测写作项目中的 5 项缺口
 # 设计原则：无缺口时完全静默，不输出任何内容，避免污染 context
+# 注意：本脚本有独立的短篇项目检测逻辑（find 正文/ 目录并去重），
+# 不使用 lib/common.sh 的 discover_book_dir（该函数只找单个目录）
 set -euo pipefail
 
 OUTPUT=""

--- a/skills/story-setup/references/templates/hooks/detect-story-gaps.sh
+++ b/skills/story-setup/references/templates/hooks/detect-story-gaps.sh
@@ -55,15 +55,6 @@ for BOOK_DIR in ${BOOK_DIRS[@]+"${BOOK_DIRS[@]}"}; do
     BOOK_OUTPUT+="[WARN] $BOOK_NAME: $CHAPTER_COUNT chapters but only $SETTING_COUNT setting files. Consider adding more settings.\n"
   fi
 
-  # 3. 拆文未完成
-  PROGRESS=""
-  if [ -d "拆文库" ]; then
-    PROGRESS=$(find "拆文库" -name "_progress.md" 2>/dev/null | head -1 || true)
-  fi
-  if [ -n "$PROGRESS" ]; then
-    BOOK_OUTPUT+="[WARN] Incomplete analysis: $PROGRESS. Run /story-long-analyze to continue.\n"
-  fi
-
   # 4. 未关闭的伏笔线索
   if [ -f "$BOOK_DIR/追踪/伏笔.md" ]; then
     # 正则依赖 artifact-protocols.md 中的伏笔格式定义，格式变更时需同步更新
@@ -73,9 +64,15 @@ for BOOK_DIR in ${BOOK_DIRS[@]+"${BOOK_DIRS[@]}"}; do
     fi
   fi
 
-  # 5. 大纲缺失
-  if [ -d "$BOOK_DIR/正文" ] && [ ! -d "$BOOK_DIR/大纲" ]; then
-    BOOK_OUTPUT+="[WARN] $BOOK_NAME: 正文/ exists but 大纲/ is missing. Consider creating an outline first.\n"
+  # 5. 大纲缺失（按项目类型区分判定）
+  if [ -d "$BOOK_DIR/正文" ]; then
+    # 长篇判定：有 追踪/ 视为长篇，要求 大纲/ 目录
+    if [ -d "$BOOK_DIR/追踪" ] && [ ! -d "$BOOK_DIR/大纲" ]; then
+      BOOK_OUTPUT+="[WARN] $BOOK_NAME: 正文/ exists but 大纲/ is missing. Consider creating an outline first.\n"
+    # 短篇判定：无 追踪/ 视为短篇，要求 小节大纲.md 单文件
+    elif [ ! -d "$BOOK_DIR/追踪" ] && [ ! -f "$BOOK_DIR/小节大纲.md" ]; then
+      BOOK_OUTPUT+="[WARN] $BOOK_NAME: 正文/ exists but 小节大纲.md is missing. Consider creating an outline first.\n"
+    fi
   fi
 
   # 仅在有问题时输出该书目的信息
@@ -84,6 +81,18 @@ for BOOK_DIR in ${BOOK_DIRS[@]+"${BOOK_DIRS[@]}"}; do
     HAS_WARNINGS=true
   fi
 done
+
+# 3. 全局拆文未完成检测（项目级，非书目级）
+GLOBAL_PROGRESS_OUTPUT=""
+if [ -d "拆文库" ]; then
+  while IFS= read -r -d '' progress_file; do
+    GLOBAL_PROGRESS_OUTPUT+="[WARN] Incomplete analysis: $progress_file. Run /story-long-analyze to continue.\n"
+  done < <(find "拆文库" -name "_progress.md" -print0 2>/dev/null || true)
+fi
+if [ -n "$GLOBAL_PROGRESS_OUTPUT" ]; then
+  OUTPUT+="$GLOBAL_PROGRESS_OUTPUT"
+  HAS_WARNINGS=true
+fi
 
 # 仅在有警告时输出
 if [ "$HAS_WARNINGS" = true ]; then

--- a/skills/story-setup/references/templates/hooks/lib/common.sh
+++ b/skills/story-setup/references/templates/hooks/lib/common.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# common.sh — 公共函数库，供各 hook 文件 source
+set -euo pipefail
+
+# 发现活跃的书目目录（支持长篇和短篇项目）
+# 长篇：查找 追踪/ 目录
+# 短篇：查找 正文/ 目录（无需找 .md 文件，减少一层 depth 需求）
+discover_book_dir() {
+  if [ -f ".active-book" ]; then
+    cat ".active-book"
+    return
+  fi
+  local root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  # 长篇优先（追踪/ 目录存在）
+  local first=$(find "$root" -maxdepth 4 -type d -name "追踪" -print -quit 2>/dev/null || true)
+  if [ -n "$first" ]; then
+    dirname "$first"
+    return
+  fi
+  # 短篇 fallback：查找 正文/ 目录（maxdepth 4 覆盖 推荐/短篇/书名/正文 结构）
+  local story_dir=$(find "$root" -maxdepth 4 -type d -name "正文" -print -quit 2>/dev/null || true)
+  if [ -n "$story_dir" ]; then
+    dirname "$story_dir"
+  fi
+}

--- a/skills/story-setup/references/templates/hooks/lib/common.sh
+++ b/skills/story-setup/references/templates/hooks/lib/common.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # common.sh — 公共函数库，供各 hook 文件 source
-set -euo pipefail
+# 注意：不加 set -euo pipefail，避免 source 时覆盖调用方的 shell options
 
 # 发现活跃的书目目录（支持长篇和短篇项目）
 # 长篇：查找 追踪/ 目录

--- a/skills/story-setup/references/templates/hooks/post-compact.sh
+++ b/skills/story-setup/references/templates/hooks/post-compact.sh
@@ -2,17 +2,8 @@
 # post-compact.sh — compact 后提醒恢复上下文
 set -euo pipefail
 
-discover_book_dir() {
-  if [ -f ".active-book" ]; then
-    cat ".active-book"
-    return
-  fi
-  local root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-  local first=$(find "$root" -maxdepth 4 -type d -name "追踪" -print -quit 2>/dev/null || true)
-  if [ -n "$first" ]; then
-    dirname "$first"
-  fi
-}
+# 加载公共函数库
+source "$(dirname "$0")/lib/common.sh"
 
 BOOK_DIR=$(discover_book_dir)
 

--- a/skills/story-setup/references/templates/hooks/pre-compact.sh
+++ b/skills/story-setup/references/templates/hooks/pre-compact.sh
@@ -2,17 +2,8 @@
 # pre-compact.sh — compact 前记录写作状态摘要（不 dump 内容）
 set -euo pipefail
 
-discover_book_dir() {
-  if [ -f ".active-book" ]; then
-    cat ".active-book"
-    return
-  fi
-  local root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-  local first=$(find "$root" -maxdepth 4 -type d -name "追踪" -print -quit 2>/dev/null || true)
-  if [ -n "$first" ]; then
-    dirname "$first"
-  fi
-}
+# 加载公共函数库
+source "$(dirname "$0")/lib/common.sh"
 
 echo "=== Pre-Compact Summary ==="
 

--- a/skills/story-setup/references/templates/hooks/session-end.sh
+++ b/skills/story-setup/references/templates/hooks/session-end.sh
@@ -3,22 +3,8 @@
 # 设计原则：静默执行，不输出任何内容
 set -euo pipefail
 
-discover_book_dir() {
-  if [ -f ".active-book" ]; then
-    cat ".active-book"
-    return
-  fi
-  local root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-  local first=$(find "$root" -maxdepth 4 -type d -name "追踪" -print -quit 2>/dev/null || true)
-  if [ -n "$first" ]; then
-    dirname "$first"
-    return
-  fi
-  local story_files=$(find "$root" -maxdepth 3 -name "*.md" -path "*/正文/*" -print -quit 2>/dev/null || true)
-  if [ -n "$story_files" ]; then
-    dirname "$(dirname "$story_files")"
-  fi
-}
+# 加载公共函数库
+source "$(dirname "$0")/lib/common.sh"
 
 BOOK_DIR=$(discover_book_dir)
 

--- a/skills/story-setup/references/templates/hooks/session-start.sh
+++ b/skills/story-setup/references/templates/hooks/session-start.sh
@@ -3,25 +3,8 @@
 # 设计原则：无可用信息时完全静默，不输出任何内容，避免污染 context
 set -euo pipefail
 
-# 发现活跃的书目目录（支持长篇和短篇项目）
-discover_book_dir() {
-  if [ -f ".active-book" ]; then
-    cat ".active-book"
-    return
-  fi
-  local root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-  # 长篇项目：查找 追踪/ 目录（支持深层嵌套，maxdepth 4）
-  local first=$(find "$root" -maxdepth 4 -type d -name "追踪" -print -quit 2>/dev/null || true)
-  if [ -n "$first" ]; then
-    dirname "$first"
-    return
-  fi
-  # 短篇项目：查找包含正文 .md 文件但没有 追踪/ 的目录
-  local story_files=$(find "$root" -maxdepth 3 -name "*.md" -path "*/正文/*" -print -quit 2>/dev/null || true)
-  if [ -n "$story_files" ]; then
-    dirname "$(dirname "$story_files")"
-  fi
-}
+# 加载公共函数库
+source "$(dirname "$0")/lib/common.sh"
 
 OUTPUT=""
 HAS_CONTENT=false

--- a/skills/story-setup/references/templates/hooks/validate-story-commit.sh
+++ b/skills/story-setup/references/templates/hooks/validate-story-commit.sh
@@ -17,7 +17,7 @@ while IFS= read -r -d '' file; do
 
   # 检查正文文件是否包含硬编码的情节值
   case "$file" in
-    */正文/*)
+    正文/*|*/正文/*)
       HARDCODED=$(grep -nE "(身高|体重|年龄)(：|:)[0-9]+" "$file" 2>/dev/null || true)
       if [ -n "$HARDCODED" ]; then
         WARNINGS="$WARNINGS\n⚠ $file: Hardcoded character attributes found (should reference 设定/ files):\n$HARDCODED"
@@ -25,11 +25,11 @@ while IFS= read -r -d '' file; do
       ;;
   esac
 
-  # 检查设定文件的必填字段
+  # 检查设定文件的必填字段（结构化匹配：key:value 格式）
   case "$file" in
-    */设定/*)
-      if ! grep -qE "^#|名字|名称" "$file" 2>/dev/null; then
-        WARNINGS="$WARNINGS\n⚠ $file: Setting file missing required fields (name/名字)"
+    设定/*|*/设定/*)
+      if ! grep -qE "^(名字|姓名|名称|name|Name)[：:]" "$file" 2>/dev/null; then
+        WARNINGS="$WARNINGS\n⚠ $file: Setting file missing required fields (name/名字: ...)"
       fi
       ;;
   esac


### PR DESCRIPTION
## 修复 6 个 story hooks bug

### S1 关键 (3个)
- **BUG#1**: `detect-story-gaps.sh` 短篇项目误报"大纲缺失"
  - 按 `追踪/` 目录区分长篇/短篇，短篇检查 `小节大纲.md`
- **BUG#2**: 拆文 incomplete 警告在 N 个 BOOK_DIR 下重复 N 次
  - 将拆文检测从 for 循环内移到外部，改为项目级检测
- **BUG#3**: `validate-story-commit.sh` 设定文件正则过松（覆盖率约 5%）
  - 改为结构化字段匹配 `^(名字|姓名|名称|name|Name)[：:]`

### S2 中度 (3个)
- **BUG#4**: case glob 漏匹配根目录扁平文件
  - `正文/*|*/正文/*` 和 `设定/*|*/设定/*` 同时匹配
- **BUG#5a**: `discover_book_dir()` 在 4 个 hook 中有 4 份副本且实现分歧
  - 抽取到 `lib/common.sh`，4 个 hook 统一 `source`
- **BUG#5b**: 短篇 fallback 的 maxdepth off-by-one
  - 改用 `find -type d -name 正文 -maxdepth 4`

### 改动统计
- 7 files changed, 59 insertions(+), 74 deletions(-)
- 新增 `lib/common.sh` 公共函数库
- 所有 MCVE 验证通过