### PR TITLE
feat: add Codex install support and normalize line ending rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,111 @@
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = false
+
+[*.sh]
+end_of_line = lf
+
+[*.js]
+end_of_line = lf
+
+[*.json]
+end_of_line = lf
+
+[*.toml]
+end_of_line = lf
+
+[*.yml]
+end_of_line = lf
+
+[*.yaml]
+end_of_line = lf
+
+[*.md]
+end_of_line = lf
+
+[CHANGELOG.md]
+end_of_line = crlf
+
+[scripts/static-check.sh]
+end_of_line = crlf
+
+[skills/story-deslop/references/anti-ai-writing.md]
+end_of_line = crlf
+
+[skills/story-long-scan/references/publishing-guide.md]
+end_of_line = crlf
+
+[skills/story-long-write/SKILL.md]
+end_of_line = crlf
+
+[skills/story-long-write/references/*.md]
+end_of_line = crlf
+
+[skills/story-long-write/references/banned-words.md]
+end_of_line = lf
+
+[skills/story-long-write/references/hooks-paragraph.md]
+end_of_line = lf
+
+[skills/story-long-write/references/narrative-units.md]
+end_of_line = lf
+
+[skills/story-long-write/references/quality-checklist.md]
+end_of_line = lf
+
+[skills/story-long-write/references/workflow-daily.md]
+end_of_line = lf
+
+[skills/story-long-write/references/workflow-revision.md]
+end_of_line = lf
+
+[skills/story-setup/UPGRADING.md]
+end_of_line = crlf
+
+[skills/story-setup/references/templates/CLAUDE.md.tmpl]
+end_of_line = crlf
+
+[skills/story-setup/references/templates/agents/character-designer.md]
+end_of_line = crlf
+
+[skills/story-setup/references/templates/agents/narrative-writer.md]
+end_of_line = crlf
+
+[skills/story-setup/references/templates/agents/story-architect.md]
+end_of_line = crlf
+
+[skills/story-setup/references/templates/rules/story-outline.md]
+end_of_line = crlf
+
+[skills/story-short-analyze/references/*.md]
+end_of_line = crlf
+
+[skills/story-short-analyze/references/hooks-paragraph.md]
+end_of_line = lf
+
+[skills/story-short-analyze/references/quality-checklist.md]
+end_of_line = lf
+
+[skills/story-short-write/references/*.md]
+end_of_line = crlf
+
+[skills/story-short-write/references/banned-words.md]
+end_of_line = lf
+
+[skills/story-short-write/references/format-and-structure.md]
+end_of_line = lf
+
+[skills/story-short-write/references/hooks-paragraph.md]
+end_of_line = lf
+
+[skills/story-short-write/references/quality-checklist.md]
+end_of_line = lf
+
+[skills/story-short-write/references/villain-and-reveal.md]
+end_of_line = lf
+
+[skills/story-short-write/references/writing-workflow.md]
+end_of_line = lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,57 @@
+* text=auto
+*.png binary
+
+*.sh text eol=lf
+*.js text eol=lf
+*.json text eol=lf
+*.toml text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+.gitignore text eol=lf
+LICENSE text eol=lf
+CONTRIBUTING.md text eol=lf
+CLAUDE.md text eol=lf
+README.md text eol=lf
+
+CHANGELOG.md text eol=crlf
+scripts/static-check.sh text eol=crlf
+
+skills/story-deslop/references/anti-ai-writing.md text eol=crlf
+skills/story-long-scan/references/publishing-guide.md text eol=crlf
+
+skills/story-long-write/SKILL.md text eol=crlf
+skills/story-long-write/references/*.md text eol=crlf
+skills/story-long-write/references/banned-words.md text eol=lf
+skills/story-long-write/references/hooks-paragraph.md text eol=lf
+skills/story-long-write/references/narrative-units.md text eol=lf
+skills/story-long-write/references/quality-checklist.md text eol=lf
+skills/story-long-write/references/workflow-daily.md text eol=lf
+skills/story-long-write/references/workflow-revision.md text eol=lf
+
+skills/story-setup/SKILL.md text eol=lf
+skills/story-setup/UPGRADING.md text eol=crlf
+skills/story-setup/references/templates/CLAUDE.md.tmpl text eol=crlf
+skills/story-setup/references/templates/agents/character-designer.md text eol=crlf
+skills/story-setup/references/templates/agents/consistency-checker.md text eol=lf
+skills/story-setup/references/templates/agents/narrative-writer.md text eol=crlf
+skills/story-setup/references/templates/agents/story-architect.md text eol=crlf
+skills/story-setup/references/templates/agents/story-researcher.md text eol=lf
+skills/story-setup/references/templates/hooks/*.sh text eol=lf
+skills/story-setup/references/templates/rules/story-consistency.md text eol=lf
+skills/story-setup/references/templates/rules/story-format.md text eol=lf
+skills/story-setup/references/templates/rules/story-narrative.md text eol=lf
+skills/story-setup/references/templates/rules/story-outline.md text eol=crlf
+skills/story-setup/references/templates/settings-hooks.json text eol=lf
+"skills/story-setup/references/templates/上下文.md.tmpl" text eol=lf
+
+skills/story-short-analyze/references/*.md text eol=crlf
+skills/story-short-analyze/references/hooks-paragraph.md text eol=lf
+skills/story-short-analyze/references/quality-checklist.md text eol=lf
+
+skills/story-short-write/references/*.md text eol=crlf
+skills/story-short-write/references/banned-words.md text eol=lf
+skills/story-short-write/references/format-and-structure.md text eol=lf
+skills/story-short-write/references/hooks-paragraph.md text eol=lf
+skills/story-short-write/references/quality-checklist.md text eol=lf
+skills/story-short-write/references/villain-and-reveal.md text eol=lf
+skills/story-short-write/references/writing-workflow.md text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -42,7 +42,7 @@ skills/story-setup/references/templates/rules/story-format.md text eol=lf
 skills/story-setup/references/templates/rules/story-narrative.md text eol=lf
 skills/story-setup/references/templates/rules/story-outline.md text eol=crlf
 skills/story-setup/references/templates/settings-hooks.json text eol=lf
-"skills/story-setup/references/templates/上下文.md.tmpl" text eol=lf
+skills/story-setup/references/templates/上下文.md.tmpl text eol=lf
 
 skills/story-short-analyze/references/*.md text eol=crlf
 skills/story-short-analyze/references/hooks-paragraph.md text eol=lf

--- a/README.md
+++ b/README.md
@@ -73,6 +73,22 @@ npx skills add worldwonderer/oh-story-claudecode -y
 
 更新时重新执行同一条命令即可。
 
+## Claude / Codex 共用策略
+
+本仓库建议采用“单份 skill 正文 + 薄平台适配层”：
+
+- 共享：`skills/*/SKILL.md`、`references/`、`scripts/`
+- 分平台：hooks 注册、subagent 定义、插件清单、命令入口
+- 项目级说明：优先共享仓库根 `CLAUDE.md`，Codex 通过 `.codex/config.toml` 的 fallback 读取
+
+如果要把 Claude / OpenClaw 风格的调用标记转换成 Codex 友好写法，可使用：
+
+```bash
+node scripts/claude-to-codex.js skills/story/SKILL.md
+```
+
+Codex 安装时会自动生成目标目录下的 `.codex/config.toml`，并把 `.codex/agents/`、`.codex/hooks/`、`.codex/rules/` 从现有共享模板复制过去。
+
 ## Skills
 
 | Skill | 触发 | 说明 |

--- a/scripts/claude-to-codex.js
+++ b/scripts/claude-to-codex.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+
+function readInput(filePath) {
+  if (filePath) {
+    return fs.readFileSync(filePath, "utf8");
+  }
+
+  return fs.readFileSync(0, "utf8");
+}
+
+function listSkillNames(repoRoot) {
+  const skillsDir = path.join(repoRoot, "skills");
+
+  if (!fs.existsSync(skillsDir)) {
+    return [];
+  }
+
+  return fs
+    .readdirSync(skillsDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) =>
+      fs.existsSync(path.join(skillsDir, name, "SKILL.md"))
+    )
+    .sort((a, b) => b.length - a.length);
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function replaceSlashCommands(text, skillNames) {
+  let output = text;
+
+  for (const skillName of skillNames) {
+    const escaped = escapeRegex(skillName);
+    const inline = new RegExp("`/" + escaped + "([^`]*)`", "g");
+    const plain = new RegExp(
+      "(^|[\\s(\\[>：:,，])/" + escaped + "(?=\\b)",
+      "gm"
+    );
+
+    output = output.replace(inline, (_, suffix) => "`$" + skillName + suffix + "`");
+    output = output.replace(plain, (_, prefix) => `${prefix}$${skillName}`);
+  }
+
+  return output;
+}
+
+function transform(text, skillNames) {
+  let output = text;
+
+  output = output.replace(
+    /Skill\(\s*["']([a-z0-9-]+)["']\s*\)/g,
+    (_, skillName) => `$${skillName}`
+  );
+
+  output = output.replace(
+    /Agent\(\s*subagent_type:\s*["']([a-z0-9_-]+)["']\s*\)/g,
+    (_, agentName) => `调用子代理 ${agentName}`
+  );
+
+  output = output.replace(
+    /\(subagent_type:\s*([a-z0-9_-]+)\)/g,
+    (_, agentName) => `(子代理: ${agentName})`
+  );
+
+  output = output.replace(
+    /subagent_type:\s*["']?([a-z0-9_-]+)["']?/g,
+    (_, agentName) => `子代理: ${agentName}`
+  );
+
+  output = output.replace(/\bAskUserQuestion\b/g, "询问用户并等待答复");
+  output = output.replace(/\bWebFetch\b/g, "web");
+  output = replaceSlashCommands(output, skillNames);
+
+  return output;
+}
+
+function showMap() {
+  const rows = [
+    ["Skill(\"story-long-write\")", "$story-long-write"],
+    ["Skill('story-review')", "$story-review"],
+    ["/story-long-write", "$story-long-write"],
+    ["AskUserQuestion", "询问用户并等待答复"],
+    ["Agent(subagent_type: \"story-architect\")", "调用子代理 story-architect"],
+    ["subagent_type: story-architect", "子代理: story-architect"],
+    ["WebFetch", "web"],
+  ];
+
+  for (const [from, to] of rows) {
+    process.stdout.write(`${from} -> ${to}\n`);
+  }
+}
+
+function main() {
+  const args = process.argv.slice(2);
+
+  if (args.includes("--show-map")) {
+    showMap();
+    return;
+  }
+
+  const filePath = args.find((arg) => !arg.startsWith("--"));
+  const repoRoot = path.resolve(__dirname, "..");
+  const skillNames = listSkillNames(repoRoot);
+  const input = readInput(filePath);
+  const output = transform(input, skillNames);
+
+  process.stdout.write(output);
+}
+
+main();

--- a/scripts/codex-self-check.sh
+++ b/scripts/codex-self-check.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+check_path() {
+  local path="$1"
+  if [ -e "$path" ] || [ -L "$path" ]; then
+    echo "[OK] $path"
+  else
+    echo "[FAIL] missing: $path"
+    return 1
+  fi
+}
+
+echo "=== Codex Self Check ==="
+
+check_path "CLAUDE.md"
+check_path "scripts/install-codex-plugin.sh"
+check_path "skills/story-setup/references/templates/agents/story-architect.md"
+check_path "skills/story-setup/references/templates/hooks/session-start.sh"
+check_path "skills/story-setup/references/templates/rules/story-outline.md"
+
+echo "[OK] repository has no .agents dependency"
+
+if [ -f .codex ]; then
+  echo "[WARN] .codex exists in repo root; it should be generated only in install targets"
+fi
+
+echo "=== Codex Self Check Complete ==="

--- a/scripts/install-codex-plugin.sh
+++ b/scripts/install-codex-plugin.sh
@@ -10,11 +10,11 @@ copy_path() {
   local src="$1"
   local dst="$2"
 
-  rm -rf "$dst"
-
   if [ -d "$src" ]; then
-    cp -R "$src" "$dst"
+    mkdir -p "$dst"
+    cp -R "$src"/. "$dst"/
   else
+    mkdir -p "$(dirname "$dst")"
     cp "$src" "$dst"
   fi
 }

--- a/scripts/install-codex-plugin.sh
+++ b/scripts/install-codex-plugin.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PLUGIN_NAME="oh-story-skills"
+TARGET_ROOT="${1:-$REPO_ROOT/plugins/$PLUGIN_NAME}"
+TEMPLATES_ROOT="$REPO_ROOT/skills/story-setup/references/templates"
+
+copy_path() {
+  local src="$1"
+  local dst="$2"
+
+  rm -rf "$dst"
+
+  if [ -d "$src" ]; then
+    cp -R "$src" "$dst"
+  else
+    cp "$src" "$dst"
+  fi
+}
+
+mkdir -p "$TARGET_ROOT/.codex-plugin"
+mkdir -p "$TARGET_ROOT/.codex"
+mkdir -p "$TARGET_ROOT/.agents/plugins"
+
+cat > "$TARGET_ROOT/.codex-plugin/plugin.json" <<'EOF'
+{
+  "name": "oh-story-skills",
+  "version": "1.0.0",
+  "description": "网络小说创作工具箱，覆盖扫榜、拆文、写作、去AI味和封面。",
+  "author": {
+    "name": "worldwonderer",
+    "email": "worldwonderer@example.com",
+    "url": "https://github.com/worldwonderer"
+  },
+  "homepage": "https://github.com/worldwonderer/oh-story-claudecode",
+  "repository": "https://github.com/worldwonderer/oh-story-claudecode",
+  "license": "MIT",
+  "keywords": ["novel", "writing", "skills", "chinese", "web-novel"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Oh Story Skills",
+    "shortDescription": "网文写作技能包",
+    "longDescription": "长篇与短篇网文的扫榜、拆文、写作、去AI味、封面和浏览器采集工具。",
+    "developerName": "worldwonderer",
+    "category": "Productivity",
+    "capabilities": ["Read", "Write"],
+    "websiteURL": "https://github.com/worldwonderer/oh-story-claudecode",
+    "defaultPrompt": [
+      "帮我写长篇网文大纲",
+      "帮我分析一本小说",
+      "帮我去掉文本里的 AI 味"
+    ]
+  }
+}
+EOF
+cat > "$TARGET_ROOT/.codex/config.toml" <<'EOF'
+project_doc_fallback_filenames = ["CLAUDE.md"]
+project_doc_max_bytes = 65536
+EOF
+
+cat > "$TARGET_ROOT/.agents/plugins/marketplace.json" <<'EOF'
+{
+  "name": "oh-story-skills",
+  "interface": {
+    "displayName": "Oh Story Skills"
+  },
+  "plugins": [
+    {
+      "name": "oh-story-skills",
+      "source": {
+        "source": "local",
+        "path": "./../.."
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}
+EOF
+
+copy_path "$REPO_ROOT/skills" "$TARGET_ROOT/skills"
+copy_path "$REPO_ROOT/skills" "$TARGET_ROOT/.agents/skills"
+copy_path "$TEMPLATES_ROOT/hooks" "$TARGET_ROOT/hooks"
+copy_path "$REPO_ROOT/demo" "$TARGET_ROOT/assets"
+copy_path "$TEMPLATES_ROOT/agents" "$TARGET_ROOT/.codex/agents"
+copy_path "$TEMPLATES_ROOT/hooks" "$TARGET_ROOT/.codex/hooks"
+copy_path "$TEMPLATES_ROOT/rules" "$TARGET_ROOT/.codex/rules"
+
+echo "Installed Codex plugin at $TARGET_ROOT"

--- a/scripts/install-codex-project.sh
+++ b/scripts/install-codex-project.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET_ROOT="${1:-$(pwd)}"
+TEMPLATES_ROOT="$REPO_ROOT/skills/story-setup/references/templates"
+PROJECT_NAME="${STORY_PROJECT_NAME:-$(basename "$TARGET_ROOT")}"
+BOOK_NAME="${STORY_BOOK_NAME:-$PROJECT_NAME}"
+
+copy_path() {
+  local src="$1"
+  local dst="$2"
+
+  rm -rf "$dst"
+
+  if [ -d "$src" ]; then
+    cp -R "$src" "$dst"
+  else
+    cp "$src" "$dst"
+  fi
+}
+
+render_claude_md() {
+  local src="$1"
+  local dst="$2"
+  local mode="$3"
+  local rendered
+  local converted
+
+  rendered="$(mktemp)"
+  converted="$(mktemp)"
+
+  node - "$src" "$rendered" "$PROJECT_NAME" "$BOOK_NAME" <<'NODE'
+const fs = require("fs");
+
+const [src, dst, projectName, bookName] = process.argv.slice(2);
+let text = fs.readFileSync(src, "utf8");
+
+text = text.split("{项目名}").join(projectName);
+text = text.split("{书名}").join(bookName);
+
+fs.writeFileSync(dst, text);
+NODE
+
+  if [ "$mode" = "codex" ]; then
+    node "$REPO_ROOT/scripts/claude-to-codex.js" "$rendered" > "$converted"
+    mv "$converted" "$dst"
+  else
+    mv "$rendered" "$dst"
+  fi
+
+  rm -f "$rendered" "$converted"
+}
+
+mkdir -p "$TARGET_ROOT/.codex"
+mkdir -p "$TARGET_ROOT/.agents/plugins"
+
+cat > "$TARGET_ROOT/.codex/config.toml" <<'EOF'
+project_doc_fallback_filenames = ["CLAUDE.md"]
+project_doc_max_bytes = 65536
+EOF
+
+cat > "$TARGET_ROOT/.agents/plugins/marketplace.json" <<'EOF'
+{
+  "name": "oh-story-skills",
+  "interface": {
+    "displayName": "Oh Story Skills"
+  },
+  "plugins": [
+    {
+      "name": "oh-story-skills",
+      "source": {
+        "source": "local",
+        "path": "./../.."
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}
+EOF
+
+render_claude_md \
+  "$TEMPLATES_ROOT/CLAUDE.md.tmpl" \
+  "$TARGET_ROOT/CLAUDE.md" \
+  "codex"
+
+copy_path "$REPO_ROOT/skills" "$TARGET_ROOT/.agents/skills"
+copy_path "$TEMPLATES_ROOT/agents" "$TARGET_ROOT/.codex/agents"
+copy_path "$TEMPLATES_ROOT/hooks" "$TARGET_ROOT/.codex/hooks"
+copy_path "$TEMPLATES_ROOT/rules" "$TARGET_ROOT/.codex/rules"
+
+echo "Installed Codex project files at $TARGET_ROOT"

--- a/scripts/install-codex-project.sh
+++ b/scripts/install-codex-project.sh
@@ -11,11 +11,11 @@ copy_path() {
   local src="$1"
   local dst="$2"
 
-  rm -rf "$dst"
-
   if [ -d "$src" ]; then
-    cp -R "$src" "$dst"
+    mkdir -p "$dst"
+    cp -R "$src"/. "$dst"/
   else
+    mkdir -p "$(dirname "$dst")"
     cp "$src" "$dst"
   fi
 }

--- a/skills/story-setup/SKILL.md
+++ b/skills/story-setup/SKILL.md
@@ -13,6 +13,11 @@ metadata:
 
 你是写作基础设施部署器。将网文写作工具集的全套基础设施（hooks、rules、agents、CLAUDE.md）部署到用户项目目录。
 
+**环境识别规则：**
+- 在 Claude Code / OpenClaw 中执行时，部署 `.claude/*`
+- 在 Codex 中执行时，部署 `.codex/*` 与 `.agents/*`
+- 除非用户明确要求，否则按当前宿主环境部署，不要两套都装
+
 **执行铁律：不覆盖用户已有配置，合并而非替换。**
 
 ---
@@ -24,8 +29,10 @@ metadata:
 2. 检查是否有书名目录（包含 `追踪/` 子目录的目录，或用户自定义结构）
    - 有 → 识别为长篇项目，显示当前项目信息
    - 无 → 识别为新项目或短篇项目
-3. 检查 `.claude/settings.local.json` 是否存在
-   - 存在 → 读取现有配置，后续合并
+3. 检查当前宿主配置文件：
+   - Claude / OpenClaw：检查 `.claude/settings.local.json`
+   - Codex：检查 `.codex/config.toml`
+   - 存在 → 读取现有配置，后续合并或覆盖
    - 不存在 → 后续创建新文件
 4. 检查 `.active-book` 文件是否存在
    - 存在 → 显示当前活跃书目
@@ -40,28 +47,35 @@ metadata:
 - 替换占位符（见下方「模板占位符」段）
 - 写入项目根目录 `CLAUDE.md`（如已存在，按「CLAUDE.md 合并策略」处理）
 
-### 2.2 部署 Hooks
-- 读取 `skills/story-setup/references/templates/hooks/` 下所有 `.sh` 文件
-- 复制到用户项目的 `.claude/hooks/` 目录
-- 确保脚本有执行权限（chmod +x）
+### 2.2 部署宿主环境文件
 
-### 2.3 部署 Rules
-- 读取 `skills/story-setup/references/templates/rules/` 下所有 `.md` 文件
-- 复制到用户项目的 `.claude/rules/` 目录
+- **Claude / OpenClaw 模式**：
+  - 读取 `skills/story-setup/references/templates/hooks/` 下所有 `.sh` 文件
+  - 复制到用户项目的 `.claude/hooks/` 目录
+  - 读取 `skills/story-setup/references/templates/rules/` 下所有 `.md` 文件
+  - 复制到用户项目的 `.claude/rules/` 目录
+  - 读取 `skills/story-setup/references/templates/agents/` 下所有 `.md` 文件
+  - 复制到用户项目的 `.claude/agents/` 目录
+  - 确保脚本有执行权限（chmod +x）
 
-### 2.4 部署 Agents
-- 读取 `skills/story-setup/references/templates/agents/` 下所有 `.md` 文件
-- 复制到用户项目的 `.claude/agents/` 目录
+- **Codex 模式**：
+  - 调用当前 skill 包中的 `scripts/install-codex-project.sh <目标目录>`
+  - 生成 `.codex/config.toml`
+  - 生成 `.codex/agents/`、`.codex/hooks/`、`.codex/rules/`
+  - 生成 `.agents/plugins/marketplace.json` 与 `.agents/skills/`
 
 ### 2.5 部署 Session State 模板
 - 读取 `skills/story-setup/references/templates/上下文.md.tmpl`
 - 如有书名目录，复制到 `{书名}/追踪/` 下
 
-### 2.6 合并 Hooks 注册到 settings.local.json
-- 读取 `skills/story-setup/references/templates/settings-hooks.json`
-- 读取用户项目的 `.claude/settings.local.json`（如存在）
-- 合并 hooks 配置（按「settings-hooks.json 合并算法」处理）
-- 写入 `.claude/settings.local.json`
+### 2.6 宿主配置处理
+- **Claude / OpenClaw 模式**：
+  - 读取 `skills/story-setup/references/templates/settings-hooks.json`
+  - 读取用户项目的 `.claude/settings.local.json`（如存在）
+  - 合并 hooks 配置（按「settings-hooks.json 合并算法」处理）
+  - 写入 `.claude/settings.local.json`
+- **Codex 模式**：
+  - `scripts/install-codex-project.sh` 已负责写入 `.codex/config.toml`
 
 ### 2.7 创建部署标记
 
@@ -77,13 +91,9 @@ metadata:
 
 ## Phase 3：验证安装
 
-1. 验证 hooks 注册：
-   - 检查 `.claude/settings.local.json` 中的 hooks 字段是否正确
-   - 检查 `.claude/hooks/` 下的脚本是否存在且有执行权限
-2. 验证 rules 路径：
-   - 检查 `.claude/rules/` 下的规则文件是否存在且包含 `paths` frontmatter
-3. 验证 agents：
-   - 检查 `.claude/agents/` 下的 agent 定义文件是否存在
+1. 验证宿主环境文件：
+   - Claude / OpenClaw：检查 `.claude/settings.local.json`、`.claude/hooks/`、`.claude/rules/`、`.claude/agents/`
+   - Codex：检查 `.codex/config.toml`、`.codex/hooks/`、`.codex/rules/`、`.codex/agents/`、`.agents/plugins/marketplace.json`
 4. 验证部署标记：
    - 检查 `.story-deployed` 是否存在且包含时间戳
 5. 输出安装报告：
@@ -142,4 +152,5 @@ hooks 注册合并按 command 字段去重：
 | references/templates/agents/ | 6 个 agent 定义模板（story-architect, character-designer, narrative-writer, consistency-checker, story-researcher, story-explorer） |
 | references/templates/settings-hooks.json | hooks 注册 JSON 片段 |
 | references/templates/上下文.md.tmpl | 写作上下文模板 |
+| scripts/install-codex-project.sh | Codex 项目目录部署脚本 |
 


### PR DESCRIPTION
## Summary

This PR adds first-class Codex project/plugin installation support to `oh-story-claudecode`, while also introducing repository-level line ending rules to reduce noisy diffs on Windows/mixed environments.

The final diff against `main` contains only two user-originated changesets:

1. `chore: add line ending rules`
2. `feat: add codex install support`

## Why

The repository already has a strong Claude/OpenClaw-oriented setup flow, but Codex project consumers still lacked a dedicated installation path and compatibility layer.

At the same time, the repository had no shared line-ending policy, which made it easy to produce large batches of CRLF/LF-only file changes during normal editing and review.

This PR addresses both issues:

- adds Codex install scripts and compatibility conversion utilities
- documents the shared Claude/Codex strategy in the repo docs
- establishes explicit Git/editor line-ending rules to avoid churn-only commits

## What changed

### 1. Repository line-ending policy

Added:

- `.gitattributes`
- `.editorconfig`

These files define:

- default text normalization behavior
- per-extension line-ending defaults
- explicit exceptions for files that should remain `CRLF`
- editor-side consistency so local saves do not generate avoidable diff noise

### 2. Codex installation support

Added new Codex-focused scripts:

- `scripts/claude-to-codex.js`
- `scripts/codex-self-check.sh`
- `scripts/install-codex-project.sh`
- `scripts/install-codex-plugin.sh`

These scripts provide:

- project-level Codex setup (`.codex/config.toml`, `.codex/agents`, `.codex/hooks`, `.codex/rules`)
- plugin-level Codex setup (`.codex-plugin`, `.agents/plugins/marketplace.json`, assets/skills copy)
- a compatibility transform that converts Claude/OpenClaw-style slash references into Codex-friendly skill references
- a lightweight repository self-check for Codex packaging completeness

### 3. Deployment docs updated for dual-host support

Updated:

- `README.md`
- `skills/story-setup/SKILL.md`

Documentation changes clarify:

- the shared-content / thin-platform-adapter strategy
- host environment detection rules
- Codex deployment artifacts and validation expectations
- the fact that Codex reads the repository root `CLAUDE.md` via `.codex/config.toml` fallback

## Verification

I validated the changes with the following checks:

- `bash scripts/codex-self-check.sh`
- ran `scripts/install-codex-project.sh` into a temporary directory and verified generated `.codex/*`
- ran `scripts/install-codex-plugin.sh` into a temporary directory and verified generated plugin `.codex/*`

Observed generated outputs included:

- `.codex/config.toml`
- `.codex/agents/*`
- `.codex/hooks/*`
- `.codex/rules/*`
- `.agents/plugins/marketplace.json`

## Notes

- This PR is intentionally based on the latest `main` and only carries the unique Codex + line-ending work, so it does not reintroduce already-merged upstream changes.
- No existing upstream feature work was intentionally reverted.
