### PR TITLE
fix: 修正 5 个 agent description 中不准确的调用声明

### DIFF
--- a/skills/story-setup/references/templates/agents/character-designer.md
+++ b/skills/story-setup/references/templates/agents/character-designer.md
@@ -2,8 +2,9 @@
 name: character-designer
 description: |
   角色设计与对话创作专家。负责角色设定、语言风格档案、动机链、人物弧线、
-  对话质量、角色关系设计。被 story-long-write（Phase 2,4）和 story-short-write（Phase 2,3）调用。
-  也可审查角色一致性和对话质量。
+  对话质量、角色关系设计。被 story-review（Phase 2 Agent 2）调用进行角色审查。
+  注意：story-long-write / story-short-write 的写作流程中并未 spawn 本 agent，
+  角色设定和对话由主线程直接执行。如需在写作流程中委托本 agent，需在对应 SKILL.md 中补充 spawn 指令。
 tools: [Read, Glob, Grep, Write, Edit]
 skills: [story-review]
 model: sonnet

--- a/skills/story-setup/references/templates/agents/consistency-checker.md
+++ b/skills/story-setup/references/templates/agents/consistency-checker.md
@@ -3,7 +3,9 @@ name: consistency-checker
 description: |
   事实一致性与伏笔状态检查专家（只读）。使用 grep-first 方式检测设定矛盾、时间线冲突、
   伏笔断线、角色属性不一致、伏笔密度异常。输出 S1-S4 分级冲突报告。
-  被 story-review、story-long-write（Phase 5）、story-short-write（Phase 4）调用。
+  被 story-review（Phase 2 Agent 4）调用进行一致性检查。
+  原设计意图中 story-long-write（Phase 5）也应调用本 agent，
+  但当前 story-long-write Phase 5 并未显式 spawn，如需委托需补充 spawn 指令。
   不做任何创作判断。
 tools: [Read, Glob, Grep]
 disallowedTools: [Write, Edit, Bash]

--- a/skills/story-setup/references/templates/agents/narrative-writer.md
+++ b/skills/story-setup/references/templates/agents/narrative-writer.md
@@ -3,7 +3,9 @@ name: narrative-writer
 description: |
   叙事文本创作与去AI味专家。负责正文写作（场景展开法、感知层/反应层）、
   情绪弧线执行、开篇/收尾、去AI味（禁用词替换、句式去套路、节奏打碎）。
-  被 story-long-write（Phase 4-5）和 story-short-write（Phase 3-4）调用。
+  被 story-review（Phase 2 Agent 3）调用进行文字质量审查。
+  注意：story-long-write / story-short-write 的写作流程中并未 spawn 本 agent，
+  正文写作由主线程直接执行。如需在写作流程中委托本 agent，需在对应 SKILL.md 中补充 spawn 指令。
   也可执行完整去AI味流程和格式合规检查。
 tools: [Read, Glob, Grep, Write, Edit]
 model: sonnet

--- a/skills/story-setup/references/templates/agents/story-architect.md
+++ b/skills/story-setup/references/templates/agents/story-architect.md
@@ -3,8 +3,9 @@ name: story-architect
 description: |
   故事架构与世界观创作专家。负责题材选择、核心梗设计、世界观构建、大纲排布、
   钩子/悬念/反转等叙事工程、情绪弧线设计、范围控制审查。
-  被 story-long-write（Phase 1-3）、story-short-write（Phase 1-2）调用。
-  也可审查已有内容的结构问题。
+  被 story-review（Phase 2 Agent 1）调用进行结构审查。
+  注意：story-long-write / story-short-write 的写作流程中并未 spawn 本 agent，
+  结构设计由主线程直接执行。如需在写作流程中委托本 agent，需在对应 SKILL.md 中补充 spawn 指令。
 tools: [Read, Glob, Grep, Write, Edit]
 model: opus
 maxTurns: 30

--- a/skills/story-setup/references/templates/agents/story-researcher.md
+++ b/skills/story-setup/references/templates/agents/story-researcher.md
@@ -3,7 +3,7 @@ name: story-researcher
 description: |
   小说写作资料研究 agent。接收研究查询，优先使用 CDP (agent-browser) 搜索并提取完整正文，
   WebSearch/webReader 作为兜底。输出带来源引用的结构化 Markdown 参考文件。
-  被 story-long-write（Phase 4）、story-review、story skill 路由调用。
+  被 story-long-write（Phase 4 Step 3.5 按需 spawn）、story-review（Phase 3 可选事实核查）、story skill 路由调用。
 tools: [Read, Glob, Grep, Bash, Write]
 disallowedTools: [Edit]
 model: sonnet


### PR DESCRIPTION
## 问题

Closes #41

通过源码 grep + Claude Code v2.1.128 实测验证发现：**Claude Code 不会根据任务自动选用 agent**，它严格按 SKILL.md 中的 spawn 指令执行——没写 spawn 就不会 spawn。

6 个 agent 中有 **5 个**的 description 与实际调用情况不一致：

| Agent | 原声称被调用位置 | 实际被 spawn 的位置 | 状态 |
|---|---|---|---|
| **story-architect** | story-long-write (Phase 1-3), story-short-write (Phase 1-2) | 只有 story-review (Phase 2 Agent 1) | ❌ |
| **character-designer** | story-long-write (Phase 2,4), story-short-write (Phase 2,3) | 只有 story-review (Phase 2 Agent 2) | ❌ |
| **narrative-writer** | story-long-write (Phase 4-5), story-short-write (Phase 3-4) | 只有 story-review (Phase 2 Agent 3) | ❌ |
| **consistency-checker** | story-review, story-long-write (Phase 5), story-short-write (Phase 4) | 只有 story-review (Phase 2 Agent 4) | ❌ |
| **story-researcher** | story-long-write (Phase 4), story-review, story 路由 | story-long-write (Step 3.5), story-review (Phase 3), story 路由 | ⚠️ 位置不精确 |
| **story-explorer** | story-long-write, story-review, story 路由 | 同左 + story-import | ✅ |

## 修复内容

修正了 5 个 agent 的 `description` 字段：

1. **将调用位置改为实际 spawn 位置**，附上具体的 Phase/Step/Agent 编号
2. **添加注意事项**：明确说明写作流程中并未 spawn 该 agent，如需委托需在对应 SKILL.md 中补充 spawn 指令
3. **story-researcher**：精化了调用位置描述

## 实测方法

```bash
# 源码 grep 验证所有 spawn 调用
grep -rn "subagent_type" skills/ --include="*.md" | grep -v "templates/agents/"

# Claude Code --print 验证
claude -p "阅读 SKILL.md Phase 4，Phase 4 是否明确要求 spawn narrative-writer？"
# 回答：没有。Step 4 写的是"直接写入"。
```

## 后续建议

这次修复只是让文档与现状一致。如果作者希望写作流程真正委托给专业 agent（如 narrative-writer 写正文、story-architect 搭大纲），需要在对应 SKILL.md 中补充 `Agent(subagent_type: "xxx")` 的 spawn 指令。