### PR TITLE
fix: improve Qidian(起点) scanning with CAPTCHA detection and retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Bug 修复
+
+- 修复起点中文网扫榜在 PC 站触发风控页时无法采集的问题：`qidian-rank-scraper.js` 默认改为移动端 SSR pageContext 抓取，并保留 CAPTCHA/CDP 回退。
+
+### 验证
+
+- 起点畅销榜实时采集成功并生成 Markdown。
+- `node --check skills/story-long-scan/scripts/qidian-rank-scraper.js`
+- `bash scripts/static-check.sh`
+
 ## v0.6.7
 
 > 拆书 skill 重构：长篇双模式合并 + 短篇去模式化

--- a/skills/story-long-scan/SKILL.md
+++ b/skills/story-long-scan/SKILL.md
@@ -52,24 +52,24 @@ metadata:
 
 | 优先级 | 模式 | 说明 | 何时用 |
 |--------|------|------|--------|
-| 1 | **browser-cdp 采集** | 直接抓取平台页面，产出结构化文件 | 有 Chrome 环境时（优先） |
+| 1 | **脚本采集** | 直接抓取平台页面/SSR 数据，产出结构化文件 | 优先；起点默认不需要 Chrome |
 | 2 | **用户提供** | 用户粘贴榜单截图/文字/链接 | 用户已有数据时 |
 | 3 | **内置知识** | 基于知识库趋势数据做分析 | 无法联网、用户无数据时 |
 
-#### browser-cdp 采集模式
+#### 脚本采集模式
 
-使用 `/browser-cdp` 启动 Chrome，直接抓取平台榜单页面的结构化数据。
+优先运行对应平台脚本直接采集结构化数据。起点使用移动端 SSR pageContext，默认不需要 Chrome/CDP；番茄等需要浏览器态的平台再使用 `/browser-cdp` 启动 Chrome。
 
 **采集流程**：
-1. 启动 browser-cdp，打开目标榜单 URL
-2. 等待列表元素加载，逐条提取字段（排名、书名、作者、题材、字数、推荐/在读数等）
+1. 选择平台脚本；起点直接运行 `scripts/qidian-rank-scraper.js`，番茄/七猫/晋江等按需启动 browser-cdp
+2. 等待列表元素或 SSR 数据加载，逐条提取字段（排名、书名、作者、题材、字数、推荐/在读数等）
 3. 需要补充数据时（标签、简介、最新更新），进入详情页提取
 4. 按规范格式写入 Markdown 文件
 5. 多榜单/多题材时，逐组采集并保存
 
 **输出规范**：详见 [references/scan-output-format.md](references/scan-output-format.md)，包含各平台字段定义、输出模板、文件命名规范。
 
-**起点采集目标**：
+**起点采集目标**（优先运行 `node scripts/qidian-rank-scraper.js --type {榜单} --outdir {输出目录}`；默认 `--mode auto` 会先用 `https://m.qidian.com` 移动端 SSR，PC/CDP 只作回退）：
 
 | 榜单 | URL | 核心字段 |
 |------|-----|----------|
@@ -317,10 +317,10 @@ URL 参数：`/rank/{channel}_{type}_{cat_id}`，channel 0=女频/1=男频，typ
 | [references/reader-profiling.md](references/reader-profiling.md) | 需要分析目标读者画像时 |
 | [references/genre-trends.md](references/genre-trends.md) | 查看题材趋势候选、切入约束和样本校验规则时 |
 | [references/publishing-guide.md](references/publishing-guide.md) | 平台适配+推荐机制校验+数据指标+简介设计 |
-| [references/scan-output-format.md](references/scan-output-format.md) | browser-cdp采集字段定义+输出模板+文件命名规范 |
+| [references/scan-output-format.md](references/scan-output-format.md) | 脚本/CDP 采集字段定义+输出模板+文件命名规范 |
 | [scripts/cdp-utils.js](scripts/cdp-utils.js) | CDP 公共工具函数（ab/sleep/evalJSON/safeStr/scrollLoad/getArg），各采集脚本共用 |
 | [scripts/fanqie-rank-scraper.js](scripts/fanqie-rank-scraper.js) | 番茄榜单采集，通过详情页绕过字体反爬，配合 browser-cdp 使用 |
-| [scripts/qidian-rank-scraper.js](scripts/qidian-rank-scraper.js) | 起点榜单采集（畅销/月票/新书等），SSR 直出提取 |
+| [scripts/qidian-rank-scraper.js](scripts/qidian-rank-scraper.js) | 起点榜单采集（畅销/月票/新书等），默认移动端 SSR 提取，PC/CDP 回退 |
 | [scripts/qimao-rank-scraper.js](scripts/qimao-rank-scraper.js) | 七猫榜单采集（大热/新书/完结等），tab 切换+滚动加载 |
 | [scripts/jjwxc-rank-scraper.js](scripts/jjwxc-rank-scraper.js) | 晋江榜单采集（收入金榜/月榜等），按频道分组提取 |
 | [scripts/ciweimao-rank-scraper.js](scripts/ciweimao-rank-scraper.js) | 刺猬猫榜单采集（点击/收藏/月票等），单页 9 榜提取 |

--- a/skills/story-long-scan/references/scan-output-format.md
+++ b/skills/story-long-scan/references/scan-output-format.md
@@ -5,6 +5,11 @@
 
 ## 起点
 
+### 起点采集说明
+
+优先使用 `scripts/qidian-rank-scraper.js` 的默认 `--mode auto`。脚本先读取 `https://m.qidian.com` 移动端 SSR pageContext JSON，规避 PC 站风控页；移动端不可用时才回退到 CDP/PC 页面。输出头部会标注 `抓取方式：mobile-ssr` 或 `cdp-pc`。
+
+
 ### 榜单URL
 
 | 榜单 | URL |

--- a/skills/story-long-scan/scripts/qidian-rank-scraper.js
+++ b/skills/story-long-scan/scripts/qidian-rank-scraper.js
@@ -3,7 +3,9 @@
  * 起点中文网 排行榜采集脚本
  *
  * 配合 browser-cdp skill 使用。先启动 Chrome CDP 环境，再运行本脚本。
- * 采集策略：起点 SSR 直出 HTML，列表页直接包含排名/书名/作者/题材/字数/推荐等。
+ * 采集策略：
+ *   1. 默认优先读取 m.qidian.com 的 SSR pageContext JSON（不依赖 CDP，规避 PC 站风控页）。
+ *   2. 移动端不可用时再回退到 Chrome CDP 采集 PC 页面。
  * 输出 Markdown 格式匹配 scan-output-format.md 规范。
  *
  * 用法：
@@ -16,16 +18,21 @@
  *   node qidian-rank-scraper.js --type recom                   # 原创推荐榜
  *   node qidian-rank-scraper.js --type sanjiang                 # 三江推荐（/sanjiang/，非 /rank/ 路径）
  *   node qidian-rank-scraper.js --type all                     # 全部榜单
+ *   node qidian-rank-scraper.js --type hotsales --mode mobile  # 仅使用移动端 SSR
+ *   node qidian-rank-scraper.js --type hotsales --mode cdp     # 仅使用旧版 CDP/PC 页面
  *
  * 前置：
- *   node {SKILL_DIR}/browser-cdp/scripts/setup-cdp-chrome.js 9222
+ *   默认 mobile/auto 模式不需要 Chrome。
+ *   cdp 模式需要：node {SKILL_DIR}/browser-cdp/scripts/setup-cdp-chrome.js 9222
  */
 
 const fs = require("fs");
+const https = require("https");
 const path = require("path");
 const { ab, sleep, evalJSON, scrollLoad, getArg } = require("./cdp-utils");
 
-const BASE_URL = "https://www.qidian.com/rank";
+const PC_BASE_URL = "https://www.qidian.com/rank";
+const MOBILE_BASE_URL = "https://m.qidian.com";
 
 /** 验证码自动重试最大次数 */
 const MAX_CAPTCHA_RETRIES = 3;
@@ -34,17 +41,51 @@ const MAX_CAPTCHA_WAIT_SEC = 120;
 /** 轮询验证码是否解除的间隔（毫秒） */
 const CAPTCHA_POLL_INTERVAL = 5000;
 
+const MOBILE_HEADERS = {
+  "User-Agent":
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) " +
+    "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+  Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+  "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
+  "Accept-Encoding": "identity",
+};
+
 const RANK_TYPES = [
-  { id: "hotsales", label: "畅销榜" },
-  { id: "yuepiao", label: "月票榜" },
-  { id: "signnewbook", label: "签约作者新书榜" },
-  { id: "pubnewbook", label: "公众作者新书榜" },
-  { id: "newauthor", label: "新人作者新书榜" },
-  { id: "newsign", label: "新人签约新书榜" },
-  { id: "recom", label: "原创推荐榜" },
-  { id: "readindex", label: "阅读指数榜" },
-  { id: "collect", label: "收藏榜" },
-  { id: "sanjiang", label: "三江推荐", baseUrl: "https://www.qidian.com/sanjiang/" },
+  { id: "hotsales", label: "畅销榜", mobilePath: "/rank/hotsales/" },
+  { id: "yuepiao", label: "月票榜", mobilePath: "/rank/yuepiao/" },
+  {
+    id: "signnewbook",
+    label: "签约作者新书榜",
+    mobilePath: "/rank/sign/",
+    mobileLabel: "签约榜",
+  },
+  {
+    id: "pubnewbook",
+    label: "公众作者新书榜",
+    mobilePath: "/rank/newbook/",
+    mobileLabel: "新书榜",
+  },
+  { id: "newauthor", label: "新人作者新书榜", mobilePath: "/rank/newauthor/", mobileLabel: "新人榜" },
+  {
+    id: "newsign",
+    label: "新人签约新书榜",
+    mobilePath: "/rank/sign/",
+    mobileLabel: "签约榜",
+  },
+  { id: "recom", label: "原创推荐榜", mobilePath: "/rank/rec/", mobileLabel: "推荐榜" },
+  { id: "readindex", label: "阅读指数榜", mobilePath: "/rank/readindex/" },
+  {
+    id: "collect",
+    label: "收藏榜",
+    mobilePath: "/rank/newfans/",
+    mobileLabel: "书友榜（移动端替代）",
+  },
+  {
+    id: "sanjiang",
+    label: "三江推荐",
+    baseUrl: "https://www.qidian.com/sanjiang/",
+    mobilePath: "/sanjiang/",
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -169,7 +210,7 @@ function openWithCaptchaHandling(port, url) {
 
     const captcha = isCaptchaPage(port);
     if (!captcha) {
-      return true; // 页面正常
+      return true;
     }
     console.log(`  ⚠ 检测到安全拦截 (${captcha.reason})，第 ${attempt}/${MAX_CAPTCHA_RETRIES} 次重试...`);
     // 递增等待后再次尝试
@@ -199,6 +240,158 @@ function openWithCaptchaHandling(port, url) {
 }
 
 // ---------------------------------------------------------------------------
+// 移动端 SSR 提取（默认路径）
+// ---------------------------------------------------------------------------
+
+function mobileUrl(pathname) {
+  if (!pathname) return "";
+  return pathname.startsWith("http") ? pathname : `${MOBILE_BASE_URL}${pathname}`;
+}
+
+function fetchText(url, redirects = 3) {
+  return new Promise((resolve, reject) => {
+    const req = https.get(url, { headers: MOBILE_HEADERS, timeout: 15000 }, (res) => {
+      if (
+        redirects > 0 &&
+        res.statusCode >= 300 &&
+        res.statusCode < 400 &&
+        res.headers.location
+      ) {
+        res.resume();
+        const nextUrl = new URL(res.headers.location, url).toString();
+        fetchText(nextUrl, redirects - 1).then(resolve, reject);
+        return;
+      }
+
+      let body = "";
+      res.setEncoding("utf8");
+      res.on("data", (chunk) => {
+        body += chunk;
+      });
+      res.on("end", () => {
+        if (res.statusCode < 200 || res.statusCode >= 300) {
+          reject(new Error(`HTTP ${res.statusCode}`));
+          return;
+        }
+        resolve(body);
+      });
+    });
+
+    req.on("timeout", () => {
+      req.destroy(new Error("request timeout"));
+    });
+    req.on("error", reject);
+  });
+}
+
+function extractMobilePageContext(html) {
+  const m = html.match(
+    /<script[^>]+id=["']vite-plugin-ssr_pageContext["'][^>]*>([\s\S]*?)<\/script>/i
+  );
+  if (!m) return null;
+  try {
+    return JSON.parse(m[1]);
+  } catch (e) {
+    console.log(`  ⚠ 移动端 pageContext JSON 解析失败: ${e.message}`);
+    return null;
+  }
+}
+
+function normalizeMobileBook(record, idx) {
+  const title = record.bName || record.bookName || "";
+  const bid = record.bid || record.bookId || "";
+  const genre = [record.cat, record.subCat].filter(Boolean).join("·");
+  const stats = [];
+  if (record.cnt) stats.push(record.cnt);
+  if (record.rankCnt) stats.push(`榜单值 ${record.rankCnt}`);
+
+  return {
+    rank: record.rankNum || idx + 1,
+    title,
+    url: bid ? `${MOBILE_BASE_URL}/book/${bid}/` : "",
+    author: record.bAuth || record.author || "",
+    genre,
+    status: stats.join(" · "),
+    descText: record.desc || "",
+    updateText: "",
+  };
+}
+
+function renderMarkdown(rt, books, url, sourceMode, extraLines = []) {
+  const now = new Date().toISOString();
+  const lines = [
+    `# 起点 · ${rt.label}`,
+    "",
+    `- 来源：${url}`,
+    `- 抓取方式：${sourceMode}`,
+    `- 抓取时间：${now}`,
+    `- 条目数：${books.length}`,
+    ...extraLines,
+    "",
+    "---",
+    "",
+  ];
+
+  for (let i = 0; i < books.length; i++) {
+    const b = books[i];
+    lines.push(`## #${b.rank || i + 1} ${b.title}`);
+    const meta = [b.author, b.genre, b.status].filter(Boolean).join(" · ");
+    if (meta) lines.push(`*${meta}*`);
+    if (b.updateText) lines.push(`**最新更新：** ${b.updateText}`);
+    if (b.tags?.length) lines.push(`**标签：** ${b.tags.join("、")}`);
+    if (b.url) lines.push(`[作品页](${b.url})`);
+    if (b.descText) {
+      lines.push("");
+      lines.push("**简介**");
+      lines.push("");
+      lines.push(b.descText);
+    }
+    lines.push("", "---", "");
+  }
+
+  return lines.join("\n");
+}
+
+async function scrapeRankMobile(rankTypeId) {
+  const rt = RANK_TYPES.find((r) => r.id === rankTypeId);
+  if (!rt) {
+    console.log(`  ⚠ 未知榜单类型: ${rankTypeId}`);
+    return null;
+  }
+  if (!rt.mobilePath) {
+    console.log(`  ⚠ 榜单 ${rankTypeId} 暂无移动端 SSR 路径`);
+    return null;
+  }
+
+  const url = mobileUrl(rt.mobilePath);
+  console.log(`\n→ 采集 起点${rt.label}（移动端 SSR）...`);
+  console.log(`  URL: ${url}`);
+
+  const html = await fetchText(url);
+  const pageContext = extractMobilePageContext(html);
+  const pageData = pageContext?.pageContext?.pageProps?.pageData;
+  const records = pageData?.records || [];
+  const books = records.map(normalizeMobileBook).filter((b) => b.title);
+
+  if (!books.length) {
+    console.log("  ⚠ 移动端 SSR 未提取到书籍");
+    return null;
+  }
+
+  console.log(`  ✓ 提取 ${books.length} 本`);
+
+  const extraLines = [];
+  if (rt.mobileLabel && rt.mobileLabel !== rt.label) {
+    extraLines.push(`- 移动端实际榜单：${rt.mobileLabel}`);
+  }
+  if (FETCH_DETAIL) {
+    extraLines.push("- 说明：移动端 SSR 已包含简介；--detail 在 mobile/auto 模式下不会额外打开详情页。");
+  }
+
+  return renderMarkdown(rt, books, url, "mobile-ssr", extraLines);
+}
+
+// ---------------------------------------------------------------------------
 // 主流程
 // ---------------------------------------------------------------------------
 
@@ -206,23 +399,23 @@ const args = process.argv.slice(2);
 const PORT = parseInt(getArg(args, "--port") || "9222", 10);
 const OUTDIR = getArg(args, "--outdir") || ".";
 const RANKTYPE = getArg(args, "--type") || "hotsales";
+const SCRAPE_MODE = getArg(args, "--mode") || "auto"; // auto | mobile | cdp
 const FETCH_DETAIL = (getArg(args, "--detail") || "no") === "yes";
 
-function scrapeRank(port, rankTypeId) {
+function scrapeRankCDP(port, rankTypeId) {
   const rt = RANK_TYPES.find((r) => r.id === rankTypeId);
   if (!rt) {
     console.log(`  ⚠ 未知榜单类型: ${rankTypeId}`);
     return null;
   }
 
-  const url = rt.baseUrl || `${BASE_URL}/${rankTypeId}/`;
-  console.log(`\n→ 采集 起点${rt.label}...`);
+  const url = rt.baseUrl || `${PC_BASE_URL}/${rankTypeId}/`;
+  console.log(`\n→ 采集 起点${rt.label}（CDP/PC）...`);
   console.log(`  URL: ${url}`);
 
-  // 使用带验证码处理的页面打开
   const pageReady = openWithCaptchaHandling(port, url);
   if (!pageReady) {
-    console.log(`  ✗ 起点采集失败：页面无法通过验证码拦截`);
+    console.log("  ✗ 起点采集失败：页面无法通过验证码拦截");
     return null;
   }
 
@@ -257,53 +450,50 @@ function scrapeRank(port, rankTypeId) {
     sleep(2000);
   }
 
-  const now = new Date().toISOString();
-  const lines = [
-    `# 起点 · ${rt.label}`,
-    "",
-    `- 来源：${url}`,
-    `- 抓取时间：${now}`,
-    `- 条目数：${books.length}`,
-    "",
-    "---",
-    "",
-  ];
-
-  for (let i = 0; i < books.length; i++) {
-    const b = books[i];
-    lines.push(`## #${b.rank || i + 1} ${b.title}`);
-    const meta = [b.author, b.genre, b.status].filter(Boolean).join(" · ");
-    if (meta) lines.push(`*${meta}*`);
-    if (b.updateText) lines.push(`**最新更新：** ${b.updateText}`);
-    if (b.tags?.length) lines.push(`**标签：** ${b.tags.join("、")}`);
-    if (b.url) lines.push(`[作品页](${b.url})`);
-    if (b.descText) {
-      lines.push("");
-      lines.push("**简介**");
-      lines.push("");
-      lines.push(b.descText);
-    }
-    lines.push("", "---", "");
-  }
-
-  return lines.join("\n");
+  return renderMarkdown(rt, books, url, "cdp-pc");
 }
 
-function main() {
-  const rankTypes =
-    RANKTYPE === "all" ? RANK_TYPES.map((r) => r.id) : [RANKTYPE];
+async function scrapeRank(rankTypeId) {
+  if (!["auto", "mobile", "cdp"].includes(SCRAPE_MODE)) {
+    throw new Error(`未知 --mode: ${SCRAPE_MODE}（可选 auto/mobile/cdp）`);
+  }
+
+  if (SCRAPE_MODE !== "cdp") {
+    try {
+      const content = await scrapeRankMobile(rankTypeId);
+      if (content || SCRAPE_MODE === "mobile") return content;
+    } catch (e) {
+      console.log(`  ⚠ 移动端 SSR 采集失败: ${e.message}`);
+      if (SCRAPE_MODE === "mobile") return null;
+    }
+  }
+
+  if (SCRAPE_MODE !== "mobile") {
+    console.log("  → 回退到 CDP/PC 页面采集");
+    return scrapeRankCDP(PORT, rankTypeId);
+  }
+
+  return null;
+}
+
+async function main() {
+  const rankTypes = RANKTYPE === "all" ? RANK_TYPES.map((r) => r.id) : [RANKTYPE];
 
   for (const rt of rankTypes) {
-    const content = scrapeRank(PORT, rt);
+    const content = await scrapeRank(rt);
     if (!content) continue;
 
     const rtInfo = RANK_TYPES.find((r) => r.id === rt);
     const date = new Date().toISOString().slice(0, 10).replace(/-/g, "");
     const filename = `起点${rtInfo.label}_${date}.md`;
+    fs.mkdirSync(OUTDIR, { recursive: true });
     const filepath = path.join(OUTDIR, filename);
     fs.writeFileSync(filepath, content, "utf-8");
     console.log(`  ✓ 已保存: ${filepath}`);
   }
 }
 
-main();
+main().catch((e) => {
+  console.error(`起点采集失败: ${e.message}`);
+  process.exit(1);
+});

--- a/skills/story-long-scan/scripts/qidian-rank-scraper.js
+++ b/skills/story-long-scan/scripts/qidian-rank-scraper.js
@@ -27,6 +27,13 @@ const { ab, sleep, evalJSON, scrollLoad, getArg } = require("./cdp-utils");
 
 const BASE_URL = "https://www.qidian.com/rank";
 
+/** 验证码自动重试最大次数 */
+const MAX_CAPTCHA_RETRIES = 3;
+/** 等待用户手动解决验证码的最大秒数 */
+const MAX_CAPTCHA_WAIT_SEC = 120;
+/** 轮询验证码是否解除的间隔（毫秒） */
+const CAPTCHA_POLL_INTERVAL = 5000;
+
 const RANK_TYPES = [
   { id: "hotsales", label: "畅销榜" },
   { id: "yuepiao", label: "月票榜" },
@@ -118,6 +125,79 @@ function extractDetail(port) {
   return evalJSON(port, js);
 }
 
+/**
+ * 检测当前页面是否被验证码/安全验证拦截。
+ * 起点常见拦截页面特征：页面中出现验证码关键词，或页面缺少榜单 DOM 元素。
+ * @returns {{ blocked: boolean, reason: string } | null} 若被拦截返回原因对象，否则 null
+ */
+function isCaptchaPage(port) {
+  const js =
+    "JSON.stringify((()=>{" +
+    "var bodyText=document.body?(document.body.innerText||'').substring(0,3000):'';" +
+    "var lower=bodyText.toLowerCase();" +
+    "var keywords=['验证','captcha','verify','安全验证','滑块','拖动','请完成验证'," +
+    "'混元','人机验证','异常请求','访问验证','操作频繁','请求过于频繁','waf','请稍后再试'];" +
+    "for(var i=0;i<keywords.length;i++){" +
+    "  if(lower.indexOf(keywords[i])>-1){" +
+    "    return {blocked:true,reason:keywords[i]};" +
+    "  }" +
+    "}" +
+    "var hasContent=document.querySelector('.book-img-text ul li,.rank-body,.rank-list,.book-img-text');" +
+    "if(!hasContent){" +
+    "  return {blocked:true,reason:'页面无榜单内容(可能被拦截)'};" +
+    "}" +
+    "return {blocked:false,reason:''};" +
+    "})())";
+  const result = evalJSON(port, js);
+  return result && result.blocked === true ? result : null;
+}
+
+/**
+ * 打开 URL 并等待页面加载，自动处理验证码拦截。
+ * 重试策略：
+ *   1. 正常加载页面
+ *   2. 检测到验证码 → 等待递增延时后刷新重试（最多 MAX_CAPTCHA_RETRIES 次）
+ *   3. 仍被拦截 → 提示用户在 Chrome CDP 窗口手动完成验证，轮询等待直到解除或超时
+ *
+ * @returns {boolean} true=页面已就绪，false=无法通过验证码
+ */
+function openWithCaptchaHandling(port, url) {
+  for (let attempt = 1; attempt <= MAX_CAPTCHA_RETRIES; attempt++) {
+    ab(port, "open", url);
+    // 首次 3 秒，后续每次多等 2 秒
+    sleep(3000 + (attempt - 1) * 2000);
+
+    const captcha = isCaptchaPage(port);
+    if (!captcha) {
+      return true; // 页面正常
+    }
+    console.log(`  ⚠ 检测到安全拦截 (${captcha.reason})，第 ${attempt}/${MAX_CAPTCHA_RETRIES} 次重试...`);
+    // 递增等待后再次尝试
+    sleep(attempt * 5000);
+  }
+
+  // 自动重试全部失败 → 等待用户手动处理
+  console.log(`  ⚠ 自动重试未通过验证码，请在 Chrome CDP 窗口手动完成验证`);
+  console.log(`  ⏳ 等待手动验证（最长 ${MAX_CAPTCHA_WAIT_SEC} 秒）...`);
+
+  const startTime = Date.now();
+  while (Date.now() - startTime < MAX_CAPTCHA_WAIT_SEC * 1000) {
+    sleep(CAPTCHA_POLL_INTERVAL);
+    // 刷新页面检查验证码是否已解除
+    ab(port, "open", url);
+    sleep(3000);
+    const captcha = isCaptchaPage(port);
+    if (!captcha) {
+      console.log(`  ✓ 验证码已解除，继续采集`);
+      return true;
+    }
+    const elapsed = Math.round((Date.now() - startTime) / 1000);
+    process.stdout.write(`  等待中... (${elapsed}s)\r`);
+  }
+  console.log(`  ✗ 等待超时，验证码仍未解除`);
+  return false;
+}
+
 // ---------------------------------------------------------------------------
 // 主流程
 // ---------------------------------------------------------------------------
@@ -139,8 +219,13 @@ function scrapeRank(port, rankTypeId) {
   console.log(`\n→ 采集 起点${rt.label}...`);
   console.log(`  URL: ${url}`);
 
-  ab(port, "open", url);
-  sleep(3000);
+  // 使用带验证码处理的页面打开
+  const pageReady = openWithCaptchaHandling(port, url);
+  if (!pageReady) {
+    console.log(`  ✗ 起点采集失败：页面无法通过验证码拦截`);
+    return null;
+  }
+
   scrollLoad(port, 3);
   sleep(1000);
 


### PR DESCRIPTION
## Summary

起点网排行榜采集脚本因混元 AI 跨域验证码拦截导致扫榜失败。本次修复添加了验证码检测和自动重试机制，显著提升了起点采集的鲁棒性。

## Changes

- 新增 `isCaptchaPage()` 函数，检测页面中的验证码关键词（验证、混元、滑块、人机验证等）和缺失的榜单 DOM 元素
- 新增 `openWithCaptchaHandling()` 函数，实现三层重试策略：
  1. 正常加载页面
  2. 检测到验证码 → 递增延时后刷新重试（最多 3 次）
  3. 自动重试仍失败 → 提示用户在 Chrome CDP 窗口手动完成验证，轮询等待最长 120 秒
- 修改 `scrapeRank()` 使用新的验证码处理流程替代原来的直接页面打开
- 所有状态消息使用中文输出，便于用户理解当前状态

## Testing

- JavaScript 语法检查通过 (`node --check`)
- 项目静态检查脚本通过 (`static-check.sh`: 13/13 skills PASS)
- 无现有测试套件

Fixes worldwonderer/oh-story-claudecode#82