### PR TITLE
fix: browser-cdp consent flow and Chrome launch hardening

### DIFF
--- a/skills/browser-cdp/SKILL.md
+++ b/skills/browser-cdp/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: browser-cdp
-version: 1.0.0
 description: "Use this skill when you need to control a Chrome browser via CDP (Chrome DevTools Protocol) to reuse existing login sessions. Covers: launching Chrome in debug mode, opening URLs, waiting for page load, evaluating JavaScript, taking snapshots, and extracting auth tokens. Trigger phrases: browser automation, CDP, agent-browser, 浏览器操作, 操作浏览器, Chrome CDP, 复用登录态, extract token from browser."
 metadata:
   openclaw:
@@ -16,19 +15,62 @@ metadata:
 
 ## 前置条件
 
-- Windows（实验性）/ macOS / Linux，已安装 Google Chrome
-- Node.js 16+（Atomics.wait + SharedArrayBuffer）
-- `agent-browser` 命令行工具已安装（`npm install -g agent-browser`）
+- macOS / Linux / Windows（实验性），已安装 Google Chrome
+- Node.js 12+
+- `agent-browser` 已安装：`npm install -g agent-browser`
+
+> ⚠️ **首次启动会 kill 用户的常规 Chrome。** 在启动前必须征求用户同意（见下方"启动流程"），否则用户可能丢失未保存的标签页/草稿。
 
 ---
 
-## 第一步：启动 CDP Chrome 环境
+## 启动流程（skill-mode 强制步骤）
+
+**第一步：探测当前状态（无副作用）**
 
 ```bash
-node {SKILL_DIR}/scripts/setup-cdp-chrome.js 9222
+node {SKILL_DIR}/scripts/setup-cdp-chrome.js 9222 --detect-only
 ```
 
-成功后所有 `agent-browser` 命令带 `--cdp 9222`。
+输出形如：
+
+```
+CDP_STATUS=ready                        # 已就绪，可直接复用
+CDP_URL=http://127.0.0.1:9222/json/version
+BROWSER=Chrome/148.0.7778.168
+```
+
+或：
+
+```
+CDP_STATUS=needs-setup
+CHROME_RUNNING=yes                      # 用户有 Chrome 在跑，启动会杀掉
+CHROME_PID_COUNT=3
+```
+
+**第二步：根据探测结果分支**
+
+- `CDP_STATUS=ready` → 直接使用 `agent-browser --cdp 9222 ...`，**不要运行 setup**。
+- `CDP_STATUS=needs-setup` 且 `CHROME_RUNNING=no` → 安全启动：
+  ```bash
+  node {SKILL_DIR}/scripts/setup-cdp-chrome.js 9222 --yes
+  ```
+- `CDP_STATUS=needs-setup` 且 `CHROME_RUNNING=yes` → **先用 AskUserQuestion 工具向用户确认**：告知会杀掉 N 个 Chrome 进程、可能丢失未保存工作；用户同意后再带 `--yes` 启动；用户拒绝则放弃这次自动化。
+
+**为什么不能直接 `--yes`：** 脚本在非 TTY（即 skill 模式 / Bash 工具）下，如果检测到 Chrome 在跑而没有 `--yes`，会以退出码 3 报 `NEEDS_CONSENT: ...` 并中止，**不会**静默杀进程。这是有意的兜底——但 skill 流程仍应先问用户，而不是看到 3 就盲传 `--yes`。
+
+---
+
+## 启动脚本选项
+
+| 选项 | 说明 |
+|------|------|
+| `--detect-only` | 只探测，不修改任何状态（skill 用） |
+| `--yes` | 已征得同意，跳过交互提示 |
+| `--reset` | 启动前清空 `~/chrome-debug-profile`（登录失效时用） |
+| `--profile <name>` | 使用非 Default 的 Chrome profile（如 `"Profile 1"`） |
+| `--dry-run` | 打印将执行的步骤，不执行 |
+
+退出码：`0` 成功 / `1` 通用错误 / `2` 用户拒绝（TTY）/ `3` 需同意但缺 `--yes`。
 
 ---
 
@@ -41,7 +83,7 @@ agent-browser --cdp 9222 open "<URL>"
 agent-browser --cdp 9222 wait 3000
 ```
 
-### 提取页面文本内容
+### 提取页面文本
 
 ```bash
 agent-browser --cdp 9222 eval 'document.body.innerText.substring(0, 8000)'
@@ -50,28 +92,38 @@ agent-browser --cdp 9222 eval 'document.body.innerText.substring(0, 8000)'
 ### 提取 Auth Token
 
 ```bash
-# 从 localStorage 或 cookie 提取
 agent-browser --cdp 9222 eval 'localStorage.getItem("token") || document.cookie'
 ```
 
-### 页面截图 / 交互式快照
+### 复杂 JS（含引号 / `$` / 反引号）
+
+shell 转义容易出错，用以下两种方式之一：
 
 ```bash
-# 查找页面元素（用于登录按钮等交互）
-agent-browser --cdp 9222 snapshot -i
+# 1) base64 包裹
+agent-browser --cdp 9222 eval -b "$(echo -n "document.querySelectorAll('a').length" | base64)"
+
+# 2) heredoc + --stdin
+cat <<'EOF' | agent-browser --cdp 9222 eval --stdin
+const links = document.querySelectorAll('a');
+links.length;
+EOF
 ```
 
-### 点击元素
+### 页面交互（snapshot 拿元素引用）
 
 ```bash
-agent-browser --cdp 9222 click "<CSS selector>"
+agent-browser --cdp 9222 snapshot -i        # 仅交互元素
+agent-browser --cdp 9222 click "<CSS or @e1>"
+agent-browser --cdp 9222 type "<sel>" "<text>"
 ```
 
-### 填写表单
+---
 
-```bash
-agent-browser --cdp 9222 type "<CSS selector>" "<text>"
-```
+## 停止 / 清理
+
+- 关掉 debug Chrome 窗口即可（或 `pkill -9 -x 'Google Chrome'` / `taskkill /F /IM chrome.exe`）。
+- 登录态失效：`node {SKILL_DIR}/scripts/setup-cdp-chrome.js 9222 --reset --yes`（注意 `--yes` 同样需要先问用户）。
 
 ---
 
@@ -79,7 +131,10 @@ agent-browser --cdp 9222 type "<CSS selector>" "<text>"
 
 | 问题 | 解决方案 |
 |------|----------|
-| CDP 端口未监听 | 重新运行 `setup-cdp-chrome.js` |
+| `NEEDS_CONSENT` + 退出码 3 | 用 AskUserQuestion 询问用户是否允许杀掉 Chrome，同意后加 `--yes` 重跑 |
+| CDP 端口未监听 | `--detect-only` 再确认；端口被占用则换端口 |
 | 页面跳转到登录页 | `snapshot -i` 找登录按钮并操作 |
-| eval 返回 null | 检查 localStorage key 名称，或改用 `document.cookie` |
-| Chrome 进程残留 | macOS/Linux: `pkill -9 -x 'Google Chrome'` / Windows: `taskkill /F /IM chrome.exe`，后重新运行脚本 |
+| `eval` 返回 `null` | 检查 localStorage key 名；含引号的 JS 用 `eval -b` 或 `--stdin` |
+| 登录态过期 | `setup-cdp-chrome.js 9222 --reset --yes` 重新拷贝 |
+| 有多个 Chrome profile | `--profile "Profile 1"` 指定 |
+| Chrome 不会启动（30s 超时） | 试 `--reset`；检查端口冲突；查看 `~/chrome-debug-profile/` 是否损坏 |

--- a/skills/browser-cdp/scripts/setup-cdp-chrome.js
+++ b/skills/browser-cdp/scripts/setup-cdp-chrome.js
@@ -3,22 +3,83 @@
 // 准备带有 CDP（Chrome DevTools Protocol）调试功能的 Chrome 环境（跨平台）。
 // 通过此脚本，agent-browser 可以复用用户的 Chrome 登录态。
 //
-// 用法: node setup-cdp-chrome.js [端口号] [--dry-run]
-//   端口号: CDP 调试端口（默认: 9222）
-//   --dry-run: 只打印检测到的路径和操作，不执行
+// 用法:
+//   node setup-cdp-chrome.js [port] [options]
+//
+// Options:
+//   --detect-only            只探测当前状态（结构化输出），不做任何修改
+//   --yes                    确认杀死现有 Chrome，跳过交互提示
+//   --reset                  清空 ~/chrome-debug-profile 后重新复制
+//   --profile <name>         使用指定 Chrome profile（默认: Default）
+//   --dry-run                打印将执行的操作，不实际执行
+//
+// 退出码:
+//   0  成功 / detect-only 完成
+//   1  通用错误（环境缺失、超时等）
+//   2  用户拒绝（TTY 模式下回答 N）
+//   3  需要同意但当前为非 TTY 且未传 --yes
+//
+// detect-only 结构化输出（stdout，每行 KEY=value）:
+//   CDP_STATUS=ready|needs-setup
+//   CDP_URL=...                    (仅当 ready)
+//   BROWSER=...                    (仅当 ready)
+//   CHROME_RUNNING=yes|no
+//   CHROME_PID_COUNT=N             (仅当 CHROME_RUNNING=yes)
 
 "use strict";
 
 const { execSync, spawn } = require("child_process");
 const fs = require("fs");
 const http = require("http");
-const net = require("net");
 const os = require("os");
 const path = require("path");
+const readline = require("readline");
 
-const args = process.argv.slice(2);
-const DRY_RUN = args.includes("--dry-run");
-const CDP_PORT = parseInt(args.find((a) => a !== "--dry-run") || "9222", 10);
+// ---------------------------------------------------------------------------
+// 参数解析
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const flags = { dryRun: false, yes: false, detectOnly: false, reset: false };
+  let profile = "Default";
+  let port = null;
+
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    switch (a) {
+      case "--dry-run": flags.dryRun = true; break;
+      case "--yes": case "-y": flags.yes = true; break;
+      case "--detect-only": flags.detectOnly = true; break;
+      case "--reset": flags.reset = true; break;
+      case "--profile":
+        profile = argv[++i];
+        if (!profile) {
+          console.error("❌ --profile 需要一个参数（例如: --profile \"Profile 1\"）");
+          process.exit(1);
+        }
+        break;
+      default:
+        if (/^\d+$/.test(a)) {
+          port = parseInt(a, 10);
+        } else if (a.startsWith("--")) {
+          console.error(`⚠️  未知参数: ${a}`);
+        } else {
+          console.error(`⚠️  忽略参数: ${a}`);
+        }
+    }
+  }
+
+  if (port === null) port = 9222;
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    console.error(`❌ 端口非法: ${port}。必须是 1-65535 的整数。`);
+    process.exit(1);
+  }
+
+  return { flags, profile, port };
+}
+
+const ARGS = parseArgs(process.argv.slice(2));
+const CDP_PORT = ARGS.port;
 const PLATFORM = os.platform();
 
 // ---------------------------------------------------------------------------
@@ -37,82 +98,44 @@ const PLATFORM_CONFIG = {
       "Google",
       "Chrome"
     ),
-    findChrome: () => {
-      for (const p of PLATFORM_CONFIG.darwin.chromePaths) {
-        if (fs.existsSync(p)) return p;
-      }
+    findChrome() {
+      for (const p of this.chromePaths) if (fs.existsSync(p)) return p;
       return null;
     },
-    listChromePids: () => {
+    listChromePids() {
       try {
-        const out = execSync("pgrep -x 'Google Chrome'", {
-          encoding: "utf-8",
-        }).trim();
-        return out
-          .split("\n")
-          .map(Number)
-          .filter((n) => n > 0);
-      } catch {
-        return [];
-      }
+        const out = execSync("pgrep -x 'Google Chrome'", { encoding: "utf-8" }).trim();
+        return out.split("\n").map(Number).filter((n) => n > 0);
+      } catch { return []; }
     },
-    killChrome: () => {
+    killChrome() {
       try { execSync("pkill -9 -x 'Google Chrome'", { stdio: "ignore" }); } catch {}
     },
   },
   win32: {
     chromePaths: [
-      path.join(
-        process.env["PROGRAMFILES(X86)"] || "",
-        "Google",
-        "Chrome",
-        "Application",
-        "chrome.exe"
-      ),
-      path.join(
-        process.env.PROGRAMFILES || "",
-        "Google",
-        "Chrome",
-        "Application",
-        "chrome.exe"
-      ),
-      path.join(
-        process.env.LOCALAPPDATA || "",
-        "Google",
-        "Chrome",
-        "Application",
-        "chrome.exe"
-      ),
+      path.join(process.env["PROGRAMFILES(X86)"] || "", "Google", "Chrome", "Application", "chrome.exe"),
+      path.join(process.env.PROGRAMFILES || "", "Google", "Chrome", "Application", "chrome.exe"),
+      path.join(process.env.LOCALAPPDATA || "", "Google", "Chrome", "Application", "chrome.exe"),
     ],
     profileDir: path.join(
       process.env.LOCALAPPDATA || path.join(os.homedir(), "AppData", "Local"),
-      "Google",
-      "Chrome",
-      "User Data"
+      "Google", "Chrome", "User Data"
     ),
-    findChrome: () => {
-      for (const p of PLATFORM_CONFIG.win32.chromePaths) {
-        if (p && fs.existsSync(p)) return p;
-      }
+    findChrome() {
+      for (const p of this.chromePaths) if (p && fs.existsSync(p)) return p;
       return null;
     },
-    listChromePids: () => {
+    listChromePids() {
       try {
-        const out = execSync('tasklist /FI "IMAGENAME eq chrome.exe" /NH /FO CSV', {
-          encoding: "utf-8",
-        }).trim();
-        return out
-          .split("\n")
-          .map((line) => {
-            const m = line.match(/"chrome.exe","(\d+)"/i);
-            return m ? parseInt(m[1], 10) : 0;
-          })
-          .filter((n) => n > 0);
-      } catch {
-        return [];
-      }
+        const out = execSync('tasklist /FI "IMAGENAME eq chrome.exe" /NH /FO CSV', { encoding: "utf-8" }).trim();
+        return out.split("\n").map((line) => {
+          const m = line.match(/"chrome.exe","(\d+)"/i);
+          return m ? parseInt(m[1], 10) : 0;
+        }).filter((n) => n > 0);
+      } catch { return []; }
     },
-    killChrome: () => {
+    killChrome() {
       try { execSync("taskkill /F /IM chrome.exe", { stdio: "ignore" }); } catch {}
     },
   },
@@ -123,25 +146,26 @@ const PLATFORM_CONFIG = {
       "/opt/google/chrome/google-chrome",
     ],
     profileDir: path.join(os.homedir(), ".config", "google-chrome"),
-    findChrome: () => {
-      for (const p of PLATFORM_CONFIG.linux.chromePaths) {
-        if (fs.existsSync(p)) return p;
-      }
+    findChrome() {
+      for (const p of this.chromePaths) if (fs.existsSync(p)) return p;
       return null;
     },
-    listChromePids: () => {
-      try {
-        const out = execSync("pgrep -x chrome", { encoding: "utf-8" }).trim();
-        return out
-          .split("\n")
-          .map(Number)
-          .filter((n) => n > 0);
-      } catch {
-        return [];
+    listChromePids() {
+      // 覆盖常见的 Chrome 进程命名
+      const patterns = ["google-chrome-stable", "google-chrome", "chrome"];
+      const pids = new Set();
+      for (const pat of patterns) {
+        try {
+          const out = execSync(`pgrep -x ${pat}`, { encoding: "utf-8" }).trim();
+          out.split("\n").map(Number).filter((n) => n > 0).forEach((n) => pids.add(n));
+        } catch {}
       }
+      return [...pids];
     },
-    killChrome: () => {
-      try { execSync("pkill -9 -x chrome", { stdio: "ignore" }); } catch {}
+    killChrome() {
+      for (const pat of ["google-chrome-stable", "google-chrome", "chrome"]) {
+        try { execSync(`pkill -9 -x ${pat}`, { stdio: "ignore" }); } catch {}
+      }
     },
   },
 };
@@ -150,21 +174,10 @@ const PLATFORM_CONFIG = {
 // 工具函数
 // ---------------------------------------------------------------------------
 
-function log(msg) {
-  console.log(msg);
-}
-
-function warn(msg) {
-  console.warn("⚠️  " + msg);
-}
-
-function ok(msg) {
-  console.log("✅ " + msg);
-}
-
-function err(msg) {
-  console.error("❌ " + msg);
-}
+function log(msg) { console.log(msg); }
+function warn(msg) { console.warn("⚠️  " + msg); }
+function ok(msg) { console.log("✅ " + msg); }
+function err(msg) { console.error("❌ " + msg); }
 
 function getConfig() {
   const config = PLATFORM_CONFIG[PLATFORM];
@@ -175,25 +188,24 @@ function getConfig() {
   return config;
 }
 
-/** 检查端口是否被占用 */
-function isPortListening(port) {
-  return new Promise((resolve) => {
-    const server = net.createServer();
-    server.once("error", () => resolve(true));
-    server.once("listening", () => {
-      server.close(() => resolve(false));
-    });
-    server.listen(port, "127.0.0.1");
-  });
+/** 同步等待 ms 毫秒（不依赖 setTimeout / 系统 sleep） */
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
-/** HTTP GET 检查 CDP 端点 */
+/** HTTP GET 检查 CDP 端点。拒绝 4xx/5xx；自动 drain 防止 keep-alive 残留连接。 */
 function httpGet(url) {
   return new Promise((resolve, reject) => {
     const req = http.get(url, { timeout: 3000 }, (res) => {
       let body = "";
       res.on("data", (chunk) => (body += chunk));
-      res.on("end", () => resolve(body));
+      res.on("end", () => {
+        if (res.statusCode >= 400) {
+          reject(new Error(`HTTP ${res.statusCode}`));
+        } else {
+          resolve(body);
+        }
+      });
     });
     req.on("error", reject);
     req.on("timeout", () => {
@@ -203,36 +215,153 @@ function httpGet(url) {
   });
 }
 
-/** 同步等待 ms 毫秒 */
-function sleepSync(ms) {
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+async function probeCDP(port) {
+  try {
+    const version = await httpGet(`http://127.0.0.1:${port}/json/version`);
+    return version;
+  } catch {
+    return null;
+  }
 }
 
-/** 复制 profile 文件（单个文件） */
+/** 复制文件（吞掉 ENOENT；其他错误打印一次警告供用户排查） */
 function copyFileSafe(src, dest) {
   try {
     fs.copyFileSync(src, dest);
     return true;
-  } catch {
+  } catch (e) {
+    if (e.code !== "ENOENT") {
+      warn(`复制失败: ${src} -> ${dest} (${e.code || e.message})`);
+    }
     return false;
   }
 }
 
 /** 递归复制目录 */
 function copyDirRecursive(src, dest) {
-  if (!fs.existsSync(dest)) {
-    fs.mkdirSync(dest, { recursive: true });
-  }
+  if (!fs.existsSync(dest)) fs.mkdirSync(dest, { recursive: true });
   const entries = fs.readdirSync(src, { withFileTypes: true });
   for (const entry of entries) {
     const srcPath = path.join(src, entry.name);
     const destPath = path.join(dest, entry.name);
     if (entry.isDirectory()) {
       copyDirRecursive(srcPath, destPath);
-    } else {
+    } else if (entry.isFile()) {
       copyFileSafe(srcPath, destPath);
     }
   }
+}
+
+/** 递归删除目录（兼容老版本 Node 的 fs.rmSync 缺失场景） */
+function rmDirSafe(dir) {
+  if (!fs.existsSync(dir)) return;
+  if (fs.rmSync) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } else {
+    fs.rmdirSync(dir, { recursive: true });
+  }
+}
+
+/**
+ * 刷新登录态相关文件（在 debugProfile 已存在的"增量"路径上使用）。
+ * 同时尝试老路径（Default/Cookies）和新路径（Default/Network/Cookies），
+ * 包含各类 -journal / -wal / -shm 旁路文件，以及 Google 账号登录数据。
+ */
+function refreshAuthFiles(srcDefault, destDefault) {
+  const targets = [
+    "Cookies", "Cookies-journal",
+    "Login Data", "Login Data-journal",
+    "Login Data For Account", "Login Data For Account-journal",
+    "Web Data", "Web Data-journal",
+    path.join("Network", "Cookies"),
+    path.join("Network", "Cookies-journal"),
+  ];
+  let copied = 0;
+  for (const rel of targets) {
+    const src = path.join(srcDefault, rel);
+    if (!fs.existsSync(src)) continue;
+    const dest = path.join(destDefault, rel);
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    if (copyFileSafe(src, dest)) copied++;
+  }
+  return copied;
+}
+
+/** 清理 Chrome singleton 锁，避免上次崩溃后下次启动失败 */
+function clearSingletonLocks(profileDir) {
+  const names = ["SingletonLock", "SingletonCookie", "SingletonSocket"];
+  for (const n of names) {
+    try { fs.unlinkSync(path.join(profileDir, n)); } catch {}
+  }
+}
+
+/** 等待 Chrome PID 列表为空 */
+function waitForChromeExit(config, maxMs = 8000, stepMs = 500) {
+  const start = Date.now();
+  while (Date.now() - start < maxMs) {
+    if (config.listChromePids().length === 0) return true;
+    sleepSync(stepMs);
+  }
+  return false;
+}
+
+/** TTY 交互式问询 */
+function promptYesNo(question) {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(/^y(es)?$/i.test((answer || "").trim()));
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// detect-only 模式
+// ---------------------------------------------------------------------------
+
+async function runDetectOnly(config) {
+  const version = await probeCDP(CDP_PORT);
+  if (version) {
+    log("CDP_STATUS=ready");
+    log(`CDP_URL=http://127.0.0.1:${CDP_PORT}/json/version`);
+    // 尝试从 JSON 提取浏览器版本（容错）
+    try {
+      const obj = JSON.parse(version);
+      if (obj.Browser) log(`BROWSER=${obj.Browser}`);
+    } catch {}
+    process.exit(0);
+  }
+  log("CDP_STATUS=needs-setup");
+  const pids = config.listChromePids();
+  if (pids.length > 0) {
+    log("CHROME_RUNNING=yes");
+    log(`CHROME_PID_COUNT=${pids.length}`);
+  } else {
+    log("CHROME_RUNNING=no");
+  }
+  process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// 同意流程：返回 true 继续，false 用户拒绝
+// ---------------------------------------------------------------------------
+
+async function ensureConsentToKill(pids) {
+  if (pids.length === 0) return true;
+  if (ARGS.flags.yes) return true;
+
+  // 非 TTY：拒绝静默杀进程，给调用方（Claude / 上层脚本）一个明确信号
+  if (!process.stdin.isTTY) {
+    err(`NEEDS_CONSENT: ${pids.length} running Chrome process(es) will be killed.`);
+    err(`Pass --yes to confirm (after asking the user), or stop Chrome manually first.`);
+    process.exit(3);
+  }
+
+  // TTY：交互问询
+  warn(`检测到 ${pids.length} 个正在运行的 Chrome 进程。`);
+  warn("继续将杀死它们，你在常规 Chrome 中未保存的工作可能丢失。");
+  return promptYesNo("继续？[y/N] ");
 }
 
 // ---------------------------------------------------------------------------
@@ -243,11 +372,22 @@ async function main() {
   const config = getConfig();
   const debugProfile = path.join(os.homedir(), "chrome-debug-profile");
 
-  log("=== CDP Chrome 环境准备 ===");
-  log(`平台: ${PLATFORM} | CDP 端口: ${CDP_PORT}`);
-
-  // 第一步：检测 Chrome 路径
+  // 1) 检测 Chrome 可执行路径（detect-only 也需要 profileDir）
   const chromePath = config.findChrome();
+
+  // detect-only：不修改任何状态
+  if (ARGS.flags.detectOnly) {
+    if (!chromePath) {
+      log("CDP_STATUS=needs-setup");
+      log("CHROME_INSTALLED=no");
+      process.exit(0);
+    }
+    return runDetectOnly(config);
+  }
+
+  log("=== CDP Chrome 环境准备 ===");
+  log(`平台: ${PLATFORM} | CDP 端口: ${CDP_PORT} | profile: ${ARGS.profile}`);
+
   if (!chromePath) {
     err("未找到 Google Chrome。请确保已安装。");
     err(`搜索路径: ${JSON.stringify(config.chromePaths, null, 2)}`);
@@ -255,119 +395,139 @@ async function main() {
   }
   log(`Chrome 路径: ${chromePath}`);
 
-  // 第二步：检测 profile
-  const defaultProfile = path.join(config.profileDir, "Default");
+  // 2) dry-run：先于任何副作用（包括"复用现有 CDP"）打印计划，让用户能看到真要执行时的步骤
+  const defaultProfile = path.join(config.profileDir, ARGS.profile);
   const hasProfile = fs.existsSync(defaultProfile);
 
-  if (DRY_RUN) {
-    log(`Chrome profile: ${config.profileDir} (${hasProfile ? "存在" : "不存在"})`);
+  if (ARGS.flags.dryRun) {
+    const cdpAlive = !!(await probeCDP(CDP_PORT));
+    log(`Chrome profile: ${defaultProfile} (${hasProfile ? "存在" : "不存在"})`);
+    log(`CDP 端口 ${CDP_PORT}: ${cdpAlive ? "已就绪（实际运行时会直接复用）" : "未监听"}`);
+    const runningPids = config.listChromePids();
+    log(`检测到 ${runningPids.length} 个 Chrome 进程`);
     log("\n--- dry-run 模式：只打印操作，不执行 ---");
-    if (hasProfile) {
-      log(`1. 复制 profile: ${config.profileDir}/Default → ${debugProfile}/Default`);
-      log(`2. 刷新 Cookie 和 Login Data`);
-    } else {
-      log(`1. ⚠️ 无用户 profile，将以空 profile 启动 Chrome`);
+    if (cdpAlive) {
+      log("0. CDP 已就绪，实际运行会直接复用并退出 0（以下步骤仅供参考）");
     }
-    log(`3. 停止现有 Chrome 进程`);
-    log(`4. 启动 Chrome: ${chromePath} --remote-debugging-port=${CDP_PORT} --user-data-dir=${debugProfile}`);
-    log(`5. 验证 CDP 端口 http://127.0.0.1:${CDP_PORT}/json/version`);
+    if (ARGS.flags.reset) log(`1. 删除 ${debugProfile}`);
+    if (runningPids.length > 0) {
+      log(`2. ${ARGS.flags.yes ? "（已同意）" : "请求同意后 "}杀死 ${runningPids.length} 个 Chrome 进程`);
+    } else {
+      log("2. 无 Chrome 进程，无需杀死");
+    }
+    if (hasProfile) {
+      log(`3. 复制 profile: ${defaultProfile} -> ${debugProfile}/Default`);
+    } else {
+      log("3. ⚠️ 无用户 profile，将以空 profile 启动");
+    }
+    log("4. 清理 SingletonLock / SingletonCookie / SingletonSocket");
+    log(`5. 启动 Chrome（含 --remote-allow-origins=*, --no-first-run 等）`);
+    log(`6. 验证 http://127.0.0.1:${CDP_PORT}/json/version`);
     ok("dry-run 完成。");
     process.exit(0);
   }
 
+  // 3) 若 CDP 已就绪 → 复用，直接退出
+  const existing = await probeCDP(CDP_PORT);
+  if (existing) {
+    ok("CDP 已就绪，复用现有 Chrome。");
+    log(existing.split("\n").slice(0, 5).join("\n"));
+    process.exit(0);
+  }
+
   if (!hasProfile) {
-    err(`未找到 Chrome 默认 profile: ${defaultProfile}`);
-    err("请确保已安装 Google Chrome 并至少使用过一次。");
+    err(`未找到 Chrome profile: ${defaultProfile}`);
+    err("请确保已安装 Google Chrome 并至少使用过一次，或用 --profile <name> 指定其他 profile。");
     process.exit(1);
   }
-  log(`Chrome profile: ${config.profileDir}`);
 
-  // 第三步：检查 CDP 端口是否已就绪
-  const portInUse = await isPortListening(CDP_PORT);
-  if (portInUse) {
-    log(`CDP 端口 ${CDP_PORT} 已在监听。`);
-    try {
-      const version = await httpGet(
-        `http://127.0.0.1:${CDP_PORT}/json/version`
-      );
-      ok("CDP 连接已验证，Chrome 就绪。");
-      log(version.split("\n").slice(0, 5).join("\n"));
-      process.exit(0);
-    } catch {
-      warn("端口正在监听但无响应，将重启 Chrome。");
+  // 4) 同意流程：如有 Chrome 进程要杀，先征得同意
+  const runningPids = config.listChromePids();
+  const consented = await ensureConsentToKill(runningPids);
+  if (!consented) {
+    err("用户拒绝，已中止。");
+    process.exit(2);
+  }
+
+  // 5) 杀死现有 Chrome 进程，等待退出
+  if (runningPids.length > 0) {
+    log(`正在停止 ${runningPids.length} 个 Chrome 进程...`);
+    config.killChrome();
+    if (!waitForChromeExit(config, 6000)) {
+      warn("首轮 kill 后仍有 Chrome 进程，再试一次...");
+      config.killChrome();
+      waitForChromeExit(config, 4000);
+    }
+    const remain = config.listChromePids();
+    if (remain.length > 0) {
+      warn(`仍有 ${remain.length} 个 Chrome 进程未退出，继续尝试启动（可能失败）`);
+    } else {
+      ok("Chrome 已退出。");
     }
   }
 
-  // 第四步：复制 Chrome profile 到调试目录
+  // 6) --reset：清空 debug profile
+  if (ARGS.flags.reset) {
+    log(`正在删除 debug profile: ${debugProfile}`);
+    rmDirSafe(debugProfile);
+  }
+
+  // 7) 复制 / 刷新 profile（此时 Chrome 已关闭，SQLite 一致）
   const debugDefault = path.join(debugProfile, "Default");
   if (!fs.existsSync(debugDefault)) {
-    log("正在复制 Chrome profile 到调试目录...");
+    log("正在复制 Chrome profile 到 debug 目录...");
     fs.mkdirSync(debugProfile, { recursive: true });
+    try { fs.chmodSync(debugProfile, 0o700); } catch {}
     copyDirRecursive(defaultProfile, debugDefault);
     ok(`Profile 已复制到: ${debugProfile}`);
   } else {
-    ok(`调试用 profile 已存在于: ${debugProfile}`);
-    log("正在刷新 Cookie 和登录数据...");
-    const srcDir = path.join(config.profileDir, "Default");
-    copyFileSafe(
-      path.join(srcDir, "Cookies"),
-      path.join(debugDefault, "Cookies")
-    );
-    copyFileSafe(
-      path.join(srcDir, "Login Data"),
-      path.join(debugDefault, "Login Data")
-    );
+    log("debug profile 已存在，刷新登录态相关文件...");
+    try { fs.chmodSync(debugProfile, 0o700); } catch {}
+    const n = refreshAuthFiles(defaultProfile, debugDefault);
+    ok(`已刷新 ${n} 个登录态文件`);
   }
 
-  // 第五步：关闭现有 Chrome 进程
-  log("正在停止已有的 Chrome 进程...");
-  config.killChrome();
-  sleepSync(3000);
+  // 8) 清理 singleton 锁
+  clearSingletonLocks(debugProfile);
 
-  const remaining = config.listChromePids();
-  if (remaining.length > 0) {
-    warn("等待 Chrome 进程完全退出...");
-    sleepSync(3000);
-    config.killChrome();
-    sleepSync(2000);
-  }
-
-  // 第六步：以 CDP 调试模式启动 Chrome
+  // 9) 以 CDP 模式启动 Chrome
   log(`正在以 CDP 模式启动 Chrome（端口 ${CDP_PORT}）...`);
-  const child = spawn(
-    chromePath,
-    [
-      `--remote-debugging-port=${CDP_PORT}`,
-      `--user-data-dir=${debugProfile}`,
-    ],
-    { detached: true, stdio: "ignore" }
-  );
+  const chromeArgs = [
+    `--remote-debugging-port=${CDP_PORT}`,
+    `--user-data-dir=${debugProfile}`,
+    "--remote-allow-origins=*",
+    "--no-first-run",
+    "--no-default-browser-check",
+    "--disable-features=ChromeWhatsNewUI",
+  ];
+  const child = spawn(chromePath, chromeArgs, { detached: true, stdio: "ignore" });
+  const childPid = child.pid;
   child.unref();
 
-  // 第七步：等待启动并验证
+  // 10) 等待启动并验证
   log("等待 Chrome 启动...");
   for (let i = 1; i <= 15; i++) {
     sleepSync(2000);
-    try {
-      const version = await httpGet(
-        `http://127.0.0.1:${CDP_PORT}/json/version`
-      );
-      if (version) {
-        ok(`Chrome 已成功以 CDP 模式启动（端口 ${CDP_PORT}）`);
-        log(version.split("\n").slice(0, 5).join("\n"));
-        process.exit(0);
-      }
-    } catch {
-      // 还没准备好
+    const version = await probeCDP(CDP_PORT);
+    if (version) {
+      ok(`Chrome 已成功以 CDP 模式启动（端口 ${CDP_PORT}）`);
+      log(version.split("\n").slice(0, 5).join("\n"));
+      process.exit(0);
     }
     log(`   尝试 ${i}/15...`);
   }
 
+  // 11) 失败清理：杀死刚才启动的孤儿 Chrome
   err("30 秒内未能启动 Chrome CDP 环境。");
+  err("正在清理刚启动的 Chrome 进程...");
+  if (childPid) {
+    try { process.kill(childPid); } catch {}
+  }
+  config.killChrome();
   err("可能原因：");
   err("  - Chrome 不支持 --remote-debugging-port");
   err(`  - 端口 ${CDP_PORT} 已被其他进程占用`);
-  err("  - user-data-dir 目录已损坏");
+  err("  - debug profile 目录已损坏（试试 --reset）");
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary

Deep review of the `browser-cdp` skill surfaced one UX hazard and several real bugs in `scripts/setup-cdp-chrome.js`. The fix rewrites the script around an explicit consent handshake that works in both skill mode and human-terminal mode, and reorders the launch flow so login state is actually preserved.

## What was wrong

- **Silently killed the user's Chrome.** `pkill -9` ran with no warning; users lost tabs/drafts.
- **Profile copy happened *before* Chrome was killed**, so SQLite files (`Cookies`, `Login Data`, …) were read mid-write. Login state often arrived torn — the #1 cause of "I copied the profile and still got logged out."
- **Cookie path coverage stale.** Only refreshed `Default/Cookies`; modern Chrome (M96+) uses `Default/Network/Cookies`. `Login Data For Account` (Google sign-in) was never copied.
- **No safety nets**: bad port silently became `NaN`; orphan Chrome left running on 30s timeout; stale `SingletonLock` could block next startup; no `--remote-allow-origins=*` (Chrome M111+ CDP origin enforcement); no `--no-first-run` (welcome-screen modals interrupted automation).
- **Two divergent copies** of the skill (`~/.claude/skills/browser-cdp/` had an old shell-only `setup_cdp_chrome.sh`).
- **Doc didn't tell Claude how to get consent** — skill mode would hang on a readline prompt if we added one naively.

## What changed

### `scripts/setup-cdp-chrome.js`

| New behavior | Why |
|---|---|
| `--detect-only` (read-only probe; structured `KEY=value` stdout) | Skill-mode entry point — Claude probes first, then asks the user, then re-invokes |
| `--yes` to bypass consent; non-TTY w/o `--yes` exits **code 3** + `NEEDS_CONSENT: …` | Safe by default in skill mode; explicit handshake instead of silent kill |
| TTY readline prompt when humans run it directly | Convenient for manual use |
| `--reset` wipes `~/chrome-debug-profile` before copy | Documented fix for stale login state |
| `--profile <name>` for non-Default Chrome profiles | Multi-profile users |
| Reordered main(): kill → wait until PIDs clear → copy profile | SQLite snapshot is consistent |
| Defensive auth paths: `Default/Cookies` **and** `Default/Network/Cookies` + `Login Data For Account` + `-journal` sidecars | Covers old + new Chrome layout |
| `--remote-allow-origins=*` + `--no-first-run` + `--no-default-browser-check` + `--disable-features=ChromeWhatsNewUI` | Required by M111+; avoids first-run modals on fresh profile |
| Singleton lock cleanup (`SingletonLock` / `Cookie` / `Socket`) | Prior crashes no longer break next startup |
| Orphan cleanup: tracks `child.pid`, kills it on 30s timeout | No leftover Chrome after failures |
| `chmod 0700` on debug profile | Profile contains cookies + saved passwords |
| Port range validation (1–65535) with clear error | `NaN` no longer reaches `--remote-debugging-port` |
| `httpGet` rejects 4xx/5xx and drains body | No keep-alive socket leaks |
| Linux PID match covers `google-chrome-stable` / `google-chrome` / `chrome` | Distro variance |
| `copyFileSafe` warns on non-ENOENT errors | Locked-file failures no longer silent |
| `--dry-run` previews even when CDP is already alive | Useful for "what would this do to me?" |
| Dead `net` import removed | Cleanup |

### `SKILL.md`

- Bold prereq warning about killing the user's Chrome.
- Documents the **detect → AskUserQuestion → `--yes`** flow explicitly, including why blind `--yes` is wrong (the exit-3 handshake is a safety net, not a green light).
- New options table, exit-code legend.
- `eval -b` / `eval --stdin` guidance for tricky JS (quoting was the #1 user trap).
- Stop / cleanup section.
- Common-issues table refreshed (stale login → `--reset`, multi-profile → `--profile`, etc.).
- Node floor dropped from 16+ to 12+ (over-conservative).

## Test plan

- [x] `node setup-cdp-chrome.js 9222 --detect-only` against live CDP → `CDP_STATUS=ready` + `BROWSER=…`
- [x] `--detect-only` on a dead port → `CDP_STATUS=needs-setup` + `CHROME_RUNNING=yes` + `CHROME_PID_COUNT=N`
- [x] `--dry-run` (CDP alive) — prints plan with reuse notice
- [x] `--dry-run --reset --yes` on dead port — shows reset step + `(已同意)` annotation
- [x] Non-TTY without `--yes` while Chrome running → exit 3 + `NEEDS_CONSENT:` stderr line (the skill-mode contract)
- [x] Invalid port (`99999`) → exit 1 with clear message
- [x] `--profile` without value → exit 1
- [x] `agent-browser --cdp 9222 eval 'document.title'` → returns live page title (sanity check that nothing in the running CDP path was broken)
- [x] `node -c` syntax check passes
- [ ] Full kill→restart cycle deferred (would have nuked the reviewer's active CDP session; each component on that path is individually verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)