### PR TITLE
docs: prepare v0.6.9 release notes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "网络小说创作工具箱 — 扫榜、拆文、写作全流程 Claude Code skill，覆盖长篇与短篇网文",
-    "version": "0.6.0"
+    "version": "0.6.9"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.6.9
+
+> story-cover 协议修复 + browser-cdp 同意握手 + story-review / story-setup 可靠性强化
+
+### 改进
+
+- **story-cover（封面生成）**：`images/edits` 流程改回正确的 `multipart/form-data` 形式（原 JSON-with-URL 仅在 yunwu 代理下歪打正着，对 OpenAI 直连必失败），文本字段用 `--form-string` 避免 `@` 前缀被误判为文件引用；自动版本号 `封面_v1/v2.png` 不再相互覆盖；落地 `.prompt.txt` 与 `.ref.txt` 旁注便于迭代；强制 `BOOK_DIR` / `PROMPT` 入口校验；`jq -n --arg` 拼 JSON 体规避中文/引号/换行的 shell 转义陷阱；`jq -er '.data[0].b64_json // empty'` 配合 `-s` 检查杜绝把 `"null"` 解码成 3 字节假 PNG；`jq`、`base64` 加入 `openclaw.requires.bins`。
+- **story-cover**：删除已与 `references/cover-styles.md` 漂移的平台风格副本表，统一以参考文件为单一来源；新增 Step 1.5「题材判定」明确关键词命中 + 多匹配优先级 + 零命中默认都市的确定性规则；`API 配置` 段重写为环境变量速查表。
+- **browser-cdp（浏览器操控）**：`setup-cdp-chrome.js` 在杀掉用户 Chrome 前先做明确的同意握手——TTY 走 readline 询问，skill 模式以 exit 3 + `NEEDS_CONSENT` 行回到 Claude Code 由 `AskUserQuestion` 询问，再以 `--yes` 显式确认。重排 `main()` 确保 Profile 复制在 Chrome 进程退出之后，避免 SQLite 写锁中复制导致 cookie 静默撕裂。
+- **browser-cdp**：cookie 路径全覆盖（旧 `Default/Cookies` + 新 `Default/Network/Cookies` + `Login Data For Account`）；启动加固——端口校验、`--remote-allow-origins`、`--no-first-run`、`SingletonLock` 清理、超时后孤儿进程回收；新增 `--detect-only` / `--reset` / `--profile` 选项。
+- **story-review（多视角审查）**：模式预检 + Agent 缺失/异常/过旧/启动失败的安全 solo 回退；reference 文件不可读时使用内置 rubric fallback；spawn 失败不再让 full/lean 半成品审稿继续；报告附带可机器校验的元数据。
+- **story-setup（环境部署）**：sentinel v9 元数据 + 项目内 reference 路径双重校验；hook 包自包含化；新增 `scripts/check-story-setup-deployment.sh` 与 `scripts/check-hook-regex-sync.sh` 兜底回归。
+
+### Bug 修复
+
+- 修复 story-cover 在 `images/generations` 请求体中带 `response_format: b64_json` 的兼容性问题——`gpt-image-2` 始终返回 base64，该参数已被 gpt-image 系列拒收。
+- 修复 story-cover 在 `BOOK_DIR` 未设置时静默落地到 CWD、`PROMPT` 未设置时报 `unbound variable` 等不友好行为，改为带说明的 `:?` 报错。
+- 修复 browser-cdp 在不询问用户的情况下直接杀掉 Chrome 的破坏性默认。
+- 修复 story-review 在用户项目尚未运行 story-setup 时直接失败而非降级 solo 模式。
+- 修复 story-setup 短篇/长篇项目根目录解析在某些路径下不稳定的问题。
+
+### 验证
+
+- story-cover：双 bash block `bash -n` 全过；`jq -n --arg` 拼接含中文/引号/换行的 prompt 校验通过；`curl --trace` 证实 `--form-string` 不把 `@` 前缀当文件引用；端到端打 `yunwu.ai/v1`，文生图 2.9 MB / 图生图 3.1 MB 两个 1024×1536 PNG + 旁注文件齐全。
+- browser-cdp：本地 fixture + Claude Code skill 模式 `NEEDS_CONSENT` 回环验证。
+- story-review：tmux + Claude Code `/story-review` 单飞回退与 deployed-agent 满编 smoke 全过；3 个独立 read-only sub-agent 审查 + 1 轮 re-review 通过。
+- story-setup：`scripts/check-story-setup-deployment.sh` / `check-hook-regex-sync.sh` / `check-shared-files.sh` / `static-check.sh` 全过；hook 模板 `bash -n` 全部通过。
+- `claude plugin validate` 通过；GitHub CI：macOS / Windows / static-check 全绿。
+
 ## v0.6.8
 
 > story-import 重构 + skill 自包含化 + 起点扫榜与 story-review 子 Agent 修复

--- a/README.md
+++ b/README.md
@@ -158,15 +158,14 @@ demo/拆文库-盘龙/
 
 Agent 按需加载 `references/` 中的写作理论（角色设计、对话技法、反转工具箱等 100+ 份方法论文件），不预占上下文。
 
-## 升级到 v0.6.8
+## 升级到 v0.6.9
 
-如果你已经在写作项目中运行过 `/story-setup`，升级 skill 后请在项目根目录重新运行一次 `/story-setup`（`agents_version` 已升级到 v8，触发 reviewer 模板重部署）。
+如果你已经在写作项目中运行过 `/story-setup`，升级 skill 后请在项目根目录重新运行一次 `/story-setup`（hook bundle sentinel 升到 v9，触发模板重部署 + 部署完整性校验）。
 
-- **story-import（导入已有小说）**：按篇幅自动分流——长篇走完整拆解 + 长篇项目结构迁移，短篇走短篇拆解 + 单文件 `正文.md` 工程。判定优先级：用户声明 > 章节结构 > 字数兜底。
-- **story-import**：长篇导入会反推 `追踪/角色状态.md`，story-long-write 日更准备层不再因为缺这个文件而走兜底分支。
-- **story-import**：调用拆书 skill 时自动越过 Stage 1 停靠点，避免「黄金三章后停下询问」的交互被透传给导入用户。
-- **story-review 子 Agent 路径修复**：reviewer 不再在用户项目 cwd 下查 `quality-checklist.md` 等裸文件名，统一走 skill 自带的规范路径。
-- **起点扫榜修复**：默认改为移动端 SSR 抓取，保留 CDP + CAPTCHA 回退；规避了 PC 站风控页拦截。
+- **story-cover（封面生成）**：`images/edits` 流程改回标准的 `multipart/form-data`（原 JSON-with-URL 仅在某代理下生效，对 OpenAI 直连必失败）；自动版本号 `封面_v1/v2.png`、`.prompt.txt`/`.ref.txt` 旁注、`jq -n` 防转义、API 错误早退、`// empty` 防假 PNG、`BOOK_DIR/PROMPT` 入口校验，全面加固出图链路。删除与 `references/cover-styles.md` 漂移的平台风格副本表，统一以参考文件为单一来源；新增 Step 1.5 题材判定。
+- **browser-cdp（浏览器操控）**：杀掉用户 Chrome 前先走明确的同意握手——TTY 用 readline 询问，skill 模式以 `NEEDS_CONSENT` 退出码 3 回到 Claude Code 由 `AskUserQuestion` 询问，避免静默关闭浏览器丢失登录态；Profile 复制重新排序到 Chrome 退出之后，避免 SQLite 写锁导致 cookie 撕裂。
+- **story-review（多视角审查）**：模式预检 + Agent 缺失/异常/过旧/启动失败的安全 solo 回退，reference 不可读时走内置 rubric fallback；项目尚未 `story-setup` 也能跑出可用审稿。
+- **story-setup（环境部署）**：sentinel v9 元数据 + 项目内 reference 路径双重校验；新增 `scripts/check-story-setup-deployment.sh` / `check-hook-regex-sync.sh` 兜底回归；hook 包自包含化。
 
 ## 自动化 Hooks
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -156,15 +156,14 @@ Writing skills internally coordinate 7 specialized agents:
 
 Agents load writing theory from `references/` on demand (character design, dialogue techniques, twist toolbox, etc. — 100+ methodology files), without reserving context window space.
 
-## Upgrading to v0.6.8
+## Upgrading to v0.6.9
 
-If you have already run `/story-setup` inside a writing project, run `/story-setup` again from the project root after updating this skill pack (`agents_version` is bumped to v8 to trigger reviewer template redeploy).
+If you have already run `/story-setup` inside a writing project, run `/story-setup` again from the project root after updating this skill pack (the hook-bundle sentinel is bumped to v9, triggering template redeploy plus deployment-integrity checks).
 
-- **story-import (import existing novels)**: automatic length routing — long-form runs the full deconstruction pipeline plus long-form project migration, short-form runs the short-form pipeline plus a single-file `正文.md` project. Priority: user declaration > chapter structure > word-count fallback.
-- **story-import**: long-form imports now reverse-engineer `追踪/角色状态.md` so the daily-writing preparation layer no longer falls back to inference when this file is missing.
-- **story-import**: when invoking the deconstruction skill it automatically skips the Stage 1 checkpoint so the "after-golden-three-chapters stop and ask" interaction is not surfaced to import users.
-- **story-review subagent path fix**: reviewers no longer look up bare names like `quality-checklist.md` against the user project's cwd; references are loaded via the owning skill's canonical path.
-- **Qidian scanner fix**: default to mobile SSR scraping with CDP + CAPTCHA fallback, avoiding the PC-site anti-bot block.
+- **story-cover**: `images/edits` now uses the correct `multipart/form-data` shape (the previous JSON-with-URL shape only worked against a specific proxy quirk and would fail against OpenAI direct). Adds auto-versioned `封面_v1/v2.png` output, `.prompt.txt` / `.ref.txt` sidecars, `jq -n` JSON escaping, early-exit on API errors, `// empty` guard against fake PNGs, and `BOOK_DIR` / `PROMPT` entry checks. Drops the duplicated platform-style table that had drifted from `references/cover-styles.md`; adds deterministic Step 1.5 genre detection.
+- **browser-cdp**: explicit consent handshake before killing the user's Chrome — TTY uses readline; skill mode exits 3 with a `NEEDS_CONSENT` line so Claude Code can ask via `AskUserQuestion`. The profile copy is reordered to run **after** Chrome has exited, eliminating silent cookie corruption from copying SQLite files under a write lock.
+- **story-review**: mode preflight + safe solo fallback when reviewer agents are missing/broken/stale/fail-to-spawn, plus an embedded rubric fallback when reference files are unreadable; usable even before `story-setup` has been run in the project.
+- **story-setup**: sentinel v9 metadata and project-local reference paths are now double-checked; new `scripts/check-story-setup-deployment.sh` and `scripts/check-hook-regex-sync.sh` provide regression coverage; the deployed hook bundle is self-contained.
 
 ## Automation Hooks
 


### PR DESCRIPTION
## Summary

为 v0.6.9 发布做文档准备。覆盖 4 个本周已合入 / 已 push 到 main 的修复：

- **story-cover**（#94）— `images/edits` 改回正确的 multipart 形式 + 运行时加固 + 协议清理
- **browser-cdp**（#93）— 杀 Chrome 前的同意握手 + Profile 复制时序 + cookie 路径全覆盖
- **story-review** — 模式预检 + 安全 solo 回退（直接合入 main 的硬化）
- **story-setup** — sentinel v9 + 部署完整性校验脚本（直接合入 main 的硬化）

## 修改的文件

- `CHANGELOG.md` — 新增 v0.6.9 段（改进 / Bug 修复 / 验证 三个子段，沿用 v0.6.8 的中文风格）
- `README.md` / `README_EN.md` — 替换原「升级到 v0.6.8」callout 为 v0.6.9
- `.claude-plugin/marketplace.json` — `metadata.version` 由旧版 0.6.0 对齐到 0.6.9

各 skill plugin 的 `version` 字段不变（与 git tag 解耦，按 SKILL.md frontmatter 管理）。Agent 列表 (7) 与 hook 列表 (6) 已对照 `skills/story-setup/references/templates/` 实际清单核对，README 表格无需变动。

## Test plan

- [x] `jq empty .claude-plugin/marketplace.json` 通过
- [x] `bash scripts/static-check.sh` — 13/13 PASS, 0 fail
- [x] CHANGELOG / README / README_EN 互相一致，时间与版本号统一
- [ ] 合入后打 v0.6.9 tag 触发 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)