### PR TITLE
chore: bump marketplace metadata.version 0.6.9 → 0.6.13

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "网络小说创作工具箱 — 扫榜、拆文、写作全流程 Claude Code skill，覆盖长篇与短篇网文",
-    "version": "0.6.9"
+    "version": "0.6.13"
   },
   "plugins": [
     {


### PR DESCRIPTION
## 概述

修复 `.claude-plugin/marketplace.json` 的 `metadata.version` 陈旧问题：自 #95（v0.6.9 release notes）后漏 bump，一直停在 **0.6.9**，而 CHANGELOG 已到 **v0.6.13**。

## 证据

- `metadata.version` 历史：`1.0.0 → 0.5.0 → 0.6.0 → 0.6.9`，最后一次动于 #95「prepare v0.6.9 release notes」，之后 v0.6.10/0.6.11/0.6.12/0.6.13 均未同步。该字段历史上随发布里程碑 bump，属漏更新。
- `publish-clawhub.yml` 不读、不 bump 此字段（它 bump 的是 per-skill 版本）→ 无功能性影响；纯对外元数据一致性修复，消除「目录显示 0.6.9 vs 实际 0.6.13」的误导。

## 改动

- `metadata.version` 0.6.9 → 0.6.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)
