### PR TITLE
fix: Fix Chinese path encoding issue in Windows bash scripts

### DIFF
--- a/scripts/check-shared-files.sh
+++ b/scripts/check-shared-files.sh
@@ -4,6 +4,10 @@
 # 兼容 bash 3+（macOS）
 set -euo pipefail
 
+# Ensure UTF-8 handling for Chinese paths (Windows compatibility)
+export LANG=${LANG:-en_US.UTF-8}
+export LC_ALL=${LC_ALL:-en_US.UTF-8}
+
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
 if [ -z "$REPO_ROOT" ]; then
   echo "Error: not in a git repository"

--- a/scripts/static-check.sh
+++ b/scripts/static-check.sh
@@ -4,6 +4,10 @@
 
 set -euo pipefail
 
+# Ensure UTF-8 handling for Chinese paths (Windows compatibility)
+export LANG=${LANG:-en_US.UTF-8}
+export LC_ALL=${LC_ALL:-en_US.UTF-8}
+
 # 用 git 定位项目根目录，避免硬编码跳级
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
 if [ -z "$REPO_ROOT" ]; then

--- a/skills/story-setup/references/templates/hooks/detect-story-gaps.sh
+++ b/skills/story-setup/references/templates/hooks/detect-story-gaps.sh
@@ -2,6 +2,10 @@
 # detect-story-gaps.sh — 检测写作项目中的 5 项缺口
 set -euo pipefail
 
+# Ensure UTF-8 handling for Chinese paths (Windows compatibility)
+export LANG=${LANG:-en_US.UTF-8}
+export LC_ALL=${LC_ALL:-en_US.UTF-8}
+
 echo "=== Story Gap Detection ==="
 
 # 1. 新项目检测：没有书名目录

--- a/skills/story-setup/references/templates/hooks/post-compact.sh
+++ b/skills/story-setup/references/templates/hooks/post-compact.sh
@@ -2,6 +2,10 @@
 # post-compact.sh — compact 后提醒恢复上下文
 set -euo pipefail
 
+# Ensure UTF-8 handling for Chinese paths (Windows compatibility)
+export LANG=${LANG:-en_US.UTF-8}
+export LC_ALL=${LC_ALL:-en_US.UTF-8}
+
 discover_book_dir() {
   if [ -f ".active-book" ]; then
     cat ".active-book"

--- a/skills/story-setup/references/templates/hooks/pre-compact.sh
+++ b/skills/story-setup/references/templates/hooks/pre-compact.sh
@@ -2,6 +2,10 @@
 # pre-compact.sh — compact 前记录写作状态摘要（不 dump 内容）
 set -euo pipefail
 
+# Ensure UTF-8 handling for Chinese paths (Windows compatibility)
+export LANG=${LANG:-en_US.UTF-8}
+export LC_ALL=${LC_ALL:-en_US.UTF-8}
+
 discover_book_dir() {
   if [ -f ".active-book" ]; then
     cat ".active-book"

--- a/skills/story-setup/references/templates/hooks/session-start.sh
+++ b/skills/story-setup/references/templates/hooks/session-start.sh
@@ -2,6 +2,10 @@
 # session-start.sh — 显示项目状态和写作上下文摘要
 set -euo pipefail
 
+# Ensure UTF-8 handling for Chinese paths (Windows compatibility)
+export LANG=${LANG:-en_US.UTF-8}
+export LC_ALL=${LC_ALL:-en_US.UTF-8}
+
 # 发现活跃的书目目录
 discover_book_dir() {
   if [ -f ".active-book" ]; then

--- a/skills/story-setup/references/templates/hooks/validate-story-commit.sh
+++ b/skills/story-setup/references/templates/hooks/validate-story-commit.sh
@@ -2,6 +2,10 @@
 # validate-story-commit.sh — 在 git commit 时检查格式问题（WARNING only, no BLOCKING）
 set -euo pipefail
 
+# Ensure UTF-8 handling for Chinese paths (Windows compatibility)
+export LANG=${LANG:-en_US.UTF-8}
+export LC_ALL=${LC_ALL:-en_US.UTF-8}
+
 # 仅在 git commit 命令时触发（由 settings.json 的 if 过滤器控制）
 # 其他 Bash 命令不应到达此脚本，但做安全检查
 


### PR DESCRIPTION
## Summary

Fixed bash script encoding issues on Windows when using Chinese directory paths.

## Changes

- Added UTF-8 locale settings (LANG/LC_ALL) at the beginning of all bash scripts
- Ensures Chinese directory names (tracking, main text, settings, outline, etc.) are handled correctly on Windows
- Fixed 5 hooks scripts and 2 CI scripts

## Modified Files

- skills/story-setup/references/templates/hooks/session-start.sh
- skills/story-setup/references/templates/hooks/detect-story-gaps.sh
- skills/story-setup/references/templates/hooks/validate-story-commit.sh
- skills/story-setup/references/templates/hooks/pre-compact.sh
- skills/story-setup/references/templates/hooks/post-compact.sh
- scripts/static-check.sh
- scripts/check-shared-files.sh

## Testing

- Ran static-check.sh to verify all skill structure checks pass
- UTF-8 locale settings do not affect existing functionality

Fixes worldwonderer/oh-story-claudecode#121