### PR TITLE
fix(hooks): byte-stable story-setup hooks on Windows Chinese systems (#164)

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -19,6 +19,14 @@ jobs:
         run: bash scripts/check-story-setup-deployment.sh
       - name: Guard against bare python3 invocations
         run: bash scripts/check-python-invocation.sh
+      - name: Guard hook locale safety (LC_ALL=C + no full-width char classes)
+        run: bash scripts/check-hook-locale-safety.sh
+      # Generate a GBK-class locale so the hook test's Part 2 runs end-to-end here,
+      # not just on macOS. Best-effort: if it fails the test self-skips Part 2.
+      - name: Generate zh_CN.GBK locale (Chinese Windows simulation)
+        run: sudo localedef -f GBK -i zh_CN zh_CN.GBK || sudo locale-gen zh_CN.GBK || true
+      - name: Hook path-encoding portability (cp936 + real GBK locale)
+        run: bash scripts/test-hook-encoding-portable.sh
       - name: Portable char-count (real interpreter)
         run: bash scripts/test-charcount-portable.sh
       - name: Portable char-count (simulated Windows Store stub)
@@ -58,6 +66,10 @@ jobs:
       - name: Portable char-count (simulated Windows Store stub)
         shell: bash
         run: bash scripts/test-charcount-portable.sh --stub
+      # Real Windows Git Bash path: the cp936 stdout bug (issue #164) bites here.
+      - name: Hook path-encoding portability (cp936 + GBK locale if present)
+        shell: bash
+        run: bash scripts/test-hook-encoding-portable.sh
 
   macos:
     runs-on: macos-latest
@@ -83,3 +95,5 @@ jobs:
         run: bash scripts/test-charcount-portable.sh
       - name: Portable char-count (simulated Windows Store stub)
         run: bash scripts/test-charcount-portable.sh --stub
+      - name: Hook path-encoding portability (cp936 + GBK locale if present)
+        run: bash scripts/test-hook-encoding-portable.sh

--- a/scripts/check-hook-locale-safety.sh
+++ b/scripts/check-hook-locale-safety.sh
@@ -21,8 +21,10 @@ echo "========================"
 
 fail=0
 
-# Check 1：在中文内容/路径上做 awk/sed/grep 文本匹配或 bash 中文通配的 hook，必须 export
+# Check 1：自身在中文内容/路径上做 awk/sed/grep 文本匹配或 bash 中文通配的 hook，必须 export
 # LC_ALL=C。这些 hook 在 GBK 区域下会按多字节错解 UTF-8。新增同类 hook 时一并加入清单。
+# 注：session-*/pre-compact/post-compact 自身只做精确 [ -f/-d ]/find -name/printf（GBK 安全），
+# 中文匹配全委托给 lib/common.sh，故不在此清单，改由 Check 3 守 common.sh。
 LOCALE_SENSITIVE_HOOKS="detect-story-gaps guard-outline-before-prose validate-story-commit"
 for h in $LOCALE_SENSITIVE_HOOKS; do
   f="$HOOKS_DIR/$h.sh"
@@ -49,6 +51,23 @@ if [ -n "$BRACKET_HITS" ]; then
   fail=1
 else
   echo "OK: 未发现含全角字符的方括号字符组"
+fi
+
+# Check 3：lib/common.sh 被多个未 export LC_ALL=C 的 hook（session-*/pre-compact/post-compact）
+# 复用，其处理中文书名/路径的 sed/grep 必须 per-command 加 LC_ALL=C，否则 GBK 下 trim 会报
+# illegal byte sequence、.active-book 被吞空、误解析到 find 的第一本书。
+COMMON="$HOOKS_DIR/lib/common.sh"
+if [ -f "$COMMON" ]; then
+  # 单文件 grep -n 输出是 LINENO:content（无文件名前缀），注释行用 ^[0-9]+:[[:space:]]*# 剔除。
+  BARE_TEXT_TOOL="$(grep -nE '(^|[^=[:alnum:]_])(sed|grep)[[:space:]]' "$COMMON" 2>/dev/null \
+    | grep -vE 'LC_ALL=C' | grep -vE '^[0-9]+:[[:space:]]*#' || true)"
+  if [ -n "$BARE_TEXT_TOOL" ]; then
+    echo "FAIL: lib/common.sh 有未加 LC_ALL=C 的 sed/grep（GBK 下处理中文书名会乱）："
+    echo "$BARE_TEXT_TOOL"
+    fail=1
+  else
+    echo "OK: lib/common.sh 的 sed/grep 均已 LC_ALL=C"
+  fi
 fi
 
 exit "$fail"

--- a/scripts/check-hook-locale-safety.sh
+++ b/scripts/check-hook-locale-safety.sh
@@ -21,11 +21,10 @@ echo "========================"
 
 fail=0
 
-# Check 1：自身在中文内容/路径上做 awk/sed/grep 文本匹配或 bash 中文通配的 hook，必须 export
-# LC_ALL=C。这些 hook 在 GBK 区域下会按多字节错解 UTF-8。新增同类 hook 时一并加入清单。
-# 注：session-*/pre-compact/post-compact 自身只做精确 [ -f/-d ]/find -name/printf（GBK 安全），
-# 中文匹配全委托给 lib/common.sh，故不在此清单，改由 Check 3 守 common.sh。
-LOCALE_SENSITIVE_HOOKS="detect-story-gaps guard-outline-before-prose validate-story-commit"
+# Check 1：所有处理中文内容/路径的部署 hook 必须 export LC_ALL=C，在 GBK 区域下走字节匹配。
+# 含内嵌 python 的 hook（guard-outline/validate-story-commit）export 位置另有讲究（见各文件注释），
+# 但都必须出现该 export。新增 hook 一并加入清单。
+LOCALE_SENSITIVE_HOOKS="detect-story-gaps guard-outline-before-prose validate-story-commit session-start session-end pre-compact post-compact"
 for h in $LOCALE_SENSITIVE_HOOKS; do
   f="$HOOKS_DIR/$h.sh"
   if [ ! -f "$f" ]; then

--- a/scripts/check-hook-locale-safety.sh
+++ b/scripts/check-hook-locale-safety.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# check-hook-locale-safety.sh — 守卫部署 hook 在 Windows 中文 GBK 区域下的字节安全。
+#
+# 背景（issue #164 同类）：部署 hook 跑在用户 Windows Git Bash。若用户导出 GBK/GB2312
+# 区域设置，gawk/GNU sed/GNU grep 和 bash 通配会把 UTF-8 中文内容/路径按多字节错误解码，
+# 让守卫静默失效（误拦或漏检）。治法是在 hook 里 `export LC_ALL=C` 走字节匹配。
+#
+# 本守卫是 locale 无关的静态检查（任何 CI 环境都能跑），与行为级回归
+# scripts/test-hook-encoding-portable.sh（在真实 GBK 区域下端到端跑 hook）互补。
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+if [ -z "$REPO_ROOT" ]; then
+  echo "Error: not in a git repository"
+  exit 1
+fi
+HOOKS_DIR="$REPO_ROOT/skills/story-setup/references/templates/hooks"
+
+echo "Hook locale-safety Guard"
+echo "========================"
+
+fail=0
+
+# Check 1：在中文内容/路径上做 awk/sed/grep 文本匹配或 bash 中文通配的 hook，必须 export
+# LC_ALL=C。这些 hook 在 GBK 区域下会按多字节错解 UTF-8。新增同类 hook 时一并加入清单。
+LOCALE_SENSITIVE_HOOKS="detect-story-gaps guard-outline-before-prose validate-story-commit"
+for h in $LOCALE_SENSITIVE_HOOKS; do
+  f="$HOOKS_DIR/$h.sh"
+  if [ ! -f "$f" ]; then
+    echo "FAIL: 预期的 locale 敏感 hook 不存在：$h.sh"
+    fail=1
+    continue
+  fi
+  if ! grep -qE '^[[:space:]]*export[[:space:]]+LC_(ALL|CTYPE)=C\b' "$f"; then
+    echo "FAIL: $h.sh 缺少 export LC_ALL=C（GBK 区域下中文匹配会乱，issue #164 同类）"
+    fail=1
+  fi
+done
+[ "$fail" -eq 0 ] && echo "OK: locale 敏感 hook 均已 export LC_ALL=C"
+
+# Check 2：禁止在部署 hook 的正则里用含全角字符的方括号字符组（如 [：:]）。含全角字符的
+# 字符组只有 UTF-8 区域才正确，在 C/GBK 区域会被拆成单字节、漏匹配；必须改用交替 (：|:)。
+# 用字节匹配检测 `[` 紧跟全角冒号/分号/逗号/句号等常见全角标点；跳过整行注释。
+BRACKET_HITS="$(LC_ALL=C grep -rnE '\[[^]]*(：|；|，|。|！|？|、)' "$HOOKS_DIR"/*.sh 2>/dev/null \
+  | grep -vE ':[0-9]+:[[:space:]]*#' || true)"
+if [ -n "$BRACKET_HITS" ]; then
+  echo "FAIL: 部署 hook 正则里出现含全角字符的方括号字符组（C/GBK 区域会漏匹配，改用交替 (A|B)）："
+  echo "$BRACKET_HITS"
+  fail=1
+else
+  echo "OK: 未发现含全角字符的方括号字符组"
+fi
+
+exit "$fail"

--- a/scripts/check-python-invocation.sh
+++ b/scripts/check-python-invocation.sh
@@ -39,3 +39,32 @@ if [ -n "$hits" ]; then
 fi
 
 echo "OK: 未发现裸调 python3"
+echo
+
+# 第二道守卫：部署型 hook 内嵌 python 不准用文本模式 stdout 输出（print(/sys.stdout.write）。
+# Windows 中文系统 python stdout 默认 cp936，文本模式会把中文路径编成 GBK，与脚本里的 UTF-8
+# 字面量字节不一致，让守卫静默失效（issue #164）。要把值交给 shell 必须直写 UTF-8 字节：
+#   sys.stdout.buffer.write(value.encode("utf-8"))
+# `print(` 不会误命中 `printf `（无括号）；`sys.stdout.write(` 不会命中允许的
+# `sys.stdout.buffer.write(`（中间多了 .buffer）。
+HOOKS_DIR="$REPO_ROOT/skills/story-setup/references/templates/hooks"
+TEXT_STDOUT='print\(|sys\.stdout\.write\('
+
+echo "Hook stdout-encoding Guard"
+echo "=========================="
+if [ -d "$HOOKS_DIR" ]; then
+  enc_hits="$(grep -rnE "$TEXT_STDOUT" "$HOOKS_DIR" --include='*.sh' 2>/dev/null || true)"
+else
+  enc_hits=""
+fi
+
+if [ -n "$enc_hits" ]; then
+  echo "FAIL: hook 内嵌 python 用了文本模式 stdout 输出（Windows 中文系统会编成 GBK，守卫静默失效）："
+  echo "$enc_hits"
+  echo
+  echo "把要交给 shell 的值直写 UTF-8 字节："
+  echo '  sys.stdout.buffer.write(value.encode("utf-8"))'
+  exit 1
+fi
+
+echo "OK: hook 内嵌 python 未发现文本模式 stdout 输出"

--- a/scripts/test-hook-encoding-portable.sh
+++ b/scripts/test-hook-encoding-portable.sh
@@ -121,6 +121,16 @@ EOF
   git -C "$P2" add -A >/dev/null 2>&1
   cout="$(cd "$P2" && GBK CLAUDE_PROJECT_DIR="$P2" STORY_COMMIT_COMMAND='git commit -m x' bash .claude/hooks/validate-story-commit.sh 2>&1 || true)"
   echo "$cout" | grep -q 'Hardcoded character attributes' && pass "[GBK] validate-commit catches fullwidth-colon attr" || bad "[GBK] validate-commit missed fullwidth-colon attr under GBK"
+
+  # 2d lib/common.sh discover_active_book：.active-book 指向「短中文书名」时，GBK 下 trim sed
+  # 会报 illegal byte sequence → active 被吞空 → 误回退到 find 的第一本书。覆盖被 session-*/
+  # pre-compact/post-compact 复用的这条共享路径。确定性构造：活跃书无 追踪/正文（fallback 找
+  # 不到它），诱饵书有 追踪/（fallback 只会命中诱饵）—— 修复前回 decoy、修复后回 .active-book。
+  P2D="$WORK/p2d"; deploy "$P2D"
+  mkdir -p "$P2D/让你管账号/设定" "$P2D/decoy小说/追踪"
+  printf '让你管账号\n' > "$P2D/.active-book"
+  active_book="$(cd "$P2D" && GBK CLAUDE_PROJECT_DIR="$P2D" bash -c 'source ".claude/hooks/lib/common.sh"; basename "$(discover_active_book)"' 2>/dev/null)"
+  [ "$active_book" = "让你管账号" ] && pass "[GBK] discover_active_book honors short Chinese .active-book" || bad "[GBK] discover_active_book dropped short Chinese .active-book -> [$active_book] (expected 让你管账号)"
 fi
 
 echo ""

--- a/scripts/test-hook-encoding-portable.sh
+++ b/scripts/test-hook-encoding-portable.sh
@@ -99,11 +99,12 @@ else
   [ "$(rg '让你管账号/正文/第1章_开端.md')" = 0 ] && pass "[GBK] guard allows present 细纲 (Chinese glob)" || bad "[GBK] guard should allow present 细纲 under GBK"
   [ "$(rg '让你管账号/正文/第001章_开端.md')" = 0 ] && pass "[GBK] guard tolerates zero-pad 第001章" || bad "[GBK] guard should tolerate 第001章 under GBK"
 
-  # 2b detect-story-gaps：正常伏笔表不误报；同时证明中文书目能被发现
+  # 2b detect-story-gaps：正常伏笔表不误报；同时证明中文书目能被发现。
+  # F001 状态用全角空格 U+3000 补白（已埋 前后各一个），守住 LC_ALL=C 下 trim 仍认全角空格。
   cat > "$BOOK/追踪/伏笔.md" <<'EOF'
 | ID | 伏笔内容 | 埋设章节 | 预计回收章节 | 状态{未埋/已埋/已回收/已过期} | 重要度{高/中/低} |
 |----|---------|---------|-------------|-----------------------------|----------------|
-| F001 | 玉佩身世 | 第1章 | 第20章 | 已埋 | 高 |
+| F001 | 玉佩身世 | 第1章 | 第20章 |　已埋　| 高 |
 | F002 | 师门往事 | 第3章 | 第25章 | 已回收 | 中 |
 EOF
   out="$(cd "$P2" && GBK CLAUDE_PROJECT_DIR="$P2" bash .claude/hooks/detect-story-gaps.sh 2>&1 || true)"
@@ -114,8 +115,9 @@ EOF
   echo "$out2" | grep -q '让你管账号' && pass "[GBK] detect-story-gaps discovers Chinese book + warns on real gap" || bad "[GBK] detect-story-gaps failed to discover Chinese book under GBK"
   rm -f "$BOOK"/正文/第*章.md
 
-  # 2c validate-story-commit：命中全角冒号硬编码属性（C/GBK 区域下方括号字符组会漏，交替修好）
-  printf '年龄 ：18\n' > "$BOOK/正文/第1章_开端.md"
+  # 2c validate-story-commit：命中全角冒号 + 全角空格的硬编码属性（C/GBK 区域下方括号字符组
+  # 会漏全角冒号、[[:space:]] 会漏全角空格，交替修好）
+  printf '年龄　：18\n' > "$BOOK/正文/第1章_开端.md"
   git -C "$P2" add -A >/dev/null 2>&1
   cout="$(cd "$P2" && GBK CLAUDE_PROJECT_DIR="$P2" STORY_COMMIT_COMMAND='git commit -m x' bash .claude/hooks/validate-story-commit.sh 2>&1 || true)"
   echo "$cout" | grep -q 'Hardcoded character attributes' && pass "[GBK] validate-commit catches fullwidth-colon attr" || bad "[GBK] validate-commit missed fullwidth-colon attr under GBK"

--- a/scripts/test-hook-encoding-portable.sh
+++ b/scripts/test-hook-encoding-portable.sh
@@ -129,8 +129,14 @@ EOF
   P2D="$WORK/p2d"; deploy "$P2D"
   mkdir -p "$P2D/让你管账号/设定" "$P2D/decoy小说/追踪"
   printf '让你管账号\n' > "$P2D/.active-book"
-  active_book="$(cd "$P2D" && GBK CLAUDE_PROJECT_DIR="$P2D" bash -c 'source ".claude/hooks/lib/common.sh"; basename "$(discover_active_book)"' 2>/dev/null)"
-  [ "$active_book" = "让你管账号" ] && pass "[GBK] discover_active_book honors short Chinese .active-book" || bad "[GBK] discover_active_book dropped short Chinese .active-book -> [$active_book] (expected 让你管账号)"
+  active_path="$(cd "$P2D" && GBK CLAUDE_PROJECT_DIR="$P2D" bash -c 'source ".claude/hooks/lib/common.sh"; discover_active_book' 2>/dev/null)"
+  # 字节安全断言：活跃书有 设定/、诱饵书有 追踪/；用 [ -d ] 直接 stat 字节路径，避免 basename
+  # 在个别 runner 的 GBK 下改写多字节而假失败。修复前回诱饵（无 设定/），修复后回活跃书。
+  if [ -d "$active_path/设定" ]; then
+    pass "[GBK] common.sh discover_active_book honors short Chinese .active-book"
+  else
+    bad "[GBK] common.sh discover_active_book dropped short Chinese .active-book (resolved [$active_path])"
+  fi
 fi
 
 echo ""

--- a/scripts/test-hook-encoding-portable.sh
+++ b/scripts/test-hook-encoding-portable.sh
@@ -68,9 +68,20 @@ done
 
 # ===== Part 2：真实 GBK 区域下跑全部 hook =====
 echo "--- Part 2: real GBK locale (LANG/LC_ALL=zh_CN.GBK) end-to-end ---"
-GBK_LOCALE="$(locale -a 2>/dev/null | grep -iE '^zh_CN\.(gbk|gb18030|gb2312)$' | head -1 || true)"
+# 探测「可用」的 GBK 类 locale：不看 `locale -a` 列表（Cygwin/MSYS2 会按需合成而不列出），
+# 而是真试着设上去看 `locale charmap` 是否返回 GB 类编码。这样 Linux(localedef 生成)、
+# macOS(自带)、Windows Git Bash(Cygwin 合成) 三处都能跑到真实 GBK。
+detect_gbk_locale() {
+  local cand cm
+  for cand in zh_CN.GBK zh_CN.gbk zh_CN.GB18030 zh_CN.gb18030 zh_CN.GB2312 zh_CN.gb2312; do
+    cm="$(LC_ALL="$cand" locale charmap 2>/dev/null | tr 'a-z' 'A-Z' | tr -d '-')"
+    case "$cm" in GBK|GB18030|GB2312) printf '%s' "$cand"; return 0 ;; esac
+  done
+  return 1
+}
+GBK_LOCALE="$(detect_gbk_locale || true)"
 if [ -z "$GBK_LOCALE" ]; then
-  echo "  SKIP: 系统未安装 zh_CN.GBK 类 locale（Part 1 已覆盖 python 那层；Part 2 需真实 GBK 区域）"
+  echo "  SKIP: 系统无可用 zh_CN.GBK 类 locale（Part 1 已覆盖 python 那层；Part 2 需真实 GBK 区域）"
 else
   echo "  using locale: $GBK_LOCALE"
   GBK() { LANG="$GBK_LOCALE" LC_ALL="$GBK_LOCALE" env "$@"; }

--- a/scripts/test-hook-encoding-portable.sh
+++ b/scripts/test-hook-encoding-portable.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# test-hook-encoding-portable.sh — 部署型 hook 在 Windows 中文系统下的编码健壮性回归。
+#
+# Windows 中文环境有两层独立的编码坑（都让 hook 静默失效，见 issue #164）：
+#   1) python stdout 默认 cp936（与区域设置无关）：print(中文) 编成 GBK，和脚本 UTF-8
+#      字面量字节不符 → 比较恒假。修法：sys.stdout.buffer.write(...encode("utf-8"))。
+#   2) 用户导出 GBK 区域设置（LANG=zh_CN.GBK）时，gawk/GNU sed/GNU grep/bash 通配
+#      按 GBK 多字节解码 UTF-8 内容/路径会乱。修法：hook 内 export LC_ALL=C 走字节匹配。
+#
+# 本测试两段都跑：
+#   Part 1：用 PYTHONIOENCODING=gbk 强制 python stdout 走 cp936，复现坑 1（任何平台可跑）。
+#   Part 2：在真实 GBK 区域下跑全部 hook，复现坑 2（需系统装有 zh_CN.GBK 类 locale；
+#           macOS 自带，CI ubuntu 由 workflow localedef 生成，Windows Git Bash 若无则跳过）。
+#
+# 用法：bash scripts/test-hook-encoding-portable.sh
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+if [ -z "$REPO_ROOT" ]; then
+  echo "Error: not in a git repository"
+  exit 1
+fi
+HOOKS_DIR="$REPO_ROOT/skills/story-setup/references/templates/hooks"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# 探测可用解释器（Windows 上 python3 可能是 Store 占位程序 exit 49）
+for PYBIN in python3 python py; do "$PYBIN" -c "" 2>/dev/null && break; done
+
+fail=0
+pass() { echo "  PASS $1"; }
+bad()  { echo "  FAIL $1"; fail=1; }
+
+deploy() { # $1 = project root
+  mkdir -p "$1/.claude"
+  cp -R "$HOOKS_DIR" "$1/.claude/hooks"
+  chmod +x "$1/.claude/hooks"/*.sh "$1/.claude/hooks/lib"/*.sh 2>/dev/null || true
+}
+
+echo "Hook encoding portability test (issue #164)"
+echo "==========================================="
+echo "interpreter: $PYBIN"
+
+# ===== Part 1：python stdout cp936（PYTHONIOENCODING=gbk）=====
+echo "--- Part 1: python stdout cp936 simulation (PYTHONIOENCODING=gbk) ---"
+P1="$WORK/p1"; deploy "$P1"
+mkdir -p "$P1/book/正文" "$P1/book/大纲" "$P1/short"
+run_guard_py() { # $1 mode(default|gbk)  $2 file_path -> exit code
+  local mode="$1" fp="$2" ec=0
+  local -a pyenv=()
+  [ "$mode" = "gbk" ] && pyenv=(env PYTHONIOENCODING=gbk)
+  printf '{"tool_name":"Write","tool_input":{"file_path":"%s","content":"x"}}' "$fp" \
+    | CLAUDE_PROJECT_DIR="$P1" ${pyenv[@]+"${pyenv[@]}"} bash "$P1/.claude/hooks/guard-outline-before-prose.sh" \
+      >/dev/null 2>&1 || ec=$?
+  printf '%s' "$ec"
+}
+for MODE in default gbk; do
+  rm -f "$P1/book/大纲/细纲_第1章.md"
+  [ "$(run_guard_py "$MODE" 'book/正文/第1章_开端.md')" = 2 ] && pass "[$MODE] long blocked, 细纲 missing" || bad "[$MODE] long should block when 细纲 missing"
+  : > "$P1/book/大纲/细纲_第1章.md"
+  [ "$(run_guard_py "$MODE" 'book/正文/第1章_开端.md')" = 0 ] && pass "[$MODE] long allowed, 细纲 present" || bad "[$MODE] long should allow when 细纲 present"
+  : > "$P1/short/设定.md"; rm -f "$P1/short/小节大纲.md"
+  [ "$(run_guard_py "$MODE" 'short/正文.md')" = 2 ] && pass "[$MODE] short blocked, 小节大纲 missing" || bad "[$MODE] short should block when 小节大纲 missing"
+  : > "$P1/short/小节大纲.md"
+  [ "$(run_guard_py "$MODE" 'short/正文.md')" = 0 ] && pass "[$MODE] short allowed, 小节大纲 present" || bad "[$MODE] short should allow when 小节大纲 present"
+done
+
+# ===== Part 2：真实 GBK 区域下跑全部 hook =====
+echo "--- Part 2: real GBK locale (LANG/LC_ALL=zh_CN.GBK) end-to-end ---"
+GBK_LOCALE="$(locale -a 2>/dev/null | grep -iE '^zh_CN\.(gbk|gb18030|gb2312)$' | head -1 || true)"
+if [ -z "$GBK_LOCALE" ]; then
+  echo "  SKIP: 系统未安装 zh_CN.GBK 类 locale（Part 1 已覆盖 python 那层；Part 2 需真实 GBK 区域）"
+else
+  echo "  using locale: $GBK_LOCALE"
+  GBK() { LANG="$GBK_LOCALE" LC_ALL="$GBK_LOCALE" env "$@"; }
+  P2="$WORK/p2"; deploy "$P2"
+  git -C "$P2" init -q; git -C "$P2" config user.email t@t.t; git -C "$P2" config user.name t
+  # 中文书名作为中间目录——正是 GBK 下 bash 通配会 NOMATCH 的场景
+  BOOK="$P2/让你管账号"; mkdir -p "$BOOK/正文" "$BOOK/大纲" "$BOOK/追踪" "$BOOK/设定"
+  printf '让你管账号\n' > "$P2/.active-book"
+
+  # 2a guard-outline：中文书名中间目录 + 中文通配 glob
+  rg() { local ec=0; printf '{"tool_name":"Write","tool_input":{"file_path":"%s","content":"x"}}' "$1" \
+    | GBK CLAUDE_PROJECT_DIR="$P2" bash "$P2/.claude/hooks/guard-outline-before-prose.sh" >/dev/null 2>&1 || ec=$?; printf '%s' "$ec"; }
+  [ "$(rg '让你管账号/正文/第1章_开端.md')" = 2 ] && pass "[GBK] guard blocks missing 细纲" || bad "[GBK] guard should block missing 细纲"
+  : > "$BOOK/大纲/细纲_第1章.md"
+  [ "$(rg '让你管账号/正文/第1章_开端.md')" = 0 ] && pass "[GBK] guard allows present 细纲 (Chinese glob)" || bad "[GBK] guard should allow present 细纲 under GBK"
+  [ "$(rg '让你管账号/正文/第001章_开端.md')" = 0 ] && pass "[GBK] guard tolerates zero-pad 第001章" || bad "[GBK] guard should tolerate 第001章 under GBK"
+
+  # 2b detect-story-gaps：正常伏笔表不误报；同时证明中文书目能被发现
+  cat > "$BOOK/追踪/伏笔.md" <<'EOF'
+| ID | 伏笔内容 | 埋设章节 | 预计回收章节 | 状态{未埋/已埋/已回收/已过期} | 重要度{高/中/低} |
+|----|---------|---------|-------------|-----------------------------|----------------|
+| F001 | 玉佩身世 | 第1章 | 第20章 | 已埋 | 高 |
+| F002 | 师门往事 | 第3章 | 第25章 | 已回收 | 中 |
+EOF
+  out="$(cd "$P2" && GBK CLAUDE_PROJECT_DIR="$P2" bash .claude/hooks/detect-story-gaps.sh 2>&1 || true)"
+  echo "$out" | grep -q '伏笔' && bad "[GBK] detect-story-gaps spuriously warns on normal 伏笔" || pass "[GBK] detect-story-gaps silent on normal 伏笔"
+  # 制造真实缺口（正文>10 设定<3），证明中文书目确实被遍历到（否则上面的"静默"是假阳性）
+  i=1; while [ "$i" -le 11 ]; do : > "$BOOK/正文/第${i}章.md"; i=$((i+1)); done
+  out2="$(cd "$P2" && GBK CLAUDE_PROJECT_DIR="$P2" bash .claude/hooks/detect-story-gaps.sh 2>&1 || true)"
+  echo "$out2" | grep -q '让你管账号' && pass "[GBK] detect-story-gaps discovers Chinese book + warns on real gap" || bad "[GBK] detect-story-gaps failed to discover Chinese book under GBK"
+  rm -f "$BOOK"/正文/第*章.md
+
+  # 2c validate-story-commit：命中全角冒号硬编码属性（C/GBK 区域下方括号字符组会漏，交替修好）
+  printf '年龄 ：18\n' > "$BOOK/正文/第1章_开端.md"
+  git -C "$P2" add -A >/dev/null 2>&1
+  cout="$(cd "$P2" && GBK CLAUDE_PROJECT_DIR="$P2" STORY_COMMIT_COMMAND='git commit -m x' bash .claude/hooks/validate-story-commit.sh 2>&1 || true)"
+  echo "$cout" | grep -q 'Hardcoded character attributes' && pass "[GBK] validate-commit catches fullwidth-colon attr" || bad "[GBK] validate-commit missed fullwidth-colon attr under GBK"
+fi
+
+echo ""
+if [ "$fail" -eq 0 ]; then
+  echo "PASS: hook 在 cp936 与真实 GBK 区域下都正确"
+else
+  echo "FAIL: hook 在某个编码/区域模式下行为不符（中文编码回归）"
+fi
+exit "$fail"

--- a/skills/story-setup/references/templates/hooks/detect-story-gaps.sh
+++ b/skills/story-setup/references/templates/hooks/detect-story-gaps.sh
@@ -53,7 +53,9 @@ for BOOK_DIR in "${BOOK_DIRS[@]}"; do
     # 避免长篇项目每次 SessionStart 都触发全量伏笔审计。
     # 行为回归脚本：scripts/check-hook-regex-sync.sh（区域设置健壮性由 export LC_ALL=C 保证）
     ABNORMAL_FORESHADOW=$(awk -F'|' '
-      function trim(s) { gsub(/^[[:space:]]+|[[:space:]]+$/, "", s); return s }
+      # 含全角空格 U+3000：LC_ALL=C 下 [[:space:]] 只认 ASCII 空白，单元格用全角空格补白时
+      # 会留在 status 里被误判为异常；用交替补上全角空格（不能进字符组，否则触发跨区域 bug）。
+      function trim(s) { gsub(/^([[:space:]]|　)+|([[:space:]]|　)+$/, "", s); return s }
       /^\|/ && $0 !~ /^\|[-[:space:]|]+$/ {
         status=trim($6)
         if (status == "" || status == "状态" || status ~ /^状态\{/) next

--- a/skills/story-setup/references/templates/hooks/detect-story-gaps.sh
+++ b/skills/story-setup/references/templates/hooks/detect-story-gaps.sh
@@ -6,6 +6,12 @@ set -euo pipefail
 # 加载公共函数库（project_root + discover_all_books）
 source "$(dirname "$0")/lib/common.sh"
 
+# 后续 awk 解析中文伏笔表 + find/grep 中文路径。Windows 中文系统若导出 GBK 区域设置，
+# gawk 会把 UTF-8 状态值按 GBK 多字节解码失败，trim 和 == 比较全乱、每行误报。强制 C
+# 区域走字节匹配（UTF-8 字面量 vs UTF-8 内容字节相等）才稳定（issue #164 同类）。本 hook
+# 无内嵌 python，可直接在顶部 export。
+export LC_ALL=C
+
 ROOT=$(project_root)
 OUTPUT=""
 HAS_WARNINGS=false
@@ -45,7 +51,7 @@ for BOOK_DIR in "${BOOK_DIRS[@]}"; do
   if [ -f "$BOOK_DIR/追踪/伏笔.md" ]; then
     # 仅检查表格数据行中的状态列。正常开放状态（未埋/已埋）不报警，
     # 避免长篇项目每次 SessionStart 都触发全量伏笔审计。
-    # 行为回归脚本：scripts/check-hook-regex-sync.sh
+    # 行为回归脚本：scripts/check-hook-regex-sync.sh（区域设置健壮性由 export LC_ALL=C 保证）
     ABNORMAL_FORESHADOW=$(awk -F'|' '
       function trim(s) { gsub(/^[[:space:]]+|[[:space:]]+$/, "", s); return s }
       /^\|/ && $0 !~ /^\|[-[:space:]|]+$/ {

--- a/skills/story-setup/references/templates/hooks/guard-outline-before-prose.sh
+++ b/skills/story-setup/references/templates/hooks/guard-outline-before-prose.sh
@@ -11,6 +11,15 @@ set -euo pipefail
 
 source "$(dirname "$0")/lib/common.sh"
 
+# 全程走字节稳定区域：本 hook 在中文路径上做 bash 通配（中间目录是中文书名时
+# 细纲_第*章*.md 在 GBK 区域会 NOMATCH）、sed 提章号、case 匹配，还内嵌 python 抽取
+# 中文路径。Windows 中文系统若导出 GBK/GB2312 区域设置，这些都会按多字节错误解码 UTF-8
+# 而失效。强制 C 区域走字节匹配（UTF-8 字面量 vs UTF-8 字节相等）才稳定（issue #164）。
+# 必须在内嵌 python 之前 export：LC_ALL=C 下 python 在 Windows 走 Unicode 环境 API、在
+# 新版 python 会把 C 强转 UTF-8，都能正确解码中文输入；反而是用户的 GBK 区域会把 python
+# 读到的 UTF-8 环境变量解成乱码。输出已用 sys.stdout.buffer 直写 UTF-8 字节、与区域无关。
+export LC_ALL=C
+
 HOOK_INPUT="${CLAUDE_TOOL_INPUT:-}"
 if [ -z "$HOOK_INPUT" ] && [ ! -t 0 ]; then
   HOOK_INPUT="$(cat)"
@@ -20,6 +29,9 @@ export HOOK_INPUT
 # 从 tool 输入 JSON 提取目标文件路径。探测真正可用的解释器：Windows 上
 # `command -v python3` 会命中 Microsoft Store 占位程序（exit 49），所以实跑
 # 一次 -c "" 而非只查 PATH。
+# 输出走 sys.stdout.buffer 直写 UTF-8 字节：Windows 中文系统 python stdout 默认
+# cp936，文本模式输出会把中文路径编成 GBK，和脚本里的 UTF-8 字面量（"正文"、第N章）
+# 字节不一致，导致每个比较恒假、守卫静默放行（issue #164）。
 extract_target_path() {
   local PYBIN=""
   for c in python3 python py; do
@@ -52,7 +64,7 @@ def dig(value):
 p = dig(obj)
 if not p:
     sys.exit(1)
-print(p)
+sys.stdout.buffer.write(p.encode("utf-8"))
 PY
 }
 

--- a/skills/story-setup/references/templates/hooks/lib/common.sh
+++ b/skills/story-setup/references/templates/hooks/lib/common.sh
@@ -35,7 +35,13 @@ discover_active_book() {
 
   if [ -f "$root/.active-book" ]; then
     local active
-    active=$(sed -n '1p' "$root/.active-book" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' || true)
+    # LC_ALL=C：书名是中文 UTF-8。Windows 中文系统若导出 GBK 区域设置，trim 的
+    # s/^[[:space:]]*// 会逼 sed 按 GBK 解码整行，短书名（如「让你管账号」「修仙传」）的
+    # UTF-8 字节是非法 GBK 序列 → BSD sed 报 illegal byte sequence、active 被吞成空 →
+    # .active-book 被忽略、误解析到 find 到的第一本书。强制 C 区域走字节处理才稳。
+    # 本库被无 export 的 session-*/pre-compact/post-compact 复用，故在此 per-command 兜底，
+    # 不在库里 export（避免给调用方留全局副作用，与文件头「不覆盖调用方 shell 选项」一致）。
+    active=$(LC_ALL=C sed -n '1p' "$root/.active-book" | LC_ALL=C sed 's/^[[:space:]]*//;s/[[:space:]]*$//' || true)
     if [ -n "$active" ]; then
       resolve_project_path "$active"
       return

--- a/skills/story-setup/references/templates/hooks/post-compact.sh
+++ b/skills/story-setup/references/templates/hooks/post-compact.sh
@@ -5,6 +5,9 @@ set -euo pipefail
 # 加载公共函数库
 source "$(dirname "$0")/lib/common.sh"
 
+# 字节稳定区域：经 discover_active_book 处理中文书名/路径，GBK 区域下才不会乱（issue #164 同类）。
+export LC_ALL=C
+
 ROOT=$(project_root)
 BOOK_DIR=$(discover_active_book)
 

--- a/skills/story-setup/references/templates/hooks/pre-compact.sh
+++ b/skills/story-setup/references/templates/hooks/pre-compact.sh
@@ -5,6 +5,9 @@ set -euo pipefail
 # 加载公共函数库
 source "$(dirname "$0")/lib/common.sh"
 
+# 字节稳定区域：经 discover_active_book 处理中文书名/路径，GBK 区域下才不会乱（issue #164 同类）。
+export LC_ALL=C
+
 ROOT=$(project_root)
 
 echo "=== Pre-Compact Summary ==="

--- a/skills/story-setup/references/templates/hooks/session-end.sh
+++ b/skills/story-setup/references/templates/hooks/session-end.sh
@@ -6,6 +6,9 @@ set -euo pipefail
 # 加载公共函数库
 source "$(dirname "$0")/lib/common.sh"
 
+# 字节稳定区域：经 discover_active_book 处理中文书名/路径，GBK 区域下才不会乱（issue #164 同类）。
+export LC_ALL=C
+
 # 默认禁用 session-log.txt 写入（避免每次会话结束都污染工作树）。
 # 显式 STORY_SESSION_LOG=1 才启用；即使启用，也只写入已存在的长篇追踪目录。
 if [ "${STORY_SESSION_LOG:-0}" != "1" ]; then

--- a/skills/story-setup/references/templates/hooks/session-start.sh
+++ b/skills/story-setup/references/templates/hooks/session-start.sh
@@ -17,6 +17,11 @@ fi
 source "$HOOK_DIR/lib/common.sh"
 source "$HOOK_DIR/lib/sentinel.sh"
 
+# 字节稳定区域：本 hook 经 discover_active_book 处理中文书名/路径。Windows 中文系统若导出
+# GBK 区域设置，locale 敏感操作会按多字节错解 UTF-8。强制 C 区域走字节处理才稳（issue #164
+# 同类）。本 hook 无内嵌 python，可直接 export。
+export LC_ALL=C
+
 ROOT=$(project_root)
 
 # story-setup 部署后的一次性重启确认。custom agents 只在会话启动时被注册成

--- a/skills/story-setup/references/templates/hooks/validate-story-commit.sh
+++ b/skills/story-setup/references/templates/hooks/validate-story-commit.sh
@@ -183,12 +183,12 @@ while IFS= read -r -d '' file; do
   fi
 
   # 检查正文文件是否包含硬编码的情节值
-  # 冒号用交替 (：|:) 而不是把全角冒号塞进方括号字符组：含全角字符的字符组在 C 区域会被
-  # 拆成单字节、漏掉全角冒号；交替 + 上面的 export LC_ALL=C 任何区域设置下都能同时命中
-  # 全角「：」和半角「:」。
+  # 冒号/空白都用交替而不是把全角字符塞进方括号字符组：含全角字符的字符组在 C 区域会被
+  # 拆成单字节、漏匹配；(：|:) 同时命中全角「：」和半角「:」，([[:space:]]|　) 在 LC_ALL=C 下
+  # 也认全角空格 U+3000（否则全角空格分隔的写法会漏检/误判）。
   case "$file" in
     正文.md|*/正文.md|正文/*|*/正文/*)
-      HARDCODED=$(grep -nE "(身高|体重|年龄)[[:space:]]*(：|:)[[:space:]]*[0-9]+" "$FULL_PATH" 2>/dev/null || true)
+      HARDCODED=$(grep -nE "(身高|体重|年龄)([[:space:]]|　)*(：|:)([[:space:]]|　)*[0-9]+" "$FULL_PATH" 2>/dev/null || true)
       if [ -n "$HARDCODED" ]; then
         WARNINGS="$WARNINGS\n⚠ $file: Hardcoded character attributes found (should reference 设定/ files):\n$HARDCODED"
       fi
@@ -198,7 +198,7 @@ while IFS= read -r -d '' file; do
   # 检查设定文件的必填字段（结构化匹配：key:value 格式）
   case "$file" in
     设定/*|*/设定/*)
-      if ! grep -qE "^[[:space:]]*(名字|姓名|名称|name|Name)[[:space:]]*(：|:)" "$FULL_PATH" 2>/dev/null; then
+      if ! grep -qE "^([[:space:]]|　)*(名字|姓名|名称|name|Name)([[:space:]]|　)*(：|:)" "$FULL_PATH" 2>/dev/null; then
         WARNINGS="$WARNINGS\n⚠ $file: Setting file missing required fields (name/名字: ...)"
       fi
       ;;

--- a/skills/story-setup/references/templates/hooks/validate-story-commit.sh
+++ b/skills/story-setup/references/templates/hooks/validate-story-commit.sh
@@ -160,6 +160,11 @@ if ! is_git_commit_command; then
   exit 0
 fi
 
+# 后续 case + grep 在中文路径/正文内容上做匹配。Windows 中文系统若导出 GBK 区域设置，
+# grep 按 GBK 多字节解码 UTF-8 内容会乱。强制 C 区域走字节匹配才稳定（issue #164 同类）。
+# 放在 is_git_commit_command（内嵌 python）之后，避免影响其输入解码。
+export LC_ALL=C
+
 ROOT=$(project_root)
 GIT_ROOT=$(git -C "$ROOT" rev-parse --show-toplevel 2>/dev/null || printf '%s\n' "$ROOT")
 WARNINGS=""
@@ -178,9 +183,12 @@ while IFS= read -r -d '' file; do
   fi
 
   # 检查正文文件是否包含硬编码的情节值
+  # 冒号用交替 (：|:) 而不是把全角冒号塞进方括号字符组：含全角字符的字符组在 C 区域会被
+  # 拆成单字节、漏掉全角冒号；交替 + 上面的 export LC_ALL=C 任何区域设置下都能同时命中
+  # 全角「：」和半角「:」。
   case "$file" in
     正文.md|*/正文.md|正文/*|*/正文/*)
-      HARDCODED=$(grep -nE "(身高|体重|年龄)[[:space:]]*[：:][[:space:]]*[0-9]+" "$FULL_PATH" 2>/dev/null || true)
+      HARDCODED=$(grep -nE "(身高|体重|年龄)[[:space:]]*(：|:)[[:space:]]*[0-9]+" "$FULL_PATH" 2>/dev/null || true)
       if [ -n "$HARDCODED" ]; then
         WARNINGS="$WARNINGS\n⚠ $file: Hardcoded character attributes found (should reference 设定/ files):\n$HARDCODED"
       fi
@@ -190,7 +198,7 @@ while IFS= read -r -d '' file; do
   # 检查设定文件的必填字段（结构化匹配：key:value 格式）
   case "$file" in
     设定/*|*/设定/*)
-      if ! grep -qE "^[[:space:]]*(名字|姓名|名称|name|Name)[[:space:]]*[：:]" "$FULL_PATH" 2>/dev/null; then
+      if ! grep -qE "^[[:space:]]*(名字|姓名|名称|name|Name)[[:space:]]*(：|:)" "$FULL_PATH" 2>/dev/null; then
         WARNINGS="$WARNINGS\n⚠ $file: Setting file missing required fields (name/名字: ...)"
       fi
       ;;


### PR DESCRIPTION
Fixes #164.

## 根因（issue #164）
`guard-outline-before-prose.sh` 的内嵌 python 用 `print(中文路径)` 把提取到的路径交给 shell。Windows 中文系统 python stdout 默认 cp936，`print()` 把中文编成 GBK 字节，和脚本里的 UTF-8 字面量（`正文`、`第N章`）字节不符 → 每个比较恒假 → BLOCKING 守卫静默 `exit 0` 放行，**保护从未生效**。
修法：`sys.stdout.buffer.write(p.encode("utf-8"))` 直写 UTF-8 字节，绕过 stdout 文本编码层（无 python 版本依赖）。

## 举一反三：同一「locale 依赖的文本层错解 UTF-8」类
在用户导出 GBK/GB2312 区域设置时（中文 Windows 常见），同类坑还命中：
| 位置 | 症状 | 修法 |
|---|---|---|
| `detect-story-gaps.sh` gawk 解析中文伏笔表 | trim / `==` 全乱 → 每次 SessionStart 每行误报 | `export LC_ALL=C` |
| `guard-outline` bash 通配（中文书名作中间目录时 `细纲_第*章*.md` NOMATCH）+ sed 提章号 | 找不到细纲 → 误拦正常写作 | `export LC_ALL=C`（置于 python 之前）|
| `validate-story-commit.sh` grep 含全角字符的方括号字符组 `[：:]` | C/GBK 区域漏掉全角冒号（连默认 C 都中招）| 改交替 `(：|:)` + `export LC_ALL=C` |

用 gawk + GNU sed/grep + `zh_CN.GBK` 真实复现每个 bug 并验证修复（C 区域走字节匹配：UTF-8 字面量 vs UTF-8 内容字节相等）。

## 加强 CI（这类问题本应更早发现）
- **`scripts/test-hook-encoding-portable.sh`**：Part 1 用 `PYTHONIOENCODING=gbk` 复现 python cp936；Part 2 探测可用的 GBK 类 locale（`locale charmap`，覆盖 Cygwin 按需合成）后，在**真实 GBK 区域**下端到端跑全部 hook。
- **`scripts/check-hook-locale-safety.sh`**：静态守卫——locale 敏感 hook 必须 `export LC_ALL=C`，且禁止正则里出现含全角字符的方括号字符组。
- **`check-python-invocation.sh`**：新增守卫禁止 hook 内嵌 python 用 `print(` / `sys.stdout.write(`（必须 `buffer.write`）。
- **`cross-platform.yml`**：三平台接入新测试；ubuntu 用 `localedef` 生成 `zh_CN.GBK`。

## 真实环境验证（本 PR 的 CI run，全绿）
全部三平台都在**真实 GBK 区域**下端到端跑过：
- **windows-latest（真实 Windows + Git Bash + Cygwin 合成 zh_CN.GBK）**：Part 1 cp936 8/8 PASS；Part 2 GBK 6/6 PASS。
- **ubuntu（localedef 生成 GBK）/ macos（自带 GBK）**：同样全 PASS。
回归意义：旧 `print(p)` 代码在真实 Windows 下 Part 1 会失败（cp936/cp1252 无法把中文回成 UTF-8），本测试可捕获。

🤖 Generated with [Claude Code](https://claude.com/claude-code)