### PR TITLE
docs(readme): 精简 OpenCode 注意事项

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,8 +163,11 @@ PR 中如果修改了 Claude Code 模板文件，CI 会自动检测 opencode 模
 
 **session-start 系统提示注入不支持**：OpenCode 公开 Plugin API 中无 `chat.message` 或等效 hook，部署状态检测和写作进度无法在会话开始时注入模型上下文。用户可手动运行 `/story-setup` 查看状态。
 
+**其它 hook 差异**：`detect-gaps`（缺口检测）插件未移植，会话开始不注入提示（仅保留 compact 摘要与写正文前的大纲守卫）；`session-end` opencode 无等价事件、暂不支持；`validate-commit` 改用 git 原生 `pre-commit` hook（适用于所有 CLI）。
+
 ### OpenCode 使用注意事项
 
 - **首次部署后需要重启 opencode**：story-setup 部署的 `.opencode/commands/` 下的 slash command 在 opencode 重启后才会生效。退出 opencode 后执行 `opencode -c` 重新进入即可。
 - **首次部署使用自然语言触发**：新项目中没有 slash command，需要用自然语言触发 story-setup（如「请使用 story-setup skill，帮我部署网文写作环境」）。
 - **opencode 配置不热加载**：修改 `opencode.json`、agent 文件或 plugin 后均需重启 opencode。
+- **browser-cdp 长耗时操作可能卡死**：opencode 无后台任务机制，长耗时浏览器操作需用户按 `ESC` 打断（SKILL.md 已内置超时包装指引）。

--- a/README.md
+++ b/README.md
@@ -89,16 +89,7 @@ npx skills add worldwonderer/oh-story-claudecode -y -g
 
 `-g` 全局安装，所有目录可用；去掉 `-g` 则只装到当前目录。更新时重新执行同一条命令即可。
 
-> **OpenCode 用户：** 全局安装后，opencode 会自动从 `~/.claude/skills/` 发现 skills。首次使用时，用自然语言触发 story-setup（如「请使用 story-setup skill，帮我部署网文写作环境」），它会自动检测 OpenCode 环境并部署对应的 agents、commands 和插件。
->
-> **首次部署后必须重启 opencode**（退出后执行 `opencode -c`），`.opencode/commands/` 下的 slash command 才会生效。之后 `/story-setup`、`/story-long-write` 等命令即可直接使用。
->
-> **OpenCode 已知差异：** opencode 与 Claude Code 的机制差异导致部分功能实现方式不同：
-> - `session-start` / `detect-gaps`：opencode 插件暂未移植这两个 hook，会话开始与缺口检测不会注入提示（仅保留 compact 摘要与写正文前的大纲守卫）
-> - `session-end`：opencode 无等价事件，暂不支持
-> - `validate-commit`：改用 git 原生 `pre-commit` hook，适用于所有 CLI
-> - `browser-cdp`：无后台任务机制，长耗时操作可能卡死，需用户按 `ESC` 打断（SKILL.md 已内置超时包装指引）
-> - `compact` 相关 hook：依赖 `experimental` API，可能在 opencode 未来版本变动
+> **OpenCode 用户：** 全局安装后 opencode 自动从 `~/.claude/skills/` 发现 skills；首次用自然语言触发 story-setup（如「用 story-setup 部署网文写作环境」），**部署后退出重进 `opencode -c`** 才能用 slash command。部分 hook 行为与 Claude Code 有差异（session-start / session-end / compact 等），详见 [CONTRIBUTING.md](CONTRIBUTING.md) 的 OpenCode 章节。
 >
 > 升级后如果项目里已经跑过 `/story-setup`，建议在项目根重跑一次 `/story-setup`，同步 hooks / agents / references。每版变更见 [CHANGELOG.md](CHANGELOG.md) 与 [Releases](https://github.com/worldwonderer/oh-story-claudecode/releases)。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -93,16 +93,7 @@ npx skills add worldwonderer/oh-story-claudecode -y -g
 
 > After updating, if a project has already run `/story-setup`, re-run `/story-setup` from the project root to sync hooks / agents / references. Per-version changes are in [CHANGELOG.md](CHANGELOG.md) and [Releases](https://github.com/worldwonderer/oh-story-claudecode/releases).
 >
-> **OpenCode users:** After global installation, opencode automatically discovers skills from `~/.claude/skills/`. On first use, trigger story-setup with natural language (e.g., "Please use story-setup skill to deploy the web novel writing environment"). It auto-detects the OpenCode environment and deploys corresponding agents, commands, and plugin.
->
-> **You must restart opencode after first deployment** (exit and run `opencode -c`) for `.opencode/commands/` slash commands to take effect.
->
-> **OpenCode known differences:** Due to mechanism differences between opencode and Claude Code:
-> - `session-start` / `detect-gaps`: not yet ported for opencode — no injection at session start or gap detection (only the compact summary and the outline-before-prose guard are active)
-> - `session-end`: No equivalent event in opencode, unsupported
-> - `validate-commit`: Uses git native `pre-commit` hook instead, works for all CLIs
-> - `browser-cdp`: No background task mechanism — long operations may hang, requiring user to press `ESC` (SKILL.md includes timeout wrapping guidance)
-> - `compact` hooks: Depend on `experimental` API, may change in future opencode versions
+> **OpenCode users:** After global install, opencode auto-discovers skills from `~/.claude/skills/`; trigger story-setup with natural language on first use (e.g., "use story-setup to deploy the web novel environment"), then **exit and re-enter with `opencode -c`** for slash commands to work. Some hook behaviors differ from Claude Code (session-start / session-end / compact, etc.) — see the OpenCode section in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 > **Multi-agent collaboration needs setup + a fresh session**: the 7 specialist agents (story-architect, narrative-writer, consistency-checker, etc.) are written into your project's `.claude/agents/` by `/story-setup`. Claude Code only registers custom agents **at session start**, so **after `/story-setup` finishes you must open a new Claude Code session** before story-review's multi-perspective review and the agent collaboration in the writing flow take effect; otherwise skills get "subagent_type unavailable" and fall back to solo (single perspective). To check: run `/story-review` in the new session — a header of `Effective Mode: full/lean` means agents registered, `Fallback: ... -> solo` means you're still in the old session.
 


### PR DESCRIPTION
自从 #151 加 OpenCode 支持后，README 里「OpenCode 已知差异」那段（5 条 bullet：session-start / session-end / validate-commit / browser-cdp / compact）有点臃肿，且与 `CONTRIBUTING.md` 的「OpenCode 关键兼容性问题 / 使用注意事项」重复、偏实现细节。

> ⚠️ **请勿直接合并，待 review。**

## 改动
- `README.md` / `README_EN.md`：把 OpenCode 段压成一行——保留入门必需的（自动发现 + 部署后重启 `opencode -c` + 首次自然语言触发），把「已知差异」细节一句话指向 `CONTRIBUTING.md`。
- 各 **−10 / +1** 行；不动安装方式、升级提示、Skills 表、顶部「适配 Claude Code、OpenCode、OpenClaw」。
- 细节没丢：CONTRIBUTING.md 已有更完整的 OpenCode 兼容性说明。

gate：static-check 13/13、whitespace 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
