### PR TITLE
fix(hooks): 大纲守卫识别 Windows 盘符绝对路径（#184）

### DIFF
--- a/scripts/test-hook-encoding-portable.sh
+++ b/scripts/test-hook-encoding-portable.sh
@@ -66,6 +66,34 @@ for MODE in default gbk; do
   [ "$(run_guard_py "$MODE" 'short/正文.md')" = 0 ] && pass "[$MODE] short allowed, 小节大纲 present" || bad "[$MODE] short should allow when 小节大纲 present"
 done
 
+# ===== Part 1b：Windows 盘符绝对路径分类（issue #184，任何平台可跑）=====
+# Windows + Git Bash 下 Claude Code 传入盘符绝对路径（F:/... 或 F:\...）。旧 case 只认 /*，
+# 把它当相对路径拼成 $ROOT/F:/...，找错 大纲/ 目录 → 误报细纲缺失。修复后盘符路径按绝对路径处理。
+# POSIX runner 无真实盘符：用反证法——fixture 只放在「旧代码会拼出来的」$ROOT/C:/<book> 下。
+#   修复后：guard 把 C:/<book> 当绝对路径（→ 文件系统根 /C:/<book>，不存在）→ 找不到 fixture → block(2)
+#   旧代码：拼成 $ROOT/C:/<book> 命中 fixture → allow(0)
+# 以 block(2) 证明盘符路径已按绝对路径处理。（真实 Windows 上同样的绝对处理会命中真盘符下的
+# 真细纲而放行，方向相反，此处只验「是否按绝对路径分类」这一修复点。）
+echo "--- Part 1b: Windows drive-letter absolute path classification (issue #184) ---"
+if mkdir -p "$P1/C:/book184/大纲" 2>/dev/null && : > "$P1/C:/book184/大纲/细纲_第2章.md" 2>/dev/null; then
+  run_guard_drive() { # $1 file_path(JSON-escaped) -> exit code
+    local ec=0
+    printf '{"tool_name":"Write","tool_input":{"file_path":"%s","content":"x"}}' "$1" \
+      | CLAUDE_PROJECT_DIR="$P1" bash "$P1/.claude/hooks/guard-outline-before-prose.sh" >/dev/null 2>&1 || ec=$?
+    printf '%s' "$ec"
+  }
+  [ "$(run_guard_drive 'C:/book184/正文/第2章_x.md')" = 2 ] \
+    && pass "[win] forward-slash drive path treated as absolute (not root-joined)" \
+    || bad  "[win] forward-slash drive path was root-joined — issue #184 regression"
+  # 反斜杠路径在真实 JSON 里是转义的（\\）；json.loads 解出单反斜杠交给 bash，case 分支再归一。
+  [ "$(run_guard_drive 'C:\\book184\\正文\\第2章_x.md')" = 2 ] \
+    && pass "[win] backslash drive path treated as absolute (separators normalized)" \
+    || bad  "[win] backslash drive path mishandled — issue #184 regression"
+  rm -rf "$P1/C:"
+else
+  echo "  SKIP: 文件系统不支持含 ':' 的目录名（无法构造盘符 fixture）"
+fi
+
 # ===== Part 2：真实 GBK 区域下跑全部 hook =====
 echo "--- Part 2: real GBK locale (LANG/LC_ALL=zh_CN.GBK) end-to-end ---"
 # 探测「可用」的 GBK 类 locale：不看 `locale -a` 列表（Cygwin/MSYS2 会按需合成而不列出），

--- a/scripts/test-hook-encoding-portable.sh
+++ b/scripts/test-hook-encoding-portable.sh
@@ -94,6 +94,35 @@ else
   echo "  SKIP: 文件系统不支持含 ':' 的目录名（无法构造盘符 fixture）"
 fi
 
+# ===== Part 1c：真实 Windows 盘符路径（cygpath，仅 Windows/MSYS 跑）=====
+# 1b 是 POSIX 反证；这里在真实 Windows/MSYS 上用 cygpath 把 $P1 映射成 C:/... 盘符路径，
+# 直接验用户可见行为：细纲在则放行、细纲缺则拦截——而不是反向的分类反证。POSIX 无 cygpath → SKIP。
+echo "--- Part 1c: real Windows drive-letter path via cygpath (issue #184) ---"
+if command -v cygpath >/dev/null 2>&1; then
+  WINROOT="$(cygpath -m "$P1" 2>/dev/null || true)"
+  case "$WINROOT" in
+    [A-Za-z]:/*)
+      mkdir -p "$P1/winbook/正文" "$P1/winbook/大纲"
+      run_guard_win() { local ec=0; printf '{"tool_name":"Write","tool_input":{"file_path":"%s","content":"x"}}' "$1" \
+        | CLAUDE_PROJECT_DIR="$P1" bash "$P1/.claude/hooks/guard-outline-before-prose.sh" >/dev/null 2>&1 || ec=$?; printf '%s' "$ec"; }
+      : > "$P1/winbook/大纲/细纲_第3章.md"
+      [ "$(run_guard_win "$WINROOT/winbook/正文/第3章_x.md")" = 0 ] \
+        && pass "[win] real drive path allowed when 细纲 present" \
+        || bad  "[win] real drive path should allow when 细纲 present"
+      rm -f "$P1/winbook/大纲/细纲_第3章.md"
+      [ "$(run_guard_win "$WINROOT/winbook/正文/第3章_x.md")" = 2 ] \
+        && pass "[win] real drive path blocked when 细纲 missing" \
+        || bad  "[win] real drive path should block when 细纲 missing"
+      rm -rf "$P1/winbook"
+      ;;
+    *)
+      echo "  SKIP: cygpath present but did not yield a drive-letter path ($WINROOT)"
+      ;;
+  esac
+else
+  echo "  SKIP: cygpath not available (not a Windows/MSYS runner)"
+fi
+
 # ===== Part 2：真实 GBK 区域下跑全部 hook =====
 echo "--- Part 2: real GBK locale (LANG/LC_ALL=zh_CN.GBK) end-to-end ---"
 # 探测「可用」的 GBK 类 locale：不看 `locale -a` 列表（Cygwin/MSYS2 会按需合成而不列出），

--- a/skills/story-setup/references/opencode/plugin.ts
+++ b/skills/story-setup/references/opencode/plugin.ts
@@ -155,7 +155,9 @@ function preCompactOutput(): string {
   return lines.join("\n")
 }
 
-// 相对路径按项目根解析（对齐 guard-outline-before-prose.sh 的 $ROOT/$TARGET）
+// 相对路径按项目根解析（对齐 guard-outline-before-prose.sh 的 $ROOT/$TARGET）。
+// Windows 盘符绝对路径（F:/... 或 F:\...）先把反斜杠归一，再交给平台感知的 path.isAbsolute
+// 判断（win32 上 F:/... 为绝对），与 bash hook 的 [A-Za-z]:[/\\]* 分支等价（issue #184）。
 function resolveTarget(root: string, target: string): string {
   const normalized = target.replace(/\\/g, "/")
   return path.isAbsolute(normalized) ? normalized : path.resolve(root, normalized)

--- a/skills/story-setup/references/templates/hooks/guard-outline-before-prose.sh
+++ b/skills/story-setup/references/templates/hooks/guard-outline-before-prose.sh
@@ -73,8 +73,13 @@ TARGET="$(extract_target_path 2>/dev/null || true)"
 [ -z "$TARGET" ] && exit 0
 
 ROOT=$(project_root)
+# 绝对路径直接采用，相对路径才拼项目根。
+# Windows + Git Bash 下 Claude Code 可能传入盘符绝对路径（F:/work/... 或 F:\work\...）；
+# 只认 /* 会把它们当相对路径拼成 $ROOT/F:/work/...，找错 大纲/ 目录、误报细纲缺失（issue #184）。
+# [A-Za-z]:[/\\]* 命中盘符绝对路径，并把反斜杠统一成正斜杠（对齐 plugin.ts 的 isAbsolute + 反斜杠归一）。
 case "$TARGET" in
   /*) ABS="$TARGET" ;;
+  [A-Za-z]:[/\\]*) ABS="${TARGET//\\//}" ;;
   *)  ABS="$ROOT/$TARGET" ;;
 esac
 


### PR DESCRIPTION
## 问题（#184）

Windows 10 + Git Bash 下，Claude Code 把正文 `file_path` 以盘符绝对路径传入 hook，例如：

```
F:/work/my-projects/web-novelist/novels/xxx/正文/第002章_xxx.md
```

`guard-outline-before-prose.sh` 的路径判定只把 `/*` 当绝对路径：

```sh
case "$TARGET" in
  /*) ABS="$TARGET" ;;
  *)  ABS="$ROOT/$TARGET" ;;   # 盘符路径落到这里
esac
```

于是 `F:/...` 被当相对路径拼成 `$ROOT/F:/work/...`，后续 `大纲/` 目录定位到错误位置，
即使 `大纲/细纲_第002章.md` 实际存在也被判为缺失，**误拦截写正文**。

## 修复

- **`guard-outline-before-prose.sh`**：`case` 增加 `[A-Za-z]:[/\\]*` 分支，命中盘符绝对路径
  （`F:/...` 与 `F:\...` 皆可），并把反斜杠统一成正斜杠后按绝对路径处理。
- **`opencode/plugin.ts`**（写正文守卫的同实现）：本就用平台感知的 `path.isAbsolute` + 反斜杠归一，
  在 win32 上已正确识别盘符路径；这里补注释标明与 bash 分支等价，避免双实现漂移。
- **`test-hook-encoding-portable.sh`**：新增 *Part 1b* 盘符路径分类回归。POSIX runner 没有真实盘符，
  用反证 fixture 确定性区分「按绝对路径处理」与「拼接项目根」两种行为。

## 验证

```
bash scripts/test-hook-encoding-portable.sh   # 含新增 Part 1b，全部 PASS
bash scripts/check-hook-locale-safety.sh       # OK
bash scripts/check-python-invocation.sh        # OK
bash scripts/static-check.sh                    # PASS
bash scripts/check-story-setup-deployment.sh    # OK（含 TS11 outline-before-prose guard）
```

已确认新测试在打补丁前失败、打补丁后通过（测试确实能捕捉该回归）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)