### PR TITLE
chore(codex): 守卫 .agents/skills symlink + 记 Windows core.symlinks 坑

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,7 +221,7 @@ OPENCLAW_REAL_CHECK=1 bash scripts/check-openclaw-skills.sh  # 本机安装 open
 
 本项目同时支持 Codex CLI（repo skills 发现 + `$story-setup` 项目部署）：
 
-- repo-local skills：`.agents/skills` 是指向 `skills/` 的 symlink，Codex 会扫描该目录；不要把 13 个 skill 复制成第二份。
+- repo-local skills：`.agents/skills` 是指向 `skills/` 的相对 symlink（`../skills`，agentskills.io 标准路径），Codex 扫描它发现 skill，别复制第二份。必须是有效相对 symlink（`check-codex-adapter.sh` 守卫 target=`../skills`；无效/绝对会让发现失效，见 openai/codex#11314）；Windows 需 git `core.symlinks=true`。OpenClaw 原生扫 workspace `skills/`，不依赖它。
 - project deployment hooks：`skills/story-setup/references/codex/hooks/hooks.json` 面向 `$story-setup` 部署到写作项目，`command`（POSIX sh）通过当前目录向上查找定位项目 `.codex/hooks/story_codex_hook.py`，不得要求项目必须是 Git 仓库；并把查到的根以 `CODEX_PROJECT_DIR=` 传给 Python（Codex 本身不注入该变量，root 解析以 Python 的 `__file__` 自定位为准）。
 - Windows hooks：Codex 在 Windows 下用 `%COMSPEC% /C`（cmd.exe）跑 hook 命令，**不是** POSIX shell，所以每个 hook 必须带 `commandWindows`（cmd.exe 语法）。当前 `commandWindows` 为 `if exist .codex\hooks\story_codex_hook.py python ... <event>`：cwd 为项目根时运行、否则干净 no-op（best-effort，上溯查找仅 POSIX `command` 具备）。Python hook 本体跨平台、已做 UTF-8 字节 stdio 与 `__file__` 自定位。改 `command` 时必须同步改 `commandWindows`（`check-codex-adapter.sh` 守卫 event 一致 + cmd.exe 安全）。
 - custom agents：`skills/story-setup/references/codex/agents/*.toml` 由 `scripts/generate-codex-agents.py` 从 `references/templates/agents/*.md` 生成。修改 Claude agent 模板后必须重新生成并提交。

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ npx skills add worldwonderer/oh-story-claudecode -y -g
 `-g` 全局安装，所有目录可用；去掉 `-g` 则只装到当前目录。更新时重新执行同一条命令即可。
 
 
-> **Codex 用户：** repo 内直接使用：Codex 会扫描 `$REPO_ROOT/.agents/skills`（本仓库是指向 `skills/` 的 symlink）并发现 13 个 skill；调用时优先用 `$story`、`$story-setup`、`$story-long-write`，或在 `/skills` 中选择。
+> **Codex 用户：** repo 内直接使用：Codex 会扫描 `$REPO_ROOT/.agents/skills`（指向 `skills/` 的 symlink）发现 13 个 skill；用 `$story`、`$story-setup` 或 `/skills` 调用。Windows 上 git 需开 `core.symlinks=true`，否则 symlink 失效，改走下方 `$story-setup` 部署。
 > 跑 `$story-setup` 部署到写作项目后，会写入 `.codex/agents/*.toml`、`.codex/hooks.json`、`.codex/hooks/story_codex_hook.py` 和 `.codex/skills/story-setup/references/agent-references/`；请信任项目 `.codex/` 配置层并在 `/hooks` review/trust hooks、新开 Codex 会话，让 custom agents 生效。
 >
 > **OpenCode 用户：** 全局安装后 opencode 自动从 `~/.claude/skills/` 发现 skills；首次用自然语言触发 story-setup（如「用 story-setup 部署网文写作环境」），**部署后退出重进 `opencode -c`** 才能用 slash command。部分 hook 行为与 Claude Code 有差异（session-start / session-end / compact 等），详见 [CONTRIBUTING.md](CONTRIBUTING.md) 的 OpenCode 章节。

--- a/README_EN.md
+++ b/README_EN.md
@@ -96,7 +96,7 @@ npx skills add worldwonderer/oh-story-claudecode -y -g
 > After updating, if a project has already run `/story-setup`, re-run `/story-setup` from the project root to sync hooks / agents / references. Per-version changes are in [CHANGELOG.md](CHANGELOG.md) and [Releases](https://github.com/worldwonderer/oh-story-claudecode/releases).
 >
 
-> **Codex users:** Use it in-place: Codex scans `$REPO_ROOT/.agents/skills` (a symlink to `skills/` here) and discovers all 13 skills. Prefer `$story`, `$story-setup`, `$story-long-write`, or select from `/skills`.
+> **Codex users:** Use it in-place: Codex scans `$REPO_ROOT/.agents/skills` (a symlink to `skills/`) and discovers all 13 skills; invoke via `$story`, `$story-setup`, or `/skills`. On Windows, enable git `core.symlinks=true` or the symlink breaks — then use the `$story-setup` deployment below.
 > After `$story-setup` deploys into a writing project, it creates `.codex/agents/*.toml`, `.codex/hooks.json`, `.codex/hooks/story_codex_hook.py`, and `.codex/skills/story-setup/references/agent-references/`. Trust the project `.codex/` layer, review/trust hooks in `/hooks`, and open a fresh Codex session so custom agents load.
 >
 > **OpenCode users:** After global install, opencode auto-discovers skills from `~/.claude/skills/`; trigger story-setup with natural language on first use (e.g., "use story-setup to deploy the web novel environment"), then **exit and re-enter with `opencode -c`** for slash commands to work. Some hook behaviors differ from Claude Code (session-start / session-end / compact, etc.) — see the OpenCode section in [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/scripts/check-codex-adapter.sh
+++ b/scripts/check-codex-adapter.sh
@@ -59,8 +59,12 @@ fi
 
 echo "  OK Windows encoding safety (UTF-8 stdio + file reads)"
 
-# Repo skill discovery: .agents/skills is a symlink to skills/, so Codex sees the
-# single canonical copy (no second materialized skill tree).
+# .agents/skills is a relative symlink to skills/ (the agentskills.io path Codex scans), so
+# there is no second skill copy. Must be a valid relative symlink: an invalid/absolute one
+# (openai/codex#11314) or a Windows no-symlinks text stub silently breaks discovery.
+[ -L ".agents/skills" ] || fail ".agents/skills must be a symlink (got a regular file/dir; on Windows enable git core.symlinks)"
+target="$(readlink .agents/skills)"
+[ "$target" = "../skills" ] || fail ".agents/skills symlink target must be relative '../skills', got '$target'"
 skill_count="$(find skills -maxdepth 2 -name SKILL.md | wc -l | tr -d ' ')"
 [ "$skill_count" = "13" ] || fail "expected 13 skills, found $skill_count"
 for skill in skills/*/SKILL.md; do


### PR DESCRIPTION
核实了 `.agents/skills` 发现机制：是 [agentskills.io](https://agentskills.io) 跨工具标准（Codex PR #10317、OpenClaw 等 30+ 工具采用），Codex 官方支持 symlink 且无 config 替代——symlink 是 Codex 唯一非复制机制，保留。

加固两处真实弱点：
- `check-codex-adapter.sh`：守卫 `.agents/skills` 是 symlink 且 target=`../skills`（无效/绝对 symlink 或 Windows 文本占位会让发现静默失效，见 openai/codex#11314）。
- README / CONTRIBUTING：补 Windows `core.symlinks=true` 兜底；注明 OpenClaw 原生扫 workspace `skills/`、不依赖它。

验证：守卫确认能挡「symlink→文件」与「错误 target」；`check-codex-adapter.sh` + `static-check.sh` 绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)