### PR TITLE
docs(scripts): 新增 scripts/README.md 索引 + 修正 CONTRIBUTING 脚本清单漂移

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,17 +19,7 @@ skills/
 ├── story-review/            # 多视角审查
 ├── story-cover/             # 封面生成
 └── browser-cdp/             # 浏览器操控
-scripts/
-├── static-check.sh                    # frontmatter + 引用路径 + 死文件 + 交叉引用
-├── check-hook-regex-sync.sh           # hook 伏笔状态检测行为
-├── check-shared-files.sh              # 跨 skill 同名副本一致性
-├── check-story-setup-deployment.sh    # story-setup 部署完整性
-├── check-opencode-adapter.sh          # OpenCode commands/agents/plugin/config 适配层检查
-├── test-opencode-cli-e2e.sh           # 本机 OpenCode CLI 真实加载 smoke（需已安装 opencode）
-├── check-openclaw-skills.sh           # OpenClaw AgentSkills/frontmatter 兼容性
-├── generate-codex-agents.py           # Claude agent 模板 → Codex TOML
-├── check-codex-adapter.sh             # Codex repo skills / custom-agent TOML / hooks 静态检查
-└── test-codex-hooks.sh                # Codex hooks 合成 stdin/stdout 契约测试
+scripts/                       # 开发守卫 / 测试 / 代码生成（20 个脚本的完整索引见 scripts/README.md）
 ```
 
 每个 skill 由一个 `SKILL.md`（入口）和 `references/` 目录（知识库）组成。
@@ -74,11 +64,12 @@ PR 自动运行 `.github/workflows/cross-platform.yml`。static-check job 跑以
 - `scripts/check-shared-files.sh` — 跨 skill 同名副本字节一致性
 - `scripts/check-story-setup-deployment.sh` — story-setup 部署完整性
 - `scripts/check-opencode-adapter.sh` — OpenCode adapter 同步、commands/agents/plugin/config 锚点检查
-- `scripts/test-opencode-cli-e2e.sh` — 本机可选 OpenCode CLI smoke：确认 repo skills 发现、临时项目 13 commands / 7 agents / plugin 真实加载
 - `scripts/check-openclaw-skills.sh` — OpenClaw 单行 frontmatter、`metadata.openclaw` 与可选真实 CLI 发现检查
 - `scripts/check-codex-adapter.sh` — Codex repo skills symlink、custom-agent TOML（schema + 生成确定性）与 hooks 锚点检查
 - `scripts/test-codex-hooks.sh` — Codex hooks 合成事件测试
 - 采集脚本 `node --check` 语法校验
+
+以上为代表性列举；**强制清单按 `.github/workflows/cross-platform.yml` 为准**，每个脚本的用途与触发时机见 [scripts/README.md](scripts/README.md)。`scripts/test-opencode-cli-e2e.sh` 需本机安装 opencode，**不在 CI**，只在本地可选运行（见下）。
 
 另有 windows / macos job 验证 cdp-utils 加载与 setup 脚本 dry-run。
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,43 @@
+# scripts/ —— 仓库开发脚本索引
+
+这些是开发本仓库（skill 套件本体）用的**守卫 / 测试 / 代码生成**脚本，**不是** skill 运行时脚本（运行时脚本在各 skill 自己的 `scripts/` 下，如 `story-deslop/scripts/check-ai-patterns.js`，跨 skill 字节同步）。
+
+- 绝大多数由 CI 自动跑（`.github/workflows/cross-platform.yml`）。提交前本地一把梭的完整命令见 [CONTRIBUTING.md](../CONTRIBUTING.md)「CI 检查」。
+- **改名 / 移动任一脚本**，要同步改 `.github/workflows/*.yml`、`CONTRIBUTING.md`、本文件，以及调用它的兄弟脚本（见下方「何时跑」里的调用关系）。
+
+## 静态守卫（check-*）
+
+| 脚本 | 检查什么 | 何时跑 |
+|---|---|---|
+| `static-check.sh` | Skill 结构、frontmatter、引用路径、死文件、references 交叉引用（结构总闸） | CI |
+| `check-shared-files.sh` | 跨 skill 同名 reference/脚本副本字节一致 | CI |
+| `check-story-setup-deployment.sh` | story-setup 部署/运行时回归（慢，>2min） | CI |
+| `check-hook-regex-sync.sh` | `detect-story-gaps.sh` 伏笔状态检测行为 | CI（也被 test-prose-net-parity 调） |
+| `check-hook-locale-safety.sh` | 部署 hook 在 Windows 中文 GBK 区域的字节安全 | CI（调 test-hook-encoding-portable） |
+| `check-python-invocation.sh` | 技能文档禁止裸调 `python3`（须 python3→python→py 探测） | CI（也被 test-charcount-portable 调） |
+| `check-opencode-adapter.sh` | OpenCode 适配层同步 + commands/agents/plugin/config 锚点 | CI + sync CI（调 sync-opencode.py） |
+| `check-openclaw-skills.sh` | OpenClaw AgentSkills/frontmatter 兼容性 | CI |
+| `check-codex-adapter.sh` | Codex 适配层：repo skills symlink、agent TOML、hooks 锚点 | CI（调 generate-codex-agents.py 验生成确定性） |
+
+## 测试回归（test-*）
+
+| 脚本 | 测什么 | 何时跑 |
+|---|---|---|
+| `test-ai-patterns.sh` | 确定性 AI 句式检测器 `check-ai-patterns.js` 回归 | CI |
+| `test-degeneration.sh` | 模型退化检测器 `check-degeneration.js` 回归 | CI |
+| `test-prose-net-parity.sh` | 正文兜底「轻量确定性网」三端 parity | CI（调 check-hook-regex-sync） |
+| `test-prose-backstop-hook.sh` | `check-prose-after-write.sh` 回归 | CI |
+| `test-story-continuity.sh` | `detect-story-gaps.sh` 跨批连续性兜底回归 | CI（调 test-codex-hooks） |
+| `test-codex-hooks.sh` | Codex hook 合成 stdin/stdout 契约 | CI（也被 test-story-continuity 调） |
+| `test-charcount-portable.sh` | 跨平台字符统计命令在三平台 + Windows 的正确性 | CI（调 check-python-invocation） |
+| `test-hook-encoding-portable.sh` | 部署 hook 在 Windows 中文系统的编码健壮性 | CI（也被 check-hook-locale-safety 调） |
+| `test-opencode-cli-e2e.sh` | 真实 OpenCode CLI 加载 smoke（repo skills 发现 / 13 commands / 7 agents / plugin） | **本机可选**，需装 opencode，**不在 CI** |
+
+## 代码生成 / 同步
+
+| 脚本 | 干什么 | 何时跑 |
+|---|---|---|
+| `sync-opencode.py` | 从 Claude agent 模板 + `CLAUDE.md.tmpl` 生成 `opencode/agents/` 与 `AGENTS.md.tmpl` | 改 agent 模板后手动跑；sync CI + 被 check-opencode-adapter 调 |
+| `generate-codex-agents.py` | 从 Claude agent 模板生成 Codex `.toml` agents | 改 agent 模板后手动跑；被 check-codex-adapter 调验确定性 |
+
+> 改了 `skills/story-setup/references/templates/agents/*.md` 或 `CLAUDE.md.tmpl`，必须重跑这两个生成脚本并提交结果，否则适配层 CI 红。详见 [CONTRIBUTING.md](../CONTRIBUTING.md)「OpenCode 模板同步」「Codex 适配维护」。


### PR DESCRIPTION
## 背景

`scripts/` 有 20 个开发脚本平铺、无索引；CONTRIBUTING 里只手列了其中 10 个，且把**本机可选**的 `test-opencode-cli-e2e.sh` 误列进「static-check job 全部强制」的 CI 清单——它根本不在 `cross-platform.yml`（CI 装不了 opencode）。

## 调研结论（先评估再动手）

`scripts/` 在危险意义上**并不乱**：

- **零死脚本** —— 17/20 由 CI 直接跑，余下 3 个被兄弟脚本或 sync CI 引用。
- **命名已自洽** —— `check-*`（8 守卫）/ `test-*`（9 回归）/ `generate-`·`sync-`（codegen）。
- **调用图干净** —— 6 处兄弟调用，结构合理。

真正的问题是**文档漂移**，不是结构。所以**不重排目录**（分子目录要改 17 处 CI 引用 + 兄弟调用路径，高 churn / 低收益），只补文档。

## 改动（纯文档，零行为）

- **新增 `scripts/README.md`**：全 20 个脚本分类索引，每个标注「检查什么 / 何时跑 / 被谁调用」，并提示改名或移动需同步 `cross-platform.yml` / `CONTRIBUTING.md` / 兄弟脚本。
- **`CONTRIBUTING.md`**：把易漂移的半截脚本清单收敛成指向 `scripts/README.md` 的指针；从「强制 CI」清单移除 `test-opencode-cli-e2e.sh` 并注明它不在 CI、需本机装 opencode；强制清单以 `cross-platform.yml` 为准。

`static-check.sh` 13/13 通过，相对链接均可解析。

🤖 Generated with [Claude Code](https://claude.com/claude-code)