### PR TITLE
Route long-form drafting through genre prose cards

### DIFF
--- a/skills/story-long-write/SKILL.md
+++ b/skills/story-long-write/SKILL.md
@@ -128,6 +128,7 @@ story-architect 属于高层级结构设计 agent。轻量题材定位优先由�
 完成核心设定后，创建以下 artifact（加载 [references/artifact-protocols.md](references/artifact-protocols.md) 中对应模板）：
 - **设定/关系.md**：角色关系映射（参考 character-relations.md「四种关系类型」）
 - **设定/题材定位.md**：题材核心梗三分法+对标分析（参考 genre-core-mechanics.md「核心梗解析」）。对标分析表保留 2-3 行摘要，详细数据见 `对标/` 目录
+- **设定/题材正文提示卡.md**：从 `设定/题材定位.md` + `references/genre-prose-cards.md`（索引）+ `references/genre-prose-cards/`（单题材正文卡目录，按题材分类优先）+ `references/style-genre-modules.md`（通用流派补充）抽取本书正文层题材卡，只写题材边界、核心逻辑、读者期待、核心爽点/情绪、正文落点、前中后期打法、节奏密度、场景颗粒、禁止漂移；不写通用格式规则，不覆盖 `设定/文风.md`
 
 > **多对标书时**：参 `references/cross-book-recall.md`，副对标 anchor 入「对标分析」表附录
 
@@ -271,7 +272,8 @@ story-architect 属于高层级结构设计 agent。轻量题材定位优先由�
 │   │   ├── 天机阁.md          # 每个势力/组织一个文件
 │   │   └── ...
 │   ├── 关系.md                # 角色关系映射
-│   └── 题材定位.md            # 题材核心梗+对标分析
+│   ├── 题材定位.md            # 题材核心梗+对标分析
+│   └── 题材正文提示卡.md       # 题材正文核心：边界/期待/爽点/节奏/禁漂移
 ├── 大纲/
 │   ├── 大纲.md                # 全书卷级结构
 │   ├── 卷纲_第一卷.md         # 每卷一个：对标结构坐标+爽点节奏+情绪弧线(含章节定位)+人物弧线+伏笔+反转
@@ -314,7 +316,8 @@ story-architect 属于高层级结构设计 agent。轻量题材定位优先由�
 | 文件 | 粒度 | 创建阶段 | 读取时机 |
 |------|------|---------|---------|
 | 设定/关系.md | 全书 | Phase 2 | 按需：story-explorer relationship 查询、story-review 查设定（不在每章写作回路里逐章读） |
-| 设定/题材定位.md（含 `主对标书` 字段，多对标时必填） | 全书 | Phase 2 | Phase 3 大纲、每卷开始前、Phase 4 文风召回 |
+| 设定/题材定位.md（含 `主对标书` 字段，多对标时必填） | 全书 | Phase 2 | Phase 3 大纲、每卷开始前、Phase 4 写前召回 |
+| 设定/题材正文提示卡.md | 全书/题材 | Phase 2（缺失则 Phase 4 写前即时生成） | Phase 4 每章写作前：按 `genre-prose-cards.md` 索引匹配后读取 `genre-prose-cards/` 目录对应单题材卡优先、`style-genre-modules.md` 通用模块兜底，与通用正文要求、情绪/节奏召回和文风一起组装 prompt |
 | 设定/角色/{角色名}.md、设定/势力/{名}.md | 角色/势力 | Phase 3 细纲后增量补全（首批含主角/主要角色） | Phase 4 状态筛选/写作 |
 | 设定/文风.md（自定义文风·优先级最高） | 本书 | 用户自写（Claude Code 可代写）；导入/拆解不覆盖 | Phase 4 每章写作前：含实质内容则取代对标文风作权威风格基 |
 | 对标/{书名}/文风.md | 对标书 | analyze Stage 6 输出 → story-import 同步 | Phase 4 每章写作前（文风召回；有自定义文风时降为参考/句长兜底） |
@@ -339,6 +342,7 @@ story-architect 属于高层级结构设计 agent。轻量题材定位优先由�
 5. **legacy 拆文库缺 `剧情/节奏.md`** → 写作继续；关键信息推进、情绪触动点和爆发节奏依次回退到 `拆文报告.md` 节奏摘要、匹配章摘要、`剧情/故事线.md`。记录 `legacy_deconstruction: true` + `rhythm_missing`。
 6. **有对标书但 `文风.md` 缺失** → 若有 `设定/文风.md`（含实质内容）走自定义文风模式继续；否则日更文风召回 fail-fast，提示先运行 `/story-long-analyze` Stage 6 并 `/story-import` 同步。**完全无对标项目**则跳过文风召回、不阻塞（有 `设定/文风.md` 时用它写作）。情绪/节奏轴（`missing_primary_contract`）独立，自定义文风模式不豁免其 fail-fast。
 7. **伏笔/时间线文件缺失** → 不检查，相关信息在卷纲或大纲中体现即可。
+8. **`设定/题材正文提示卡.md` 缺失** → 不阻塞；写前从 `设定/题材定位.md` 精确匹配 `references/genre-prose-cards.md` 索引，并只读取 `references/genre-prose-cards/` 中对应题材单卡（高/中/低置信照原卡标注），无命中再用 `references/style-genre-modules.md` 通用流派模块即时生成短 `genre_prose_card`。只有 `设定/题材定位.md` 也缺失时，退回细纲和目标平台做低置信题材卡，并在意图确认写明。
 
 **对标分析权威优先级（canonical read order）**：
 1. `剧情/情绪模块.md` 是读者需求 / 情绪引擎、爽文套路框架、可复现模块和重组指南的权威来源。
@@ -374,16 +378,18 @@ story-architect 属于高层级结构设计 agent。轻量题材定位优先由�
    - (11) 对标书路径下 `设定/世界观/*.md`（glob，按对标书路径查找）— 从拆文产出的设定中获取参考。**回退顺序**：① glob `设定/世界观/*.md`；② 若 `设定/世界观/` 子目录不存在则读单文件 `设定/世界观.md`（早期拆文库格式）；③ 若也无则读 `设定/金手指.md` 当作最低限度参考；④ 都没有则跳过本步骤（缺失不阻塞）
    - (12) 对标书路径下 `剧情/情绪模块.md`（按对标书路径查找）— 读者需求 / 情绪引擎、爽文套路框架、可复现模块；缺失按上方「缺失文件回退」规则（v12 停下修复，仅 legacy 回退）
    - (13) 对标书路径下 `剧情/节奏.md`（按对标书路径查找）— 关键信息推进、情绪触动点、爆发节奏；缺失按上方「缺失文件回退」规则（v12 停下修复，仅 legacy 回退）
+   - (14) `设定/题材正文提示卡.md`（如存在）— 本书正文层题材卡；缺失时从 `设定/题材定位.md` + `references/genre-prose-cards.md` 索引 + `references/genre-prose-cards/` 单题材卡目录（按题材分类优先）+ `references/style-genre-modules.md`（兜底）即时生成 `genre_prose_card`，不阻塞写作
 3. **写前准备**（下面的 3 步是核心方法在单章写作中的落地：筛选状态 → 召回模块 → 确认意图）：
    - 3.1 **状态筛选**：从 `追踪/角色状态.md` 中筛选本章涉及角色的当前状态，从 `追踪/伏笔.md` 中筛选本章需要回收/推进的伏笔。输出本节速记（参考 state-tracking.md）。如果角色状态文件不存在，从角色设定和前文推断
-   - 3.2 **模块召回与文风召回**：
+   - 3.2 **模块召回、题材卡与文风召回**：
      - ① 本章目标情绪词？② 借鉴哪个参考文件的哪个技法？③ 用在哪些段落？答不出 → 先回读参考再动笔
      - (a) **情绪模块召回**：按「对标书路径查找」规则优先读 `{对标书路径}/剧情/情绪模块.md`，选出 1 个与本章目标情绪最贴近的 `selected_emotion_module`（读者需求、触发器、戏剧单元、可替换要素、反抄袭提醒）。v12 新契约缺失时停下提示重跑拆文/导入；仅 legacy 拆文库可依次回退 `拆文报告.md` 读者需求 / 情绪引擎摘要、`文风.md` 可借鉴技巧、匹配章摘要，并记录 `legacy_deconstruction: true` + `module_missing`
      - (b) **节奏召回**：优先读 `{对标书路径}/剧情/节奏.md`，选出 1 条 `rhythm_reference`（关键信息 → 扩写技法 → 情绪触动点 → 爆发/冷却）。v12 新契约缺失时停下提示重跑拆文/导入；仅 legacy 拆文库可依次回退 `拆文报告.md` 节奏摘要、匹配章摘要、`剧情/故事线.md`，并记录 `legacy_deconstruction: true` + `rhythm_missing`
-     - (c) **文风召回**：先直接读 `设定/文风.md`（不经 explorer）：含实质内容（去空白 ≥200 字，或含 句长 / 标点 / 对话 / 锚点 / 笔调 小节且小节内有可执行约束：比例 / 例句 / 禁止或偏好描述）则置 `custom_style=true`、进入「自定义文风模式」，它作权威风格基（句长 / 软标点 / 潜台词 / 情绪交替），对标 / 拆文 `文风.md` 降为参考（锚点 + 句长兜底）；空 / 仅空白 / 仅标题 / 占位 stub（待办 / 待补充 / ___）视为不存在。否则按「对标书路径查找」规则读 `{对标书路径}/文风.md`（路径优先 `{项目}/对标/{书名}/`，回退 `拆文库/{书名}/`）；多本对标书时从 `设定/题材定位.md` 读 `主对标书` 字段。**未进入自定义文风模式且**文风文件不存在 → **fail-fast 报错**：「对标书 X 缺少 文风.md。请用 `/story-long-analyze` 跑 Stage 6 生成文风，再 `/story-import` 同步。」不 inline 生成（自定义文风模式则不 fail-fast；情绪 / 节奏轴 `missing_primary_contract` 仍独立阻塞）
-     - (d) **匹配章节挑选**：从 `{对标书路径}/章节/*_摘要.md` grep `基调：(紧张|轻松|悲伤|热血|爽|甜|温馨|恐怖|压抑|其他)`（全角冒号），按本章目标情绪挑章 K——多章同基调时选择规则：先看爽点类型是否接近，再看情节点数量/原文章节估算字数是否接近本章目标字数，最后取章节号最小者；必读 `{对标书路径}/章节/第K章_摘要.md`，若同章存在 `第K章_深度拆解.md` 则加读，否则回退黄金三章深度拆解/文风文件里的可借鉴技巧，不因非黄金三章缺少深度拆解而失败
-     - (e) **结构化模块召回**：从对标的结构化子目录（角色/剧情/设定）中按本章情节检索相关模块；若与 `剧情/情绪模块.md` / `剧情/节奏.md` 冲突，权威文件优先，记录 `conflict`
-     - (f) 输出"主对标召回摘要 + 副对标召回摘要 + selected_emotion_module + rhythm_reference + 文风召回指令 + 原文锚点片段引用"，作为 narrative-writer 的输入。**多对标书时**参 `references/cross-book-recall.md`：主对标提供文风、原文锚点与 selected_emotion_module / rhythm_reference；副对标/参考对标按阶段预算提供结构化摘要，不限制登记书目，不读取副书 `文风.md` / 原文，超过预算时裁条目不裁书目记录。
+     - (c) **题材正文提示卡召回**：优先读 `设定/题材正文提示卡.md`；缺失则先读 `设定/题材定位.md` + `references/genre-prose-cards.md` 索引，按主题材精确匹配后只读取 `references/genre-prose-cards/` 中对应单题材卡（如 都市脑洞 / 豪门总裁 / 年代 / 双男主；低置信卡必须在意图确认标注低置信，并要求同题材对标校准），无命中再读 `references/style-genre-modules.md` 通用流派模块。跨题材时主题材抽 3-5 条、辅题材抽 1-2 条，生成短 `genre_prose_card`（题材边界、核心逻辑、读者期待、核心爽点/情绪、正文落点、前中后期打法、节奏密度、场景颗粒、禁止漂移、本章取舍、卡片置信度）。题材卡只约束正文层题材味，不改细纲剧情、不覆盖 `selected_emotion_module` / `rhythm_reference` / `设定/文风.md`
+     - (d) **文风召回**：先直接读 `设定/文风.md`（不经 explorer）：含实质内容（去空白 ≥200 字，或含 句长 / 标点 / 对话 / 锚点 / 笔调 小节且小节内有可执行约束：比例 / 例句 / 禁止或偏好描述）则置 `custom_style=true`、进入「自定义文风模式」，它作权威风格基（句长 / 软标点 / 潜台词 / 情绪交替），对标 / 拆文 `文风.md` 降为参考（锚点 + 句长兜底）；空 / 仅空白 / 仅标题 / 占位 stub（待办 / 待补充 / ___）视为不存在。否则按「对标书路径查找」规则读 `{对标书路径}/文风.md`（路径优先 `{项目}/对标/{书名}/`，回退 `拆文库/{书名}/`）；多本对标书时从 `设定/题材定位.md` 读 `主对标书` 字段。**未进入自定义文风模式且**文风文件不存在 → **fail-fast 报错**：「对标书 X 缺少 文风.md。请用 `/story-long-analyze` 跑 Stage 6 生成文风，再 `/story-import` 同步。」不 inline 生成（自定义文风模式则不 fail-fast；情绪 / 节奏轴 `missing_primary_contract` 仍独立阻塞）
+     - (e) **匹配章节挑选**：从 `{对标书路径}/章节/*_摘要.md` grep `基调：(紧张|轻松|悲伤|热血|爽|甜|温馨|恐怖|压抑|其他)`（全角冒号），按本章目标情绪挑章 K——多章同基调时选择规则：先看爽点类型是否接近，再看情节点数量/原文章节估算字数是否接近本章目标字数，最后取章节号最小者；必读 `{对标书路径}/章节/第K章_摘要.md`，若同章存在 `第K章_深度拆解.md` 则加读，否则回退黄金三章深度拆解/文风文件里的可借鉴技巧，不因非黄金三章缺少深度拆解而失败
+     - (f) **结构化模块召回**：从对标的结构化子目录（角色/剧情/设定）中按本章情节检索相关模块；若与 `剧情/情绪模块.md` / `剧情/节奏.md` 冲突，权威文件优先，记录 `conflict`
+     - (g) 输出"主对标召回摘要 + 副对标召回摘要 + selected_emotion_module + rhythm_reference + genre_prose_card + 文风召回指令 + 原文锚点片段引用"，作为 narrative-writer 的输入。**多对标书时**参 `references/cross-book-recall.md`：主对标提供文风、原文锚点与 selected_emotion_module / rhythm_reference；副对标/参考对标按阶段预算提供结构化摘要，不限制登记书目，不读取副书 `文风.md` / 原文，超过预算时裁条目不裁书目记录。
      - **快捷路径**：项目已部署 story-explorer agent 时，可一次性召回文风/模块材料。
        - 检查顺序：`.claude/agents/story-explorer.md` → `.opencode/agents/` → `.codex/agents/`。
        - 查询类型：`benchmark_style_load`；传入项目目录、章节号、目标基调/字数和爽点类型。
@@ -409,6 +415,7 @@ story-architect 属于高层级结构设计 agent。轻量题材定位优先由�
      - 写前准备输出：本节速记、情绪目标、涉及角色、参考技法。
      - 主对标/拆文路径、主/副对标召回摘要。
      - `selected_emotion_module`、`rhythm_reference` 及来源路径。
+     - `genre_prose_card`（题材正文提示卡摘要，只含本章相关条目）。
      - 文风路径、文风召回指令、原文锚点片段。
      - 字数目标、情节点预算、格式硬约束。
    - 不把本文件整套规则复制进 prompt；细节以已加载 references 和 narrative-writer 模板为准。
@@ -546,7 +553,7 @@ advisory 只提示可疑处，先看脚本给出的例外；故事内系统/界�
 | 章节钩子 | `references/hooks-chapter.md` |
 | 悬念设计 | `references/hooks-suspense.md` |
 | 段落级钩子 | `references/hooks-paragraph.md` |
-| 题材风格 | `references/style-genre-modules.md` |
+| 题材正文提示卡 / 题材分类卡 | `references/genre-prose-cards.md` 索引 + `references/genre-prose-cards/` 单题材卡目录（按题材分类优先） + `references/style-genre-modules.md`（通用流派补充） |
 | 打斗/装逼 | `references/style-combat-face.md` |
 | 写作技法 | `references/style-craft.md` |
 | 商业创作核心方法 | `references/commercial-core-methods.md` |

--- a/skills/story-long-write/references/workflow-daily.md
+++ b/skills/story-long-write/references/workflow-daily.md
@@ -2,15 +2,18 @@
 
 本文件为"日更续写"场景的完整指引。SKILL.md 路由到本文件后，按以下流程执行。
 
-> **日更准备步骤**：每章写作前 3 步——状态筛选 + 文风召回 + 意图确认，嵌入 Step 2 逐章循环。
+> **日更准备步骤**：每章写作前 4 步——状态筛选 + 题材正文提示卡召回 + 文风召回 + 意图确认，嵌入 Step 2 逐章循环。
 >
-> Step 2 必读四类对标资料：
+> Step 2 必读 / 生成五类写前资料：
 > 1. `{对标书路径}/剧情/情绪模块.md`（读者需求 / 情绪引擎 + 可复现模块；缺失按下方「模块/节奏缺失」规则：v12 停下修复，仅 legacy 回退）
 > 2. `{对标书路径}/剧情/节奏.md`（关键信息推进 + 情绪触动点 + 爆发节奏；缺失按下方「模块/节奏缺失」规则：v12 停下修复，仅 legacy 回退）
-> 3. `{对标书路径}/文风.md`（整书级 ~4000 字，含原文锚点范例片段）
-> 4. `{对标书路径}/章节/第K章_摘要.md`（按本章情绪/基调挑 1 章）；若同章存在 `第K章_深度拆解.md` 则加读，否则回退黄金三章深度拆解/文风文件里的可借鉴技巧
+> 3. `设定/题材正文提示卡.md`（题材边界 / 核心逻辑 / 读者期待 / 节奏密度；缺失时用 `设定/题材定位.md` + `references/genre-prose-cards.md` 索引匹配并读取 `references/genre-prose-cards/{题材}.md` 单卡优先生成，`references/style-genre-modules.md` 通用流派兜底）
+> 4. `{对标书路径}/文风.md`（整书级 ~4000 字，含原文锚点范例片段）
+> 5. `{对标书路径}/章节/第K章_摘要.md`（按本章情绪/基调挑 1 章）；若同章存在 `第K章_深度拆解.md` 则加读，否则回退黄金三章深度拆解/文风文件里的可借鉴技巧
 >
 > 对标书路径查找：先 `{项目}/对标/{书名}/`，回退 `拆文库/{书名}/`。
+>
+> **题材正文提示卡**：优先读 `设定/题材正文提示卡.md`；缺失时不阻塞，先从 `设定/题材定位.md` 精确匹配 `references/genre-prose-cards.md` 索引，并只读取 `references/genre-prose-cards/{题材}.md` 题材单卡（高/中/低置信照原卡标注），无命中再从 `references/style-genre-modules.md` 抽取通用流派短 `genre_prose_card`。题材卡只管题材味和正文取舍，不改细纲、不覆盖情绪/节奏权威文件，也不接管句长/标点等文风细节。
 >
 > **自定义文风（`设定/文风.md`，优先级最高）**：主会话每章写作前直接读 `设定/文风.md`（不经 story-explorer——它只看 `对标/文风.md`）。存在且含实质内容（去空白 ≥200 字，或含「句长 / 标点 / 对话 / 锚点 / 笔调」风格小节且小节内有可执行约束：比例 / 例句 / 禁止或偏好描述）即进入「自定义文风模式」：它是本书既定笔调的**权威**风格基，narrative-writer 的句长带 / 标点节奏 / 对话潜台词 / 情绪交替以它为准；对标 / 拆文 `文风.md` 降级为「**参考**」——只供原文锚点范例与句长分布数值兜底，不再是被遵循的最终文风。空 / 仅空白 / 仅标题 / 占位 stub（待办 / 待补充 / ___）视为不存在。仅接管风格，**不覆盖** `剧情/情绪模块.md` / `剧情/节奏.md` 的情绪与节奏意图（同下「冲突规则」）。**硬门禁不让位**：`设定/文风.md` 里命中硬安全线的写法（`……`、破折号 `——`/`—`、段间空行、三五字碎句）仍按 narrative-writer 归一为句号 / 逗号 / 动作 beat / 单 `\n`；自定义文风只接管句长 / 软标点节奏 / 潜台词 / 情绪交替（要让这些标记原样进正文须放宽题材硬门禁，本期不做）。
 >
@@ -100,8 +103,9 @@
    - 读细纲 → 按需加载角色设定
    - **2.1 标题预检**：扫描既有章节标题；如本章标题同名或明显重复，先按本章核心事件改名，并同步细纲标题与正文文件名
    - **2.2 状态筛选**：每章开始前必须确认以下来源已经在本轮 workflow 中读取或刚更新：本章细纲、上一章正文（或上一章刚写入的正文）、`追踪/上下文.md`、`追踪/伏笔.md`、`追踪/时间线.md`；涉及角色时，还必须确认 `追踪/角色状态.md` 或对应 `设定/角色/{角色名}.md` 的来源。"已加载"只指本轮 workflow 内实际读取/更新过的文件，不得用未标明来源的聊天记忆替代。角色最新状态优先从 `追踪/角色状态.md` 筛选（如不存在则从角色设定推断），待回收/推进伏笔从 `追踪/伏笔.md` 筛选；细纲不存在时仍按下方补建流程处理，不允许直接写正文
-   - **2.3 对标模块/节奏/文风召回**：
+   - **2.3 对标模块/节奏/题材卡/文风召回**：
      - 调 story-explorer 的 `benchmark_style_load` query_type（输入：项目目录 + 本章目标情绪 + 本章爽点类型 + 本章目标字数）一次性拿到：`{style_profile_path, style_profile_summary, selected_emotion_module, rhythm_reference, module_source_path, rhythm_source_path, matched_chapter_K, matched_chapter_techniques, anchor_excerpts, gaps}`
+     - **题材正文提示卡召回**：主会话优先读 `设定/题材正文提示卡.md`；缺失则先读 `设定/题材定位.md` + `references/genre-prose-cards.md` 索引，按主题材精确匹配后只读取 `references/genre-prose-cards/{题材}.md` 单卡（如 都市脑洞 / 豪门总裁 / 年代 / 双男主；低置信卡必须在意图确认标注低置信，并要求同题材对标校准），无命中再读 `references/style-genre-modules.md` 通用流派模块。跨题材时主题材抽 3-5 条、辅题材抽 1-2 条，生成 `genre_prose_card`（题材边界、核心逻辑、读者期待、核心爽点/情绪、节奏密度、场景颗粒、禁止漂移、本章取舍、卡片置信度）。题材卡必须进入 narrative-writer prompt，但只传短摘要
      - **自定义文风覆盖（先于下列 gaps 判定）**：主会话直接读 `设定/文风.md`（不经 explorer），含实质内容（去空白 ≥200 字，或含 句长 / 标点 / 对话 / 锚点 / 笔调 小节且小节内有可执行约束：比例 / 例句 / 禁止或偏好描述）则置 `custom_style=true`——它作权威风格基**取代** `style_profile_path` 喂给 narrative-writer（句长 / 标点 / 潜台词 / 情绪交替），对标 / 拆文 `style_profile_path` 降级为参考（原文锚点 + 句长分布数值兜底）。空 / 仅空白 / 仅标题 / 占位 stub（待办 / 待补充 / ___）视为不存在。仅接管风格，**不豁免情绪 / 节奏轴**。
      - 若 `gaps.no_benchmark: true` → `custom_style` 为真则进入「自定义文风模式」（用 `设定/文风.md` 写作；无对标可召回，情绪 / 节奏目标改从本书细纲「目标情绪」、卷纲、`设定/题材定位.md` 等内部材料取，`selected_emotion_module` / `rhythm_reference` 记为「无」，不声称从对标召回）；否则跳过文风召回，在 2.4 意图确认标记"无对标参考"
      - 若 `gaps.missing_primary_contract: true` → 停止本章准备，按 `repair_action` 提示重跑 `/story-long-analyze` Stage 3+ 或重新 `/story-import`；不得进入 narrative-writer（情绪 / 节奏轴独立于文风轴，**自定义文风模式不豁免此停止**——补 `剧情/情绪模块.md` / `剧情/节奏.md`，而非写 `设定/文风.md`）
@@ -111,9 +115,9 @@
      - 若 `gaps.profile_missing: true` → `custom_style` 为真则进入自定义文风模式继续；否则按上文 fail-fast 流程停止
      - 若 `gaps.profile_degenerate: true`（对标文风不可用） → `custom_style` 为真则用 `设定/文风.md` 写作；否则跳过文风、回到默认 Gates 写作
      - 若 `gaps.tone_match_failed: true` → 仅用整书文风写作，不喂 matched_chapter
-     - 否则原样传给 `style_profile_path`、`style_profile_summary`、`selected_emotion_module`、`rhythm_reference`、`module_source_path`、`rhythm_source_path`、`matched_chapter_K`、`matched_chapter_techniques`、`anchor_excerpts` 给 Step 2 末尾的 narrative-writer spawn prompt；其中 `selected_emotion_module` 必须进入情绪目标，`rhythm_reference` 必须进入节奏/爆发安排，`matched_chapter_techniques` 必须进入「文风召回指令」。写前准备记录必须保留 `gaps` 原值，尤其 `gaps.module_missing`、`gaps.rhythm_missing`、`gaps.conflict`、`gaps.matched_deep_dive_missing`；若 `matched_deep_dive_missing` 为 true，文风召回指令中明确写“同章深度拆解缺失，已回退黄金三章/文风技巧”，不得在后续报告中反转为 false
-     - **无 story-explorer 时降级**：主会话手动按对标书路径查找，先读 `剧情/情绪模块.md` 选 `selected_emotion_module`，再读 `剧情/节奏.md` 选 `rhythm_reference`，先读 `设定/文风.md`（含实质内容则 `custom_style=true`、作权威风格基，对标 `文风.md` 降为参考 / 句长兜底）、再读对标 `文风.md` + grep `章节/*_摘要.md` 的「基调」字段找匹配章，然后读对应 `第K章_摘要.md`；如 `第K章_深度拆解.md` 不存在，改读 `第1-3章_深度拆解.md` 中与本章基调最接近的一章。模块/节奏文件缺失时先判定 v12 vs legacy：v12 停止修复，legacy 才按上方回退继续
-   - **2.4 意图确认**：从细纲「目标情绪」字段确认本章情绪目标，综合状态筛选结果 + `selected_emotion_module` + `rhythm_reference` + 文风召回输出，用一句话写本章意图（情绪+节奏+模块+文风指令）。若新版细纲存在，意图确认必须显式带入：内容概括决定起承转合，情节安排决定主线/辅线/事件线/感情线/逻辑线的取舍，人物关系和出场顺序决定镜头进入顺序，情节细化决定代价兑现/收益兑现，结尾设定和钩子决定章尾承接；并落实两条 craft——① 发展/转折=爽点(高潮)的铺垫蓄势，爽点出手前先铺可指认的危机/期待（plot-emotion-system 倒推法，不铺=空洞）；② 装逼/打脸/揭露章把 视角/信息差 经 出场顺序 里的在场配角放大成差异化反应（plot-core-methods 信息差×人际×情绪/集体震惊）；③ 对话声线基线随基调——高压/生死/悲痛 beat→搞笑担当/轻快配角声线让位、信息型配角不当科普嘴、对话逐句承接对方情绪，写进本章意图、生成时即按基调收敛。例：「快节奏打脸——起因=账单暴露，逻辑线=发现→逼问→反证→公开代价；复现 M03‘信息差反杀’的读者期待，关键信息先压后爆，爆发后用一段冷却承接下一钩子；标点照文风里的停顿节奏、对话潜台词用问非所答。」
+     - 否则原样传给 `style_profile_path`、`style_profile_summary`、`selected_emotion_module`、`rhythm_reference`、`module_source_path`、`rhythm_source_path`、`matched_chapter_K`、`matched_chapter_techniques`、`anchor_excerpts` 和 `genre_prose_card` 给 Step 2 末尾的 narrative-writer spawn prompt；其中 `selected_emotion_module` 必须进入情绪目标，`rhythm_reference` 必须进入节奏/爆发安排，`genre_prose_card` 必须进入题材取舍，`matched_chapter_techniques` 必须进入「文风召回指令」。写前准备记录必须保留 `gaps` 原值，尤其 `gaps.module_missing`、`gaps.rhythm_missing`、`gaps.conflict`、`gaps.matched_deep_dive_missing`；若 `matched_deep_dive_missing` 为 true，文风召回指令中明确写“同章深度拆解缺失，已回退黄金三章/文风技巧”，不得在后续报告中反转为 false
+     - **无 story-explorer 时降级**：主会话手动按对标书路径查找，先读 `剧情/情绪模块.md` 选 `selected_emotion_module`，再读 `剧情/节奏.md` 选 `rhythm_reference`，读 `设定/题材正文提示卡.md` 或按 `genre-prose-cards.md` 索引 + 单题材卡优先即时生成 `genre_prose_card`，先读 `设定/文风.md`（含实质内容则 `custom_style=true`、作权威风格基，对标 `文风.md` 降为参考 / 句长兜底）、再读对标 `文风.md` + grep `章节/*_摘要.md` 的「基调」字段找匹配章，然后读对应 `第K章_摘要.md`；如 `第K章_深度拆解.md` 不存在，改读 `第1-3章_深度拆解.md` 中与本章基调最接近的一章。模块/节奏文件缺失时先判定 v12 vs legacy：v12 停止修复，legacy 才按上方回退继续
+   - **2.4 意图确认**：从细纲「目标情绪」字段确认本章情绪目标，综合状态筛选结果 + `selected_emotion_module` + `rhythm_reference` + `genre_prose_card` + 文风召回输出，用一句话写本章意图（情绪+节奏+模块+题材取舍+文风指令）。若新版细纲存在，意图确认必须显式带入：内容概括决定起承转合，情节安排决定主线/辅线/事件线/感情线/逻辑线的取舍，人物关系和出场顺序决定镜头进入顺序，情节细化决定代价兑现/收益兑现，结尾设定和钩子决定章尾承接；并落实两条 craft——① 发展/转折=爽点(高潮)的铺垫蓄势，爽点出手前先铺可指认的危机/期待（plot-emotion-system 倒推法，不铺=空洞）；② 装逼/打脸/揭露章把 视角/信息差 经 出场顺序 里的在场配角放大成差异化反应（plot-core-methods 信息差×人际×情绪/集体震惊）；③ 对话声线基线随基调——高压/生死/悲痛 beat→搞笑担当/轻快配角声线让位、信息型配角不当科普嘴、对话逐句承接对方情绪，写进本章意图、生成时即按基调收敛。例：「快节奏打脸——起因=账单暴露，逻辑线=发现→逼问→反证→公开代价；复现 M03‘信息差反杀’的读者期待，按都市世情题材卡落到账单/转账/旁人反应，关键信息先压后爆，爆发后用一段冷却承接下一钩子；标点照文风里的停顿节奏、对话潜台词用问非所答。」
    - 写正文 → **字数验证（优先 Python 字符统计，`wc -m` 仅作 Unix 备选，< 目标90%则对照情节点字数预算定位欠账密点、一次性重写到配额，不挤牙膏反复回炉；> 章目标×1.1 则压过场/合并疏点收敛；90% 是放行下限非目标，理想落在 [章目标, 章目标×1.1]）** → 检查钩子/爽点 → **正文元信息扫描** → 禁用词扫描
      - **正文元信息扫描**：标题行以外不得出现 `第[一二三四五六七八九十百千万两0-9]+章|上一章|上章|前一章|本章|这一章|前文|后文|伏笔|细纲|读者`。这些词属于写作/工程元信息，必须改成角色当下能感知的事件锚点或相对时间；例如“比第一章那三秒开火更疼”改成“比那三秒开火更疼”。只有角色在故事世界内真实阅读/讨论“第X章”文本，或真实身为作者/读者并谈论读者身份时例外。
    - 每章写完后**立即更新**以下文件：

--- a/skills/story-setup/references/codex/agents/narrative-writer.toml
+++ b/skills/story-setup/references/codex/agents/narrative-writer.toml
@@ -36,7 +36,8 @@ developer_instructions = """
 |---|---|
 | `story-setup/references/agent-references/writing-craft.md` | 正文写作（三维度揉进、身体细节、物件三次出现、小节密度）时 |
 | `story-setup/references/agent-references/emotional-arc-design.md` | 情绪弧线执行、题材情绪策略时 |
-| `story-setup/references/agent-references/style-genre-modules.md` | 题材风格模块（各题材独特写法）时 |
+| `story-setup/references/agent-references/genre-prose-cards.md` | 按番茄题材分类校准正文提示卡时先读索引，再只读取 `genre-prose-cards/{题材}.md` 单卡 |
+| `story-setup/references/agent-references/style-genre-modules.md` | 题材风格模块（通用流派补充）时 |
 | `story-setup/references/agent-references/opening-design.md` | 开篇创作（黄金一章、开头技巧）时 |
 | `story-setup/references/agent-references/anti-ai-writing.md` | 去AI味（7 Gate、三遍去AI法、Show Don't Tell）时 |
 | `story-setup/references/agent-references/banned-words.md` | 禁用词替换（Gate A）时 |

--- a/skills/story-setup/references/opencode/agents/narrative-writer.md
+++ b/skills/story-setup/references/opencode/agents/narrative-writer.md
@@ -39,7 +39,8 @@ steps: 30
 |---|---|
 | `story-setup/references/agent-references/writing-craft.md` | 正文写作（三维度揉进、身体细节、物件三次出现、小节密度）时 |
 | `story-setup/references/agent-references/emotional-arc-design.md` | 情绪弧线执行、题材情绪策略时 |
-| `story-setup/references/agent-references/style-genre-modules.md` | 题材风格模块（各题材独特写法）时 |
+| `story-setup/references/agent-references/genre-prose-cards.md` | 按番茄题材分类校准正文提示卡时先读索引，再只读取 `genre-prose-cards/{题材}.md` 单卡 |
+| `story-setup/references/agent-references/style-genre-modules.md` | 题材风格模块（通用流派补充）时 |
 | `story-setup/references/agent-references/opening-design.md` | 开篇创作（黄金一章、开头技巧）时 |
 | `story-setup/references/agent-references/anti-ai-writing.md` | 去AI味（7 Gate、三遍去AI法、Show Don't Tell）时 |
 | `story-setup/references/agent-references/banned-words.md` | 禁用词替换（Gate A）时 |

--- a/skills/story-setup/references/templates/agents/narrative-writer.md
+++ b/skills/story-setup/references/templates/agents/narrative-writer.md
@@ -44,7 +44,8 @@ memory: project
 |---|---|
 | `story-setup/references/agent-references/writing-craft.md` | 正文写作（三维度揉进、身体细节、物件三次出现、小节密度）时 |
 | `story-setup/references/agent-references/emotional-arc-design.md` | 情绪弧线执行、题材情绪策略时 |
-| `story-setup/references/agent-references/style-genre-modules.md` | 题材风格模块（各题材独特写法）时 |
+| `story-setup/references/agent-references/genre-prose-cards.md` | 按番茄题材分类校准正文提示卡时先读索引，再只读取 `genre-prose-cards/{题材}.md` 单卡 |
+| `story-setup/references/agent-references/style-genre-modules.md` | 题材风格模块（通用流派补充）时 |
 | `story-setup/references/agent-references/opening-design.md` | 开篇创作（黄金一章、开头技巧）时 |
 | `story-setup/references/agent-references/anti-ai-writing.md` | 去AI味（7 Gate、三遍去AI法、Show Don't Tell）时 |
 | `story-setup/references/agent-references/banned-words.md` | 禁用词替换（Gate A）时 |


### PR DESCRIPTION
## Summary\n- Add Phase 2 artifact guidance for 设定/题材正文提示卡.md\n- Add per-chapter genre_prose_card recall to story-long-write and daily workflow\n- Teach narrative-writer references to read the genre card index first, then a single matching card\n\n## Stacked PR\n- Base branch: pr/genre-prose-cards\n- Depends on #222 because this PR references the new genre card assets\n\n## Validation\n- bash scripts/check-story-setup-deployment.sh\n- bash scripts/static-check.sh\n- git diff --check pr/genre-prose-cards...HEAD\n- git diff --check origin/main...HEAD\n\n## Risk\n- Medium: changes writing workflow prompts, but keeps cards subordinate to outline, continuity, emotion/rhythm recall, and book voice