### PR TITLE
Fix Codex hook treating a blank .active-book first line as the repo root

### DIFF
--- a/skills/story-setup/references/codex/hooks/story_codex_hook.py
+++ b/skills/story-setup/references/codex/hooks/story_codex_hook.py
@@ -106,9 +106,13 @@ def safe_rel(root: Path, path: Path) -> str:
 def read_active_book(root: Path) -> Path | None:
     active_file = root / ".active-book"
     if active_file.exists():
-        first = active_file.read_text(encoding="utf-8", errors="ignore").splitlines()
-        if first:
-            candidate = (root / first[0].strip()).resolve()
+        lines = active_file.read_text(encoding="utf-8", errors="ignore").splitlines()
+        # A blank/whitespace first line must fall through to discovery, not resolve to
+        # root/"" == root (mirrors the bash oracle common.sh discover_active_book, which
+        # trims then requires non-empty, and the JS hook's firstLine()+truthy guard).
+        declared = lines[0].strip() if lines else ""
+        if declared:
+            candidate = (root / declared).resolve()
             try:
                 candidate.relative_to(root.resolve())
             except Exception:


### PR DESCRIPTION
## Summary

Fixes a pre-existing bug in the Codex hook (independent of the ZCode adapter in #234): a `.active-book` file whose **first line is blank or whitespace** makes `read_active_book` resolve the **repository root** as the "active book".

`read_active_book` did `if first:` on the raw `splitlines()`, so a leading blank line left `first[0].strip() == ""` and `(root / "").resolve() == root`. That passes the under-root check and `.exists()`, so the hook reports the repo root as the current book and looks for `root/追踪/上下文.md` — polluting the SessionStart context.

The ZCode JS hook (`firstLine()` + truthy guard) and the Claude bash oracle (`common.sh discover_active_book`, which trims then requires non-empty) both handle this correctly; only Codex/Python had the bug.

## Fix

Trim the first line and require it non-empty before resolving, matching the two correct implementations.

## Testing

- Reproduced: a `.active-book` with a blank first line (and whitespace-only) resolved to the repo root; after the fix both fall through to the real nested book.
- Normal declared book still resolves; `check-codex-adapter.sh` and `check-shared-files.sh` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
