### PR TITLE
fix(readme): correct Zhihu Yanyan romanization typo in README_EN.md

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -135,7 +135,7 @@ After updating, if a project has already run `/story-setup`, re-run `/story-setu
 | `story-long-scan` | `/story-long-scan` | Long-form trend scan — Qidian/Fanqie/Jinjiang market trends |
 | `story-short-write` | `/story-short-write` | Short-form writing — emotion design, twist crafting, polish & delivery |
 | `story-short-analyze` | `/story-short-analyze` | Short-form deconstruction — story core, structure, emotional arc, reversal design, writing techniques, resonance analysis |
-| `story-short-scan` | `/story-short-scan` | Short-form trend scan — Zhihu Yanayan/Fanqie short-form trending data |
+| `story-short-scan` | `/story-short-scan` | Short-form trend scan — Zhihu Yanyan/Fanqie short-form trending data |
 | `story-deslop` | `/story-deslop` | De-AI-ify — detect and remove AI writing traces |
 | `story-import` | `/story-import` | Reverse import — parse existing novels into standard project structure |
 | `story-review` | `/story-review` | Multi-perspective review — 4-agent adversarial review + Fanqie/Qidian/Zhihu scoring rubrics |
@@ -364,7 +364,7 @@ Each skill includes a `references/` knowledge base loaded on demand to keep cont
 
 **Long-form** Qidian (起点中文网) · Fanqie Novels (番茄小说) · Jinjiang (晋江文学城) · Qimao (七猫小说) · Ciweimao (刺猬猫)
 
-**Short-form** Zhihu Yanayan (知乎盐言故事) · Fanqie Short-form (番茄短篇) · Qimao Short-form (七猫短篇)
+**Short-form** Zhihu Yanyan (知乎盐言故事) · Fanqie Short-form (番茄短篇) · Qimao Short-form (七猫短篇)
 
 Real output samples are in [demo/](demo/): short-form deconstruction 《曾将爱意私藏》 · long-form deconstruction 《盘龙》 · long-form continuation project 《让你管账号，你高燃混剪炸全网》 · cover sample 《剑道独尊》.
 


### PR DESCRIPTION
## What
Fix a romanization typo in README_EN.md: "Zhihu Yanayan" -> "Zhihu Yanyan" (referring to 知乎盐言故事, 盐言 = Yanyan).

## Why
"Yanayan" is not the correct pinyin for 盐言 (both characters are pronounced "yan"). Every other reference to this platform in the repo already uses "Yanyan" - this occurrence in the English README was an isolated slip.

## Scope
Doc-only change, 2 lines in README_EN.md, no code/skill/CI impact