### PR TITLE
fix(dashboard): 隔离项目与拆文库节点预算

### DIFF
--- a/skills/story/assets/app.js
+++ b/skills/story/assets/app.js
@@ -290,7 +290,15 @@ function truncationMessage(limits, scanErrors = []) {
   const byNodes = typeof limits.truncatedByNodes === "boolean" ? limits.truncatedByNodes : !byDepth;
   const reasons = [];
   if (byNodes) {
-    reasons.push(`工作区文件太多，目录树只列到 ${formatNumber(limits.maxTreeNodes)} 条上限，部分文稿没有列出`);
+    const categoryFlags = limits.truncatedByNodesByCategory;
+    const categories = [];
+    if (categoryFlags?.projects) categories.push("写作项目");
+    if (categoryFlags?.libraries) categories.push("拆文库");
+    const subject = categories.length ? `${categories.join("和")}文件太多` : "工作区文件太多";
+    const budget = Number.isFinite(limits.maxTreeNodesPerCategory)
+      ? `写作项目和拆文库每类最多列出 ${formatNumber(limits.maxTreeNodesPerCategory)} 个节点`
+      : `目录树只列到 ${formatNumber(limits.maxTreeNodes)} 条上限`;
+    reasons.push(`${subject}，${budget}，部分文稿没有列出`);
   }
   if (byDepth) {
     const depthLimit = Number.isFinite(limits.maxTreeDepth)

--- a/skills/story/scripts/dashboard-server.mjs
+++ b/skills/story/scripts/dashboard-server.mjs
@@ -40,7 +40,8 @@ const IGNORED_DIRECTORIES = new Set([
 const MAX_FILE_BYTES = 2 * 1024 * 1024;
 const MAX_REQUEST_BYTES = MAX_FILE_BYTES + 64 * 1024;
 const MAX_TREE_DEPTH = 10;
-const MAX_TREE_NODES = 5000;
+const MAX_TREE_NODES_PER_CATEGORY = 5000;
+const MAX_TREE_NODES = MAX_TREE_NODES_PER_CATEGORY * 2;
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "localhost"]);
 const FILE_MUTATION_TAILS = new Map();
 
@@ -175,7 +176,7 @@ export async function resolveWorkspacePath(root, requestedPath, options = {}) {
 async function buildTreeNode(root, absolutePath, relativePath, state, depth = 0) {
   // 两个上限都会真的丢文件，必须各自留痕：靠 state.nodes 反推截断只能看见节点预算，
   // 目录太深被剪掉的子树会一声不响地消失，作者还以为文稿本来就不存在。
-  if (state.nodes >= MAX_TREE_NODES) {
+  if (state.nodes >= MAX_TREE_NODES_PER_CATEGORY) {
     state.nodeLimitHit = true;
     return null;
   }
@@ -405,11 +406,16 @@ export async function scanWorkspace(root) {
       maxFileBytes: MAX_FILE_BYTES,
       editableExtensions: [...EDITABLE_EXTENSIONS],
       maxTreeNodes: MAX_TREE_NODES,
+      maxTreeNodesPerCategory: MAX_TREE_NODES_PER_CATEGORY,
       maxTreeDepth: MAX_TREE_DEPTH,
       // truncated 仍是前端读的总闸门，但成因要分开报：「文件太多」和「目录套太深」
       // 对作者是两种处置办法，混成一句话等于让人照着错的办法搬文件。
       truncated: nodeLimitHit || depthLimitHit || scanErrors.length > 0,
       truncatedByNodes: nodeLimitHit,
+      truncatedByNodesByCategory: {
+        projects: projectState.nodeLimitHit,
+        libraries: libraryState.nodeLimitHit,
+      },
       truncatedByDepth: depthLimitHit,
       truncatedByReadError: scanErrors.length > 0,
     },

--- a/skills/story/scripts/dashboard-server.mjs
+++ b/skills/story/scripts/dashboard-server.mjs
@@ -362,10 +362,17 @@ export async function scanWorkspace(root) {
   const libraryPaths = libraryRoots.map((entry) => entry.absolutePath);
   const projectRoots = await findProjectRoots(realRoot, libraryPaths, scanErrors);
 
-  // 共享节点预算必须顺序消费：Promise.all 会让“哪本书先抢到剩余预算”取决于文件系统调度，
-  // 同一个工作区刷新两次可能展示不同子树。仍保持写作项目优先于参考档案。
-  const state = { nodes: 0, nodeLimitHit: false, depthLimitHit: false, scanErrors };
-  const buildRoots = async (roots) => {
+  // 写作项目和拆文库是两个独立入口：任一侧文件过多时，只截断自身，
+  // 不能耗尽共享预算后让另一侧看起来像是空的。
+  const createTreeState = () => ({
+    nodes: 0,
+    nodeLimitHit: false,
+    depthLimitHit: false,
+    scanErrors,
+  });
+  const projectState = createTreeState();
+  const libraryState = createTreeState();
+  const buildRoots = async (roots, state) => {
     const trees = [];
     for (const entry of roots) {
       const tree = await buildTreeNode(
@@ -378,8 +385,10 @@ export async function scanWorkspace(root) {
     }
     return trees;
   };
-  const projects = await buildRoots(projectRoots);
-  const libraries = await buildRoots(libraryRoots);
+  const projects = await buildRoots(projectRoots, projectState);
+  const libraries = await buildRoots(libraryRoots, libraryState);
+  const nodeLimitHit = projectState.nodeLimitHit || libraryState.nodeLimitHit;
+  const depthLimitHit = projectState.depthLimitHit || libraryState.depthLimitHit;
 
   libraries.sort(compareTreeEntries);
   projects.sort(compareTreeEntries);
@@ -399,9 +408,9 @@ export async function scanWorkspace(root) {
       maxTreeDepth: MAX_TREE_DEPTH,
       // truncated 仍是前端读的总闸门，但成因要分开报：「文件太多」和「目录套太深」
       // 对作者是两种处置办法，混成一句话等于让人照着错的办法搬文件。
-      truncated: state.nodeLimitHit || state.depthLimitHit || scanErrors.length > 0,
-      truncatedByNodes: state.nodeLimitHit,
-      truncatedByDepth: state.depthLimitHit,
+      truncated: nodeLimitHit || depthLimitHit || scanErrors.length > 0,
+      truncatedByNodes: nodeLimitHit,
+      truncatedByDepth: depthLimitHit,
       truncatedByReadError: scanErrors.length > 0,
     },
   };

--- a/tests/dashboard-server.test.mjs
+++ b/tests/dashboard-server.test.mjs
@@ -76,28 +76,57 @@ async function createDeepWorkspace(nesting = 12) {
   return root;
 }
 
-// 节点预算同样会真的丢文件，用一棵扁平但超量的项目树顶到 MAX_TREE_NODES。
-async function createOversizedWorkspace(fileCount = 5010) {
+// 分别给项目和拆文库造宽目录，验证每类预算互不挤占且总量契约一致。
+async function createOversizedWorkspace(projectFileCount = 5010, libraryFileCount = 0) {
   const root = await mkdtemp(resolve(tmpdir(), "oh-story-dashboard-oversized-"));
   temporaryDirectories.push(root);
   const body = resolve(root, "长篇", "巨书", "正文");
   const library = resolve(root, "拆文库", "盘龙");
+  const libraryChapters = resolve(library, "章节");
   await mkdir(resolve(root, "长篇", "巨书", "大纲"), { recursive: true });
   await mkdir(body, { recursive: true });
-  await mkdir(resolve(library, "章节"), { recursive: true });
+  await mkdir(libraryChapters, { recursive: true });
   await writeFile(resolve(library, "拆文报告.md"), "# 盘龙\n", "utf8");
-  for (let start = 0; start < fileCount; start += 200) {
-    await Promise.all(
-      Array.from({ length: Math.min(200, fileCount - start) }, (_, offset) =>
-        writeFile(
-          resolve(body, `第${String(start + offset + 1).padStart(5, "0")}章.md`),
-          "初稿",
-          "utf8",
+
+  async function writeNumberedFiles(directory, fileCount, prefix) {
+    for (let start = 0; start < fileCount; start += 200) {
+      await Promise.all(
+        Array.from({ length: Math.min(200, fileCount - start) }, (_, offset) =>
+          writeFile(
+            resolve(directory, `${prefix}${String(start + offset + 1).padStart(5, "0")}.md`),
+            "初稿",
+            "utf8",
+          ),
         ),
-      ),
-    );
+      );
+    }
   }
+  await writeNumberedFiles(body, projectFileCount, "第");
+  await writeNumberedFiles(libraryChapters, libraryFileCount, "摘要_");
   return root;
+}
+
+function countTreeNodes(trees) {
+  let count = 0;
+  function visit(node) {
+    count += 1;
+    if (node.type === "directory") node.children.forEach(visit);
+  }
+  trees.forEach(visit);
+  return count;
+}
+
+function countTreeFiles(trees) {
+  let count = 0;
+  function visit(node) {
+    if (node.type === "file") {
+      count += 1;
+      return;
+    }
+    node.children.forEach(visit);
+  }
+  trees.forEach(visit);
+  return count;
 }
 
 async function startServer(root) {
@@ -128,8 +157,15 @@ describe("workspace scanning", () => {
     // 前端要靠这几个字段判断「树是否被截断」，缺一个就会又变成静默漏文件
     assert.equal(workspace.limits.truncated, false);
     assert.equal(workspace.limits.truncatedByNodes, false);
+    assert.deepEqual(workspace.limits.truncatedByNodesByCategory, {
+      projects: false,
+      libraries: false,
+    });
     assert.equal(workspace.limits.truncatedByDepth, false);
-    assert.ok(workspace.limits.maxTreeNodes > 0);
+    assert.equal(
+      workspace.limits.maxTreeNodes,
+      workspace.limits.maxTreeNodesPerCategory * 2,
+    );
     assert.ok(workspace.limits.maxTreeDepth > 0);
   });
 
@@ -167,6 +203,10 @@ describe("workspace scanning", () => {
 
     assert.equal(workspace.limits.truncated, true);
     assert.equal(workspace.limits.truncatedByNodes, true);
+    assert.deepEqual(workspace.limits.truncatedByNodesByCategory, {
+      projects: true,
+      libraries: false,
+    });
     assert.equal(workspace.limits.truncatedByDepth, false);
     assert.ok(workspace.stats.files <= workspace.limits.maxTreeNodes);
     assert.deepEqual(
@@ -174,6 +214,31 @@ describe("workspace scanning", () => {
       ["拆文库/盘龙"],
     );
     assert.match(JSON.stringify(workspace.libraries), /拆文报告\.md/);
+  });
+
+  test("keeps both categories inside independent budgets when both are oversized", async () => {
+    const root = await createOversizedWorkspace(5010, 5010);
+    const workspace = await scanWorkspace(root);
+    const projectNodes = countTreeNodes(workspace.projects);
+    const libraryNodes = countTreeNodes(workspace.libraries);
+
+    assert.deepEqual(workspace.limits.truncatedByNodesByCategory, {
+      projects: true,
+      libraries: true,
+    });
+    assert.equal(workspace.limits.truncatedByNodes, true);
+    assert.equal(workspace.limits.maxTreeNodesPerCategory, 5000);
+    assert.equal(workspace.limits.maxTreeNodes, 10000);
+    assert.ok(projectNodes <= workspace.limits.maxTreeNodesPerCategory);
+    assert.ok(libraryNodes <= workspace.limits.maxTreeNodesPerCategory);
+    assert.ok(projectNodes + libraryNodes <= workspace.limits.maxTreeNodes);
+    assert.ok(workspace.stats.files <= workspace.limits.maxTreeNodes);
+    assert.equal(
+      workspace.stats.files,
+      countTreeFiles(workspace.projects) + countTreeFiles(workspace.libraries),
+    );
+    assert.ok(workspace.projects.length > 0);
+    assert.ok(workspace.libraries.length > 0);
   });
 
   test("ignores infrastructure folders and marks unsupported files read-only", async () => {

--- a/tests/dashboard-server.test.mjs
+++ b/tests/dashboard-server.test.mjs
@@ -81,8 +81,11 @@ async function createOversizedWorkspace(fileCount = 5010) {
   const root = await mkdtemp(resolve(tmpdir(), "oh-story-dashboard-oversized-"));
   temporaryDirectories.push(root);
   const body = resolve(root, "长篇", "巨书", "正文");
+  const library = resolve(root, "拆文库", "盘龙");
   await mkdir(resolve(root, "长篇", "巨书", "大纲"), { recursive: true });
   await mkdir(body, { recursive: true });
+  await mkdir(resolve(library, "章节"), { recursive: true });
+  await writeFile(resolve(library, "拆文报告.md"), "# 盘龙\n", "utf8");
   for (let start = 0; start < fileCount; start += 200) {
     await Promise.all(
       Array.from({ length: Math.min(200, fileCount - start) }, (_, offset) =>
@@ -166,6 +169,11 @@ describe("workspace scanning", () => {
     assert.equal(workspace.limits.truncatedByNodes, true);
     assert.equal(workspace.limits.truncatedByDepth, false);
     assert.ok(workspace.stats.files <= workspace.limits.maxTreeNodes);
+    assert.deepEqual(
+      workspace.libraries.map((entry) => entry.path),
+      ["拆文库/盘龙"],
+    );
+    assert.match(JSON.stringify(workspace.libraries), /拆文报告\.md/);
   });
 
   test("ignores infrastructure folders and marks unsupported files read-only", async () => {

--- a/tests/e2e/dashboard.spec.mjs
+++ b/tests/e2e/dashboard.spec.mjs
@@ -414,7 +414,7 @@ test("文件顶到节点上限时提示的是减量，而不是拍平目录", as
   const created = [];
 
   try {
-    // 比 MAX_TREE_NODES 多出一截，扫描必然在列完之前用光预算
+    // 比单类节点预算多出一截，项目扫描必然在列完之前用光自身预算
     for (let start = 0; start < 5010; start += 200) {
       await Promise.all(
         Array.from({ length: Math.min(200, 5010 - start) }, (_, offset) => {
@@ -426,8 +426,10 @@ test("文件顶到节点上限时提示的是减量，而不是拍平目录", as
     }
 
     await page.goto("/");
-    await expect(page.locator("#treeTruncationNotice")).toContainText("工作区文件太多");
-    await expect(page.locator("#treeTruncationNotice")).toContainText("条上限");
+    await expect(page.locator("#treeTruncationNotice")).toContainText("写作项目文件太多");
+    await expect(page.locator("#treeTruncationNotice")).toContainText(
+      "写作项目和拆文库每类最多列出 5,000 个节点",
+    );
     await expect(page.locator("#treeTruncationNotice")).not.toContainText("有目录套得太深");
     await expect(page.locator("#fileCount")).toContainText("+");
   } finally {


### PR DESCRIPTION
## 问题

Dashboard 扫描工作区时，写作项目与拆文库共用同一份 `MAX_TREE_NODES` 节点预算，并且先扫描写作项目。

当大型写作项目耗尽 5000 个节点后，后续拆文库即使真实存在，也会被返回为空数组。界面因此把“扫描预算已被另一类目录耗尽”误呈现成“拆文库为空”。

## 修复

- 为写作项目与拆文库分别创建扫描状态和节点预算
- 任一分类达到上限时，只截断自身，不再隐藏另一分类
- 保留现有 `limits.truncated*` 响应字段，由两类扫描结果合并生成，避免前端兼容性变化
- 增加超大写作项目与有效拆文库并存的回归用例

5000 节点安全上限仍然保留；本次只改变预算隔离范围，不取消防止超大目录拖垮 Dashboard 的保护。

## 验证

- `npm run test:dashboard`：21/21 通过
- `npm run test:dashboard:e2e`：13/13 通过
- `./scripts/static-check.sh`：13/13 skills 通过
- 使用包含 4977+ 文件的真实写作工作区扫描：2 个写作项目与 2 个拆文库均能返回；大型项目仍正确报告节点截断
