### PR TITLE
fix(hooks): 修 #173 遗留的三处会话起点缺陷

### DIFF
--- a/scripts/check-story-setup-deployment.sh
+++ b/scripts/check-story-setup-deployment.sh
@@ -248,6 +248,11 @@ out_gaps="$(run_from_nested "$root" detect-story-gaps.sh || true)"
 if [ -n "$out_gaps" ] && echo "$out_gaps" | grep -q "$root/nested"; then
   fail "detect-story-gaps leaked nested cwd paths"
 fi
+# 与 session-start 同口径：未完成的要报、已完成的不许报（两边各自读取 拆文库/，需各自钉死）。
+echo "$out_gaps" | grep -q '拆文未完成：拆文库/sample/_progress.md' || fail "detect-story-gaps missed unfinished 拆文"
+if echo "$out_gaps" | grep -q '拆文库/done/_progress.md'; then
+  fail "detect-story-gaps counted completed 拆文 as unfinished"
+fi
 
 fallback_root="$TMP_DIR/git-fallback"
 mkdir -p "$fallback_root/book/追踪" "$fallback_root/book/正文" "$fallback_root/book/大纲"

--- a/scripts/check-story-setup-deployment.sh
+++ b/scripts/check-story-setup-deployment.sh
@@ -226,10 +226,14 @@ cat > "$root/book/追踪/上下文.md" <<'CTX'
 - 章: 第1章
 CTX
 touch "$root/拆文库/sample/_progress.md"
+# 负向 fixture：已拆完的书不得再被报成「未完成」（裸数 _progress.md 会永久误报）。
+mkdir -p "$root/拆文库/done"
+printf '# 深度拆解进度：done\n\n- 最终状态：completed\n- schema_version: 2\n' > "$root/拆文库/done/_progress.md"
 
 out_start="$(run_from_nested "$root" session-start.sh || true)"
 echo "$out_start" | grep -q '当前位置' || fail "session-start did not resolve active book from project root"
 echo "$out_start" | grep -q '未完成拆文' || fail "session-start did not resolve 拆文库 from project root"
+echo "$out_start" | grep -q '有 1 个未完成拆文' || fail "session-start counted completed 拆文 as unfinished"
 if echo "$out_start" | grep -q '参考资料包缺失'; then
   fail "session-start reported missing reference bundle after deployed refs were copied"
 fi

--- a/skills/story-setup/UPGRADING.md
+++ b/skills/story-setup/UPGRADING.md
@@ -52,8 +52,8 @@
 - `_progress.md` 恢复只接受 `schema_version: 2` 与章节边界表，不再执行隐式历史迁移。
 - Codex hooks 升级使用稳定管理身份替换注册；会先移除旧直调 Python 命令与已有 launcher 命令，再写入当前 6 个注册，不会双重执行。
 - 定制 hook 如果调用了已删除的 `discover_book_dir()`，请改为 `discover_active_book()`。当前版不再保留该兼容别名。
-- `拆文库/` 的「未完成拆文」提醒按 `_progress.md` 的「最终状态」过滤：`completed` / `completed_with_errors` 不再计入，会话起点与缺口检测只报真正断在半路的拆解（此前裸数文件，拆完的书会被永久误报）。判定逻辑收在 `lib/common.sh` 的 `analysis_incomplete()` / `discover_incomplete_analyses()`，定制 hook 可直接复用。
-- 被动版本更新提醒的 24h 节流现在管的是提示本身：此前只节流网络请求，缓存里有 latest 时同一个版本每开一次会话都会提醒一次。取不到 GitHub 时写入负缓存，不再每次会话空等 5 秒 curl。
+- `拆文库/` 的「未完成拆文」提醒按 `_progress.md` 的「最终状态」取值过滤：`completed` / `completed_with_errors` 不计入，其余取值与字段缺失、空文件、不可读一律按未完成上报。判定收在 `lib/common.sh` 的 `discover_incomplete_analyses()`。
+- 被动版本更新提醒按 24h 节流提示本身；取不到 GitHub 时写入负缓存，同一窗口内不重复请求。
 
 ## 升级步骤
 
@@ -225,6 +225,8 @@
 - 各分支都要求落在句末断言位，避免吃进条件从句（等这一切结束了，…）、动补（说明得非常清楚）、成语跨匹配（命中注定）、系表（结果是注定的）、及物用法（才结束了这个话题）与场内报幕（宣布…圆满落幕）——这些形状已作为负例 fixture 钉进 `scripts/test-ai-patterns.sh`。
 - 校准（文末 600 字窗口，命中逐条人工复核）：qimao 章中段 20000 章命中 1 处（0.005%）、heiyan 整篇 3999 篇命中 22 处（0.550%，全部是上列禁用形态）；同批既有 `trailer-ending` 分别命中 1.345% / 6.602%。短篇整篇即收口，基线天然高于长篇章中段，故两个总体分别报数。
 - **细纲模板改问落幕动作（#255）**：`story-architect` 细纲模板、`story-long-write` 与 `story-import` 的细纲字段、`rules/story-outline.md` 的必填项描述，「结尾 / 结尾设定」统一从「收束到什么状态」改成「最后落在谁的什么动作、画面或台词上」，规格本身不再是总结句形状。依据是真人语料实测：长篇章末句里，对话收尾约 29%、动作或画面约 26%、疑问或省略号悬停约 6%，明确的状态总结只占约 1%，章末最后一段字数中位 23 字——真实章节多是停在一个具体动作上，并不做收束。
+- **会话起点两处提醒修正（#173）**：`拆文库/` 的「未完成拆文」提醒改按 `_progress.md` 的「最终状态」取值过滤，`completed` / `completed_with_errors` 不再计入——原实现裸数文件，拆完的书每次会话都被报一次；判定收进 `lib/common.sh` 的 `analysis_incomplete()` / `discover_incomplete_analyses()`，`session-start.sh` 与 `detect-story-gaps.sh` 共用。取值只认冒号后的状态本身，模板占位符与 `pending（上次 completed 后重跑）` 这类括注按未完成处理，宁可多报不漏报。
+- **被动版本更新提醒按 24h 节流提示本身（#173）**：原实现只节流网络请求，缓存里有 latest 时同一个版本每开一次会话提醒一次；另外 curl 失败不写缓存，取不到 GitHub 的环境每次会话空等 5 秒且收不到提醒，现改为失败也写时间戳作负缓存。
 - 已部署项目请重新运行 `/story-setup` 刷新 hooks/agents/rules/references；**部署后新开会话**，否则旧会话仍使用 v20 部署，且 agent 模板改动只在会话启动时注册。
 
 ### v20

--- a/skills/story-setup/UPGRADING.md
+++ b/skills/story-setup/UPGRADING.md
@@ -52,6 +52,8 @@
 - `_progress.md` 恢复只接受 `schema_version: 2` 与章节边界表，不再执行隐式历史迁移。
 - Codex hooks 升级使用稳定管理身份替换注册；会先移除旧直调 Python 命令与已有 launcher 命令，再写入当前 6 个注册，不会双重执行。
 - 定制 hook 如果调用了已删除的 `discover_book_dir()`，请改为 `discover_active_book()`。当前版不再保留该兼容别名。
+- `拆文库/` 的「未完成拆文」提醒按 `_progress.md` 的「最终状态」过滤：`completed` / `completed_with_errors` 不再计入，会话起点与缺口检测只报真正断在半路的拆解（此前裸数文件，拆完的书会被永久误报）。判定逻辑收在 `lib/common.sh` 的 `analysis_incomplete()` / `discover_incomplete_analyses()`，定制 hook 可直接复用。
+- 被动版本更新提醒的 24h 节流现在管的是提示本身：此前只节流网络请求，缓存里有 latest 时同一个版本每开一次会话都会提醒一次。取不到 GitHub 时写入负缓存，不再每次会话空等 5 秒 curl。
 
 ## 升级步骤
 

--- a/skills/story-setup/references/templates/hooks/detect-story-gaps.sh
+++ b/skills/story-setup/references/templates/hooks/detect-story-gaps.sh
@@ -98,9 +98,11 @@ done
 # 3. 全局拆文未完成检测（项目级，非书目级）
 GLOBAL_PROGRESS_OUTPUT=""
 if [ -d "$ROOT/拆文库" ]; then
-  while IFS= read -r -d '' progress_file; do
+  # 同 session-start：按「最终状态」过滤，拆完的书不再报（裸数文件会永久误报）。
+  while IFS= read -r progress_file; do
+    [ -n "$progress_file" ] || continue
     GLOBAL_PROGRESS_OUTPUT+="[WARN] 拆文未完成：${progress_file#$ROOT/}，运行 /story-long-analyze 继续。${NL}"
-  done < <(find "$ROOT/拆文库" -name "_progress.md" -print0 2>/dev/null || true)
+  done < <(discover_incomplete_analyses "$ROOT")
 fi
 if [ -n "$GLOBAL_PROGRESS_OUTPUT" ]; then
   OUTPUT+="$GLOBAL_PROGRESS_OUTPUT"

--- a/skills/story-setup/references/templates/hooks/lib/common.sh
+++ b/skills/story-setup/references/templates/hooks/lib/common.sh
@@ -64,6 +64,35 @@ discover_active_book() {
   fi
 }
 
+# analysis_incomplete <_progress.md 路径> — 判断一份拆文进度是否仍未完成（返回 0 表示未完成）
+# 判据取「最终状态」字段：completed / completed_with_errors 视为已完成，其余状态
+# （pending / paused_after_stage1）以及字段缺失、文件为空、读取失败一律按未完成处理——
+# 宁可多提醒一次，也不让真断在半路的拆文静默消失（空文件正是管道刚起步就被打断的形态）。
+# LC_ALL=C 下全角冒号按字节匹配，故写成 (：|:) 而非字符组 [：:]：字符组会把全角标点按字节拆开。
+analysis_incomplete() {
+  local status
+  status=$(LC_ALL=C grep -m1 -E '最终状态(：|:)' "$1" 2>/dev/null || true)
+  [ -n "$status" ] || return 0
+  case "$status" in
+    *completed*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+# discover_incomplete_analyses <项目根> — 列出 拆文库/ 下仍未完成的 _progress.md
+# 输出：换行分隔的绝对路径（与 discover_all_books 同口径）。拆文库不存在时输出空。
+discover_incomplete_analyses() {
+  local root="$1"
+  [ -d "$root/拆文库" ] || return 0
+  { find "$root/拆文库" -name "_progress.md" -print 2>/dev/null || true; } | while IFS= read -r progress_file; do
+    [ -n "$progress_file" ] || continue
+    if analysis_incomplete "$progress_file"; then printf '%s\n' "$progress_file"; fi
+  done
+  # 显式收 0：循环体最后一次判定若落在「已完成」上，while 会把 1 带出来，调用方
+  # 一旦开了 pipefail（各 hook 都开）就会被 set -e 打断。用 if 包住 + return 0 双保险。
+  return 0
+}
+
 # discover_all_books — 多本书查询（项目内所有书目）
 # 输出：换行分隔的绝对目录路径列表（不含重复）。
 # 使用场景：detect-story-gaps —— 需要遍历项目内所有书目做缺口检测。

--- a/skills/story-setup/references/templates/hooks/lib/common.sh
+++ b/skills/story-setup/references/templates/hooks/lib/common.sh
@@ -70,11 +70,20 @@ discover_active_book() {
 # 宁可多提醒一次，也不让真断在半路的拆文静默消失（空文件正是管道刚起步就被打断的形态）。
 # LC_ALL=C 下全角冒号按字节匹配，故写成 (：|:) 而非字符组 [：:]：字符组会把全角标点按字节拆开。
 analysis_incomplete() {
-  local status
-  status=$(LC_ALL=C grep -m1 -E '最终状态(：|:)' "$1" 2>/dev/null || true)
-  [ -n "$status" ] || return 0
-  case "$status" in
-    *completed*) return 1 ;;
+  local value
+  # 只认冒号后的状态值本身：拿整行做 *completed* 子串判断，会把模板占位符
+  # `{pending/paused_after_stage1/completed/completed_with_errors}` 和
+  # `pending（上次 completed 后重跑）` 这类括注误判成已完成，把真断在半路的拆文静默抹掉。
+  #
+  # 全角字符只许出现在 LC_ALL=C grep 的单引号模式里，绝不能进参数扩展或 case 模式：
+  # GBK 区域下 bash 按双字节解码脚本源码，全角冒号的尾字节会和紧邻的 `}` 配成一个字符、
+  # 把右花括号吃掉，`${x#*：}` 这种写法会让整个 common.sh 语法错误、所有 hook 一起哑掉。
+  # 字符组同理（[：:] 会被按字节拆开），故用 (：|:) 交替。
+  value=$(LC_ALL=C grep -m1 -oE '最终状态(：|:)[[:space:]]*[A-Za-z_]+' "$1" 2>/dev/null \
+    | LC_ALL=C grep -oE '[A-Za-z_]+$' || true)
+  [ -n "$value" ] || return 0
+  case "$value" in
+    completed|completed_with_errors) return 1 ;;
     *) return 0 ;;
   esac
 }

--- a/skills/story-setup/references/templates/hooks/session-start.sh
+++ b/skills/story-setup/references/templates/hooks/session-start.sh
@@ -129,7 +129,8 @@ fi
 if [ -d "$ROOT/拆文库" ]; then
   # 同上：子目录不可读时 find 退 1，pipefail 把它变成整条管道的退出码，set -e 就在这里
   # 终止脚本、一个字节都不输出。`|| true` + 数字兜底保证只是这一项降级、其余提示照常送达。
-  PROGRESS_COUNT=$(find "$ROOT/拆文库" -name "_progress.md" 2>/dev/null | wc -l | tr -d ' ' || true)
+  # 只数「最终状态」不是 completed 的那些：裸数 _progress.md 会把拆完的书永久报成未完成。
+  PROGRESS_COUNT=$(discover_incomplete_analyses "$ROOT" | wc -l | tr -d ' ' || true)
   case "$PROGRESS_COUNT" in ''|*[!0-9]*) PROGRESS_COUNT=0 ;; esac
   if [ "$PROGRESS_COUNT" -gt 0 ]; then
     OUTPUT+="[INFO] 拆文库/ 中有 $PROGRESS_COUNT 个未完成拆文。运行 /story-long-analyze 或 /story-short-analyze。${NL}"
@@ -155,11 +156,18 @@ story_update_check() {
     latest=$(sed -n '2p' "$cache" 2>/dev/null || echo "")
   fi
   case "$last" in ''|*[!0-9]*) last=0;; esac
-  if [ "$((now - last))" -ge 86400 ] || [ -z "$latest" ]; then
+  local checked=0
+  if [ "$((now - last))" -ge 86400 ]; then
+    checked=1
     latest=$(curl -fsS --max-time 5 "https://api.github.com/repos/worldwonderer/oh-story-claudecode/releases/latest" 2>/dev/null \
       | grep -o '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | grep -o '[0-9][0-9.]*' | head -1) || latest=""
-    [ -n "$latest" ] && printf '%s\n%s\n' "$now" "$latest" > "$cache" 2>/dev/null || true
+    # 成功失败都写时间戳：失败时 latest 留空当负缓存，否则取不到 GitHub 的环境每次开会话
+    # 都要白等 5 秒 curl，且永远等不到提醒。
+    printf '%s\n%s\n' "$now" "$latest" > "$cache" 2>/dev/null || true
   fi
+  # 提示本身也要节流：缓存里的 latest 会一直有值，若不看 checked，同一个版本每开一次会话
+  # 就提醒一次，与「每 24h 至多一次」的承诺不符（原实现只节流了网络请求）。
+  [ "$checked" -eq 1 ] || return 0
   [ -n "$latest" ] || return 0
   if [ "$latest" != "$cur" ] && [ "$(printf '%s\n%s\n' "$cur" "$latest" | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)" = "$latest" ]; then
     OUTPUT+="[INFO] 网文工具箱有新版本 v${latest}（当前 v${cur}）。更新：npx skills add worldwonderer/oh-story-claudecode -y -g 后重跑 /story-setup；或对 /story 说“检查更新”。关掉提醒：export STORY_NO_UPDATE_CHECK=1${NL}"

--- a/skills/story/SKILL.md
+++ b/skills/story/SKILL.md
@@ -21,6 +21,7 @@ metadata: {"openclaw":{"source":"https://github.com/worldwonderer/oh-story-claud
 | 选题决策 | 写什么能爆、帮我选题、选题方向 | `/story-long-scan` |
 | 短篇扫榜 | 短篇排行、知乎盐言排行 | `/story-short-scan` |
 | 去 AI 味 | 去 AI 味、太 AI、去味 | `/story-deslop` |
+| 审查稿件 | 审查、审稿、帮我审一下、一致性检查、看看有没有问题 | `/story-review` |
 | 封面 | 封面、封面图 | `/story-cover` |
 | 环境部署 | 准备写书、搭环境、初始化 | `/story-setup` |
 | 浏览器操控 | 浏览器、抓取、登录态 | `/browser-cdp` |


### PR DESCRIPTION
审计 issue #173 各条承诺的落地情况时，发现三处与该 issue 直接相关、可确定性复现的缺陷。都是小改动，逐条附实测。

## 1. 已拆完的书被永久报成「未完成拆文」

`session-start.sh` 与 `detect-story-gaps.sh` 都只 `find -name _progress.md` 计数，从不读「最终状态」。仓库自带的 `demo/拆文库/盘龙/_progress.md` 标了 `最终状态：completed`，照样每次会话被计入。

现按最终状态过滤：`completed` / `completed_with_errors` 不计；其余（`pending`、`paused_after_stage1`、字段缺失、空文件）仍按未完成报——空文件正是管道刚起步就被打断的形态，不能漏。判定收进 `lib/common.sh` 的 `analysis_incomplete()` / `discover_incomplete_analyses()`，两个调用点共用一份实现。

实测（同一 fixture：1 个空 + 1 个 completed）：

```
OLD: 有 2 个未完成拆文
NEW: 有 1 个未完成拆文
```

## 2. 版本更新提醒每次会话都打

24h 节流只包住了 curl；末尾的 `[INFO]` 分支在 `$latest` 非空时无条件执行，而 `$latest` 来自缓存——于是同一个版本每开一次会话提醒一次，与代码注释承诺的「每 24h 至多一次」不符。

另外原实现只在 curl 成功时写缓存，取不到 GitHub 的环境每次会话白等 5 秒且永远收不到提醒。改为成功失败都写时间戳，失败时留空 `latest` 作负缓存。

实测（VERSION 置为 0.0.1，隔离 HOME，连开 3 次会话）：

```
OLD: 1 1 1
NEW: 1 0 0
```

## 3. `/story` 路由表漏 story-review

13 个 skill 里唯一没有路由行的一个，「一个口子进」对审查不成立。补一行。

## 回归

`check-story-setup-deployment.sh` TS4 加负向 fixture：`最终状态：completed` 的书不得计入，断言 `有 1 个未完成拆文`。该断言在旧实现下会失败（旧实现输出「有 2 个」）。

## 版本

不 bump `agents_version`：本发布周期已从 20 升到 21，按约定同周期不再 +1，改动随 21 下发。UPGRADING 的 v21 契约段补两条行为说明。

Related: #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U6ECjHwsyA3yUa4UUaHkcc