### PR TITLE
feat: 新增 Atlas Cloud 封面生成支持

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,10 @@
   "private": true,
   "scripts": {
     "dashboard": "node skills/story/scripts/dashboard-server.mjs",
+    "test:story-cover": "node --test skills/story-cover/scripts/atlas-image.test.mjs",
     "test:dashboard": "node --test tests/dashboard-server.test.mjs tests/dashboard-trigger-contract.test.mjs",
     "test:dashboard:e2e": "playwright test",
-    "test": "npm run test:dashboard && npm run test:dashboard:e2e"
+    "test": "npm run test:story-cover && npm run test:dashboard && npm run test:dashboard:e2e"
   },
   "devDependencies": {
     "@playwright/test": "^1.62.0"

--- a/skills/story-cover/SKILL.md
+++ b/skills/story-cover/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: story-cover
 version: 1.0.0
-description: "小说封面生成。根据书名、作者名自动分析题材风格，调用 GPT-Image-2 直接生成含标题和署名的专业级网文封面。触发方式：/story-cover、/封面、「帮我做个封面」「生成封面图」「做个小说封面」「封面设计」。"
-metadata: {"openclaw":{"requires":{"env":["GPT_IMAGE_API_KEY"],"bins":["curl","jq","base64"]},"primaryEnv":"GPT_IMAGE_API_KEY","source":"https://github.com/worldwonderer/oh-story-claudecode"}}
+description: "小说封面生成。根据书名、作者名自动分析题材风格，通过 GPT-Image-2 或 Atlas Cloud 生成含标题和署名的专业级网文封面。触发方式：/story-cover、/封面、「帮我做个封面」「生成封面图」「做个小说封面」「封面设计」。"
+metadata: {"openclaw":{"requires":{"bins":["curl","jq","base64","node"]},"source":"https://github.com/worldwonderer/oh-story-claudecode"}}
 ---
 # story-cover：小说封面生成
 
-你是小说封面设计师。根据书名和题材，调用 GPT-Image-2 一次性生成包含书名和作者名的完整封面。
+你是小说封面设计师。根据书名和题材，通过 GPT-Image-2 或 Atlas Cloud 一次性生成包含书名和作者名的完整封面。
 
 **核心原则：封面是读者的第一印象，一眼传达题材和氛围。**
 
@@ -16,10 +16,15 @@ metadata: {"openclaw":{"requires":{"env":["GPT_IMAGE_API_KEY"],"bins":["curl","j
 
 | 变量 | 必填 | 默认 | 说明 |
 |:-----|:----:|:-----|:-----|
-| `GPT_IMAGE_API_KEY` | ✅ | — | OpenAI 或兼容代理的 API Key |
+| `COVER_IMAGE_PROVIDER` | | `gpt-image` | `gpt-image` 或 `atlas` |
+| `GPT_IMAGE_API_KEY` | 选一 | — | `gpt-image` provider 的 API Key |
 | `GPT_IMAGE_BASE_URL` | | `https://api.openai.com/v1` | 兼容代理时改这个 |
 | `GPT_IMAGE_MODEL` | | `gpt-image-2` | 仅在测试新模型时覆盖 |
 | `GPT_IMAGE_SIZE` | | `1024x1536` | 目标比例提示（番茄 3:4→`768x1024`，默认 2:3→`1024x1536`）。官方 gpt-image-2 认任意 16 倍数尺寸（比例≤3:1），但**很多中转代理会忽略 size、按预设返回约 2:3**（已实测）——平台尺寸不靠它，由「导出平台上传尺寸」步骤兜底 |
+| `ATLASCLOUD_API_KEY` | 选一 | — | `atlas` provider 的 Atlas Cloud API Key |
+| `ATLASCLOUD_API_BASE_URL` | | `https://api.atlascloud.ai/api/v1` | Atlas Cloud 媒体生成 API；仅在代理或私有网关场景覆盖 |
+| `ATLASCLOUD_IMAGE_MODEL` | | `bytedance/seedream-v5.0-lite` | Atlas Cloud 图片模型 ID |
+| `ATLASCLOUD_IMAGE_SIZE` | | `1664*2496` | Atlas 输出尺寸；番茄 3:4 用 `2592*3456`，默认 2:3 用 `1664*2496` |
 | `UPLOAD_SIZE` | | — | 平台固定上传像素（番茄 `600x800`）；设置后由「导出平台上传尺寸」步骤居中裁剪+缩放出上传版（不变形、不依赖出图尺寸） |
 | `BOOK_DIR` | ✅ | — | 输出目录，建议 `./covers/<书名>` |
 | `REF_IMAGE` | | — | 参考图本地路径或 URL；设置后走 `images/edits` 图生图 |
@@ -37,10 +42,10 @@ metadata: {"openclaw":{"requires":{"env":["GPT_IMAGE_API_KEY"],"bins":["curl","j
 
 **按目标平台定封面尺寸**：番茄上传 600×800 是 **3:4**（不是 2:3），出图比例不对、平台二次裁剪就会切掉书名/笔名。
 
-| 平台 | 上传尺寸 | 比例 | 生成 `GPT_IMAGE_SIZE`（尽量） |
-|:-----|:--------|:-----|:-------------------|
-| 番茄小说 | 600×800 | 3:4 | `768x1024` |
-| 其他平台（默认竖版） | 按平台规格 | 2:3 | `1024x1536` |
+| 平台 | 上传尺寸 | 比例 | `GPT_IMAGE_SIZE`（尽量） | `ATLASCLOUD_IMAGE_SIZE` |
+|:-----|:--------|:-----|:------------------------|:------------------------|
+| 番茄小说 | 600×800 | 3:4 | `768x1024` | `2592*3456` |
+| 其他平台（默认竖版） | 按平台规格 | 2:3 | `1024x1536` | `1664*2496` |
 
 `export GPT_IMAGE_SIZE` 给目标比例（官方按它出图，很多代理会忽略、返回约 2:3）；平台有固定上传像素再 `export UPLOAD_SIZE`（番茄 `600x800`）。**平台尺寸最终由「导出平台上传尺寸」步骤居中裁剪+缩放保证，不依赖代理认不认 size。** 平台与题材风格见 [references/cover-styles.md](references/cover-styles.md)。
 
@@ -138,6 +143,43 @@ Professional book cover, high detail digital painting, portrait [平台比例：
 - 用 `digital painting style` 而非 `photo`，避免真人照片感
 
 ### Step 4：调用 API 并保存
+
+先读取 `COVER_IMAGE_PROVIDER`。默认 `gpt-image` 保持原流程；显式设为 `atlas` 时使用 Atlas Cloud 异步图片生成。两个 provider 只需配置对应的一把 API Key。
+
+#### Atlas Cloud 文生图
+
+Atlas Cloud 路径使用 `bytedance/seedream-v5.0-lite`，该模型擅长海报排版和多语言文字渲染。当前 preset 只处理文生图；设置了 `REF_IMAGE` 时继续使用下方 GPT-Image 图生图流程，不能静默忽略参考图。
+
+```bash
+set -euo pipefail
+[ "${COVER_IMAGE_PROVIDER:-gpt-image}" = "atlas" ] || { echo "当前 provider 不是 atlas" >&2; exit 1; }
+: "${ATLASCLOUD_API_KEY:?请设置 export ATLASCLOUD_API_KEY=你的key}"
+: "${PROMPT:?请先 export PROMPT=构建提示词步骤拼好的完整提示词}"
+: "${BOOK_DIR:?请先 export BOOK_DIR=./covers/<书名>}"
+[ -z "${REF_IMAGE:-}" ] || { echo "Atlas Cloud 当前 preset 仅支持文生图；有参考图时请使用 gpt-image provider" >&2; exit 1; }
+
+mkdir -p "$BOOK_DIR/封面"
+i=1
+while [ -f "$BOOK_DIR/封面/封面_v${i}.png" ]; do i=$((i+1)); done
+OUT="$BOOK_DIR/封面/封面_v${i}.png"
+
+# ATLAS_SCRIPT 是当前 story-cover skill 目录下 scripts/atlas-image.mjs 的绝对路径。
+ATLAS_SCRIPT="${ATLAS_SCRIPT:?请设置为 story-cover/scripts/atlas-image.mjs 的绝对路径}"
+node "$ATLAS_SCRIPT" \
+  --prompt "$PROMPT" \
+  --output "$OUT" \
+  --model "${ATLASCLOUD_IMAGE_MODEL:-bytedance/seedream-v5.0-lite}" \
+  --size "${ATLASCLOUD_IMAGE_SIZE:-1664*2496}"
+
+file "$OUT"
+ls -lt "$BOOK_DIR/封面/"
+```
+
+客户端会提交任务、轮询到 `completed`/`succeeded`、下载结果并校验 PNG/JPEG 文件签名；API 错误、失败状态和三分钟超时都会非零退出，不会留下伪图片。
+
+#### GPT-Image 文生图 / 图生图
+
+仅当 `COVER_IMAGE_PROVIDER=gpt-image`（默认值）时执行本节；Atlas Cloud 生成成功后直接进入 Step 5。
 
 `gpt-image-2` 始终返回 base64，请求体不要带 `response_format`（旧 DALL-E 参数，gpt-image 系列不支持）。`$PROMPT` 为「构建提示词」步骤拼出的完整提示词。
 

--- a/skills/story-cover/scripts/atlas-image.mjs
+++ b/skills/story-cover/scripts/atlas-image.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+
+const DEFAULT_BASE_URL = "https://api.atlascloud.ai/api/v1";
+const DEFAULT_MODEL = "bytedance/seedream-v5.0-lite";
+const DEFAULT_SIZE = "1664*2496";
+const DEFAULT_SUBMIT_PATH = "model/generateVideo";
+const DEFAULT_RESULT_PATH = "model/result";
+
+function parseArgs(argv) {
+  const values = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith("--") || value === undefined) {
+      throw new Error(`invalid argument: ${key ?? ""}`);
+    }
+    values[key.slice(2)] = value;
+  }
+  return values;
+}
+
+function unwrap(payload) {
+  return payload?.data && typeof payload.data === "object" ? payload.data : payload;
+}
+
+function apiError(payload) {
+  if (payload?.error) {
+    return typeof payload.error === "string"
+      ? payload.error
+      : payload.error.message || JSON.stringify(payload.error);
+  }
+  if (payload?.code !== undefined && ![0, 200].includes(payload.code)) {
+    return payload.message || `Atlas Cloud API returned code ${payload.code}`;
+  }
+  return null;
+}
+
+async function readJson(response, stage) {
+  const text = await response.text();
+  let payload;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    throw new Error(`${stage} returned non-JSON response (HTTP ${response.status})`);
+  }
+
+  const error = apiError(payload);
+  if (!response.ok || error) {
+    throw new Error(`${stage} failed: ${error || `HTTP ${response.status}`}`);
+  }
+  return payload;
+}
+
+function joinUrl(baseUrl, path) {
+  return `${baseUrl.replace(/\/$/, "")}/${path.replace(/^\//, "")}`;
+}
+
+function outputUrl(payload) {
+  const data = unwrap(payload);
+  const outputs = data?.outputs ?? data?.output;
+  if (Array.isArray(outputs)) return outputs.find(Boolean);
+  return typeof outputs === "string" ? outputs : undefined;
+}
+
+function isImage(bytes) {
+  const png =
+    bytes.length >= 8 &&
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47;
+  const jpeg = bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff;
+  return png || jpeg;
+}
+
+const sleep = (milliseconds) => new Promise((resolvePromise) => setTimeout(resolvePromise, milliseconds));
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const prompt = args.prompt?.trim();
+  const output = args.output ? resolve(args.output) : "";
+  const apiKey = process.env.ATLASCLOUD_API_KEY;
+
+  if (!apiKey) throw new Error("ATLASCLOUD_API_KEY is required");
+  if (!prompt) throw new Error("--prompt is required");
+  if (!output) throw new Error("--output is required");
+
+  const baseUrl = process.env.ATLASCLOUD_API_BASE_URL || DEFAULT_BASE_URL;
+  const model = args.model || process.env.ATLASCLOUD_IMAGE_MODEL || DEFAULT_MODEL;
+  const size = args.size || process.env.ATLASCLOUD_IMAGE_SIZE || DEFAULT_SIZE;
+  const submitPath = process.env.ATLASCLOUD_IMAGE_SUBMIT_PATH || DEFAULT_SUBMIT_PATH;
+  const resultPath = process.env.ATLASCLOUD_IMAGE_RESULT_PATH || DEFAULT_RESULT_PATH;
+  const pollInterval = Number(process.env.ATLASCLOUD_POLL_INTERVAL_MS || 3000);
+  const timeout = Number(process.env.ATLASCLOUD_TIMEOUT_MS || 180000);
+
+  const submitResponse = await fetch(joinUrl(baseUrl, submitPath), {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ model, prompt, size, output_format: "png" }),
+  });
+  const submitted = await readJson(submitResponse, "image submission");
+  const predictionId = unwrap(submitted)?.id;
+  if (!predictionId) throw new Error("image submission did not return a prediction id");
+
+  const deadline = Date.now() + timeout;
+  let imageUrl;
+  while (Date.now() < deadline) {
+    const resultResponse = await fetch(joinUrl(baseUrl, `${resultPath}/${encodeURIComponent(predictionId)}`), {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    const result = await readJson(resultResponse, "prediction polling");
+    const status = String(unwrap(result)?.status || "").toLowerCase();
+    if (["completed", "succeeded"].includes(status)) {
+      imageUrl = outputUrl(result);
+      if (!imageUrl) throw new Error("completed prediction did not return an output URL");
+      break;
+    }
+    if (["failed", "canceled", "cancelled"].includes(status)) {
+      throw new Error(`prediction ${predictionId} ended with status ${status}`);
+    }
+    await sleep(pollInterval);
+  }
+  if (!imageUrl) throw new Error(`prediction ${predictionId} timed out after ${timeout}ms`);
+
+  const imageResponse = await fetch(imageUrl);
+  if (!imageResponse.ok) throw new Error(`image download failed: HTTP ${imageResponse.status}`);
+  const bytes = new Uint8Array(await imageResponse.arrayBuffer());
+  if (!isImage(bytes)) throw new Error("downloaded output is not a PNG or JPEG image");
+
+  await mkdir(dirname(output), { recursive: true });
+  await writeFile(output, bytes);
+  await writeFile(`${output.replace(/\.[^.]+$/, "")}.prompt.txt`, `${prompt}\n`, "utf8");
+  process.stdout.write(`${output}\n`);
+}
+
+main().catch((error) => {
+  process.stderr.write(`Atlas Cloud cover generation failed: ${error.message}\n`);
+  process.exitCode = 1;
+});

--- a/skills/story-cover/scripts/atlas-image.test.mjs
+++ b/skills/story-cover/scripts/atlas-image.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import http from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawn } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const script = fileURLToPath(new URL("./atlas-image.mjs", import.meta.url));
+const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+function run(args, env) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [script, ...args], {
+      env: { ...process.env, ...env },
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => (stdout += chunk));
+    child.stderr.on("data", (chunk) => (stderr += chunk));
+    child.on("close", (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+test("submits, polls, and downloads an Atlas Cloud cover", async (t) => {
+  let polls = 0;
+  let submittedBody;
+  const server = http.createServer(async (request, response) => {
+    if (request.method === "POST" && request.url === "/api/v1/model/generateVideo") {
+      let body = "";
+      for await (const chunk of request) body += chunk;
+      submittedBody = JSON.parse(body);
+      assert.equal(request.headers.authorization, "Bearer test-key");
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({ code: 200, data: { id: "prediction-1", status: "created" } }));
+      return;
+    }
+    if (request.url === "/api/v1/model/result/prediction-1") {
+      polls += 1;
+      response.setHeader("content-type", "application/json");
+      response.end(
+        JSON.stringify(
+          polls === 1
+            ? { id: "prediction-1", status: "processing", outputs: [] }
+            : { data: { id: "prediction-1", status: "completed", outputs: [`${baseUrl}/cover.png`] } },
+        ),
+      );
+      return;
+    }
+    if (request.url === "/cover.png") {
+      response.setHeader("content-type", "image/png");
+      response.end(png);
+      return;
+    }
+    response.writeHead(404).end();
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(() => server.close());
+  const address = server.address();
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+  const directory = await mkdtemp(join(tmpdir(), "atlas-cover-"));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const output = join(directory, "cover.png");
+
+  const result = await run(["--prompt", "Chinese novel cover", "--output", output, "--size", "2592*3456"], {
+    ATLASCLOUD_API_KEY: "test-key",
+    ATLASCLOUD_API_BASE_URL: `${baseUrl}/api/v1`,
+    ATLASCLOUD_POLL_INTERVAL_MS: "1",
+  });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.deepEqual(submittedBody, {
+    model: "bytedance/seedream-v5.0-lite",
+    prompt: "Chinese novel cover",
+    size: "2592*3456",
+    output_format: "png",
+  });
+  assert.deepEqual(await readFile(output), png);
+  assert.equal(await readFile(join(directory, "cover.prompt.txt"), "utf8"), "Chinese novel cover\n");
+  assert.equal(polls, 2);
+});
+
+test("fails before making a request when the API key is missing", async () => {
+  const result = await run(["--prompt", "cover", "--output", "/tmp/unused.png"], {
+    ATLASCLOUD_API_KEY: "",
+  });
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /ATLASCLOUD_API_KEY is required/);
+});

--- a/skills/story-setup/references/openclaw/AGENTS.md.tmpl
+++ b/skills/story-setup/references/openclaw/AGENTS.md.tmpl
@@ -15,7 +15,7 @@ OpenClaw 会从项目 `skills/` 目录发现 `SKILL.md`。优先通过 OpenClaw 
 | `/skill story-long-scan`、长篇扫榜 | story-long-scan | 长篇小说榜单与市场趋势 |
 | `/skill story-short-scan`、短篇扫榜 | story-short-scan | 短篇小说榜单与情绪风口 |
 | `/skill story-deslop`、去 AI 味 | story-deslop | 去除 AI 写作痕迹 |
-| `/skill story-cover`、封面 | story-cover | 生成封面图；需要 `GPT_IMAGE_API_KEY` |
+| `/skill story-cover`、封面 | story-cover | 生成封面图；需要所选 provider 的 API Key |
 | `/skill story-review`、审查 | story-review | 多视角审查；OpenClaw Phase 1 默认 solo/soft-fallback |
 | `/skill story-import`、导入 | story-import | 逆向导入已有小说到项目结构 |
 | `/skill story`、网文 | story | 工具箱路由 · 模糊意图自动分发 |
@@ -27,7 +27,7 @@ OpenClaw 会从项目 `skills/` 目录发现 `SKILL.md`。优先通过 OpenClaw 
 - Phase 1 只部署 skills：`skills/*/SKILL.md` 使用 OpenClaw 兼容 frontmatter（`name` / `description` 单行，`metadata` 单行 JSON）。
 - 暂不部署 OpenClaw agents/hooks：写正文前大纲守卫、commit 提醒、session/compact 自动注入在 OpenClaw 下不是硬拦截，只作为 skill 内软约束执行。
 - OpenClaw 会在 session 启动时 snapshot eligible skills；部署或更新后如未立即出现，请新开 OpenClaw session，或等待 skills watcher 刷新。
-- `story-cover` 依赖 `GPT_IMAGE_API_KEY`，未配置时 OpenClaw 会将该 skill 标记为不可用/缺少 env。
+- `story-cover` 使用 `COVER_IMAGE_PROVIDER=gpt-image|atlas` 选择 provider，并在运行时校验对应的 `GPT_IMAGE_API_KEY` 或 `ATLASCLOUD_API_KEY`。
 
 ## 文件结构
 

--- a/skills/story-setup/references/reasonix/AGENTS.md.tmpl
+++ b/skills/story-setup/references/reasonix/AGENTS.md.tmpl
@@ -15,7 +15,7 @@ Reasonix 会从项目 `.agents/skills`（部署时创建的指向 `skills/` 的 
 | 长篇扫榜 | story-long-scan | 长篇小说榜单与市场趋势 |
 | 短篇扫榜 | story-short-scan | 短篇小说榜单与情绪风口 |
 | 去 AI 味 | story-deslop | 去除 AI 写作痕迹 |
-| 封面 | story-cover | 生成封面图；需要 `GPT_IMAGE_API_KEY` |
+| 封面 | story-cover | 生成封面图；需要所选 provider 的 API Key |
 | 审查 | story-review | 多视角审查；Reasonix 默认 solo/direct fallback |
 | 导入 | story-import | 逆向导入已有小说到项目结构 |
 | 网文工具箱 | story | 模糊意图自动分发 |
@@ -28,7 +28,7 @@ Reasonix 会从项目 `.agents/skills`（部署时创建的指向 `skills/` 的 
 - 暂不部署 Reasonix hooks/custom agents：写正文前大纲守卫、commit 提醒、session/compact 自动注入在 Reasonix 下不是硬拦截，只作为 skill 内软约束执行。
 - 涉及专业 Agent 的 Skill（story-review 多视角、story-long-write 的 narrative-writer/story-architect 等）按 solo/direct fallback 执行，并在结果里说明降级。
 - Windows 未启用 symlink 时改走根 `reasonix-plugin.json` 原生 plugin 安装。
-- `story-cover` 依赖 `GPT_IMAGE_API_KEY`，未配置时该 skill 不可用。
+- `story-cover` 使用 `COVER_IMAGE_PROVIDER=gpt-image|atlas` 选择 provider，并在运行时校验对应的 `GPT_IMAGE_API_KEY` 或 `ATLASCLOUD_API_KEY`。
 
 ## 文件结构
 


### PR DESCRIPTION
## 变更\n\n- 为  增加显式  provider，同时保留现有  默认路径\n- 新增无依赖 Node 客户端，完成 Atlas Cloud 异步提交、轮询、结果下载与 PNG/JPEG 文件签名校验\n- 默认使用 ，并提供 2:3 与番茄 3:4 尺寸配置\n- 更新 OpenClaw/Reasonix 的 provider key 说明，并增加提交/轮询协议测试\n\n## 验证\n\n- 
> test:story-cover
> node --test skills/story-cover/scripts/atlas-image.test.mjs

✔ submits, polls, and downloads an Atlas Cloud cover (62.493ms)
✔ fails before making a request when the API key is missing (19.493125ms)
ℹ tests 2
ℹ suites 0
ℹ pass 2
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 118.805041：2 passed\n- 
> test:dashboard
> node --test tests/dashboard-server.test.mjs tests/dashboard-trigger-contract.test.mjs

▶ workspace scanning
  ✔ recognizes standard long and short projects without treating loose files or libraries as projects (10.340084ms)
  ✔ does not use symlinked short-story marker files (3.083791ms)
  ✔ uses a stable dot path when the workspace itself is a short-story project (1.638625ms)
  ✔ discovers roots without recursively serializing every manuscript (0.810125ms)
  ✔ loads only one directory level and keeps infrastructure folders hidden (3.894584ms)
  ✔ paginates a wide directory without dropping or duplicating files (22.371791ms)
  ✔ searches unloaded descendants on demand and respects the active collection (4.965125ms)
  ✔ continues searching later projects after one subtree exceeds the depth limit (6.55425ms)
  ✔ reports result-limit and node-budget truncation independently (507.917ms)
  ✔ marks search results incomplete when an unloaded descendant is unreadable (18.984125ms)
✔ workspace scanning (581.17775ms)
▶ path boundary
  ✔ rejects traversal and absolute paths (3.342208ms)
  ✔ does not follow file symlinks (2.651ms)
✔ path boundary (6.055875ms)
▶ CLI portability
  ✔ uses each operating system's default-browser command (0.066042ms)
  ✔ recognizes the CLI entrypoint through a symlinked install path (3.031041ms)
✔ CLI portability (3.14375ms)
▶ HTTP API
  ✔ serves lazy roots, directory pages, and on-demand search (7.911084ms)
  ✔ loads and atomically saves an editable file (6.846459ms)
  ✔ returns 409 instead of overwriting an externally changed file (24.829ms)
  ✔ deletes an unchanged editable file but rejects cross-origin deletion (5.035208ms)
  ✔ does not delete a file changed after it was opened (25.373792ms)
  ✔ accepts only one of several simultaneous saves based on the same version (8.10525ms)
  ✔ serializes simultaneous save and delete operations on the same version (5.149958ms)
  ✔ rejects unsupported files, traversal, and malformed JSON (4.356375ms)
  ✔ keeps the saved file's permission bits instead of letting umask narrow them (4.150833ms)
  ✔ still serves the rest of the workspace when one library directory is unreadable (3.495333ms)
  ✔ reports an actionable error when the workspace root itself is unreadable (2.8415ms)
✔ HTTP API (98.291ms)
✔ story skill exposes the platform-specific dashboard triggers (1.587375ms)
✔ Claude Code marketplace exposes story while Codex uses the canonical skill bundle (1.520625ms)
ℹ tests 27
ℹ suites 4
ℹ pass 27
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 727.661166：27 passed\n- Skill Static Check
==================
Repo: /Users/zby/Documents/提pr/triage-20260803-1341/oh-story-claudecode

--- browser-cdp ---
  [PASS] structured frontmatter, links, anchors, agents, and references
  Result: PASS

--- story ---
  [PASS] structured frontmatter, links, anchors, agents, and references
  Result: PASS

--- story-cover ---
  [PASS] structured frontmatter, links, anchors, agents, and references
  Result: PASS

--- story-deslop ---
  [PASS] structured frontmatter, links, anchors, agents, and references
  Result: PASS

--- story-import ---
  [PASS] structured frontmatter, links, anchors, agents, and references
  Result: PASS

--- story-long-analyze ---
  [PASS] structured frontmatter, links, anchors, agents, and references
  Result: PASS

--- story-long-scan ---
  [PASS] structured frontmatter, links, anchors, agents, and references
  Result: PASS

--- story-long-write ---
  [PASS] structured frontmatter, links, anchors, agents, and references
  Result: PASS

--- story-review ---
  [PASS] structured frontmatter, links, anchors, agents, and references
  Result: PASS

--- story-setup ---
  [PASS] structured frontmatter, links, anchors, agents, and references
  Result: PASS

--- story-short-analyze ---
  [PASS] structured frontmatter, links, anchors, agents, and references
  Result: PASS

--- story-short-scan ---
  [PASS] structured frontmatter, links, anchors, agents, and references
  Result: PASS

--- story-short-write ---
  [PASS] structured frontmatter, links, anchors, agents, and references
  Result: PASS

==================
Total: 13 | Pass: 13 | Fail: 0 | Warn: 0：13/13 skills passed\n- OpenClaw skills check
=====================
Repo: /Users/zby/Documents/提pr/triage-20260803-1341/oh-story-claudecode
  OK browser-cdp
  OK story
  OK story-cover
  OK story-deslop
  OK story-import
  OK story-long-analyze
  OK story-long-scan
  OK story-long-write
  OK story-review
  OK story-setup
  OK story-short-analyze
  OK story-short-scan
  OK story-short-write
OK: 13 skills have OpenClaw-compatible single-line frontmatter
OK: OpenClaw skills checks passed\n- Story setup deployment check
============================
Repo: /Users/zby/Documents/提pr/triage-20260803-1341/oh-story-claudecode
  OK TS1 hook dependency completeness
  OK TS1b session-start self-check lists all hook scripts and node cores
  OK TS2 deployment manifest
  OK TS3 agent reference integrity
  OK TS4 hook root resolution
  OK TS5 sentinel diagnostics
  OK TS6 short project non-mutation
  OK TS7 commit hook self-gating
  OK TS8 multi-book gap detection
  OK TS9 settings JSON
  OK TS10 version + behavior anchors
  OK TS11 outline-before-prose guard
  OK TS11b outline guard fail-closed without node
  OK TS11c outline guard fail-closed when node present-but-broken
  OK TS12 restart-flag confirmation

OK: story-setup deployment checks passed\n- Current Skill Contract Check
============================
  [PASS] manifest schema and declared release values
  [PASS] legacy/path guards
  [PASS] version, phase, progress, and artifact contracts
  [PASS] primary-artifact fallback semantics
  [PASS] demo primary artifacts and 20 outlines

Result: all current-contract checks passed\n- Shared File Consistency Check
==============================
OK: 5 canonical groups manage 12 synchronized copies

==============================
Reference groups checked: 60 | Mismatches: 0
All shared files are consistent.\n- Reasonix adapter check
======================
Repo: /Users/zby/Documents/提pr/triage-20260803-1341/oh-story-claudecode
  OK reasonix-plugin.json (schema + version pin + 13 Skills)

OK: Reasonix adapter checks passed\n- PASS: 267 Markdown file(s) use canonical workflow numbering：267 Markdown files passed\n- 真实 Atlas Cloud 调用：生成并校验 1664x2496 PNG\n- Playwright Dashboard E2E：15/16 passed；既有 CRLF 用例等待  启用超时，单独重跑仍失败，与本次 story-cover 改动无代码交集\n\n## 说明\n\n当前发布的  不再提供文档中的  子命令；仓库自带的 static-check 与 adapter checks 均已通过。