### PR TITLE
feat(story-graph): 叙事知识图谱增强系统（SQLite 图数据库）

### DIFF
--- a/skills/story-graph/SKILL.md
+++ b/skills/story-graph/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: story-graph
+version: 1.0.0
+description: "叙事知识图谱管理。构建/查询故事实体（人物/地点/事件/物品/组织）的关系图数据库，支持时间切片查询、钩子雷达、因果链遍历。触发方式：/story-graph、/知识图谱、「建知识图谱」「查关系」「时间切片」"
+metadata: {}
+---
+# story-graph：叙事知识图谱
+
+你是叙事知识图谱的管理员。你的任务是根据用户意图，将请求分发到对应的构建/查询流程。
+
+---
+
+## 场景路由
+
+| 用户意图 | 执行路径 |
+|---------|---------|
+| "setup"、"部署"、"安装知识图谱" | → **Setup 流程**（部署 agents/hooks/依赖） |
+| "初始化知识图谱"、"seed"、"建图"、"从设定建图" | → **Seed 流程**（全量构建） |
+| "更新知识图谱"、"update"、"更新第N章" | → **Update 流程**（增量更新） |
+| "查沈栀状态"、"时间切片"、"第30章时谁在哪" | → 分发到 **story-explorer agent**（图可用时走图查询，不可用自动降级读文件） |
+| "钩子雷达"、"这一章有什么钩子"、"伏笔触发" | → 分发到 **story-explorer agent** |
+| "因果链"、"这件事导致了什么" | → 分发到 **story-explorer agent** |
+| "知识缺口"、"沈栀怎么知道这件事的" | → 分发到 **story-explorer agent** |
+| "时间线"、"查看时间线"、"故事时间" | → 分发到 **story-explorer agent** |
+| "设置时间"、"星辰历"、"定纪元" | → **时间点管理**（`set-timepoint-time` + `repair-timeline`） |
+| 裸调用 `/story-graph` | → 执行 `story_graph_cli.js session-status` 输出当前图状态统计 + 可用操作提示 |
+
+---
+
+## 数据库位置
+
+```
+{书名}/
+├── story.db              ← 图数据库（不进 git）
+└── ...
+```
+
+使用部署后的 `.claude/hooks/story_graph_cli.js` 与图数据库交互（seed/update 也可用 `.claude/skills/story-graph/scripts/story_graph_cli.js`，两处为同一份代码）。
+
+---
+
+## Setup 流程：部署知识图谱增强系统
+
+**适用场景**: 写作项目已通过 `/story-setup` 初始化，需要叠加知识图谱能力。
+
+### 前置条件
+
+确认项目已部署 story-setup：
+- `.claude/agents/` 目录存在（至少包含 story-explorer.md）
+- `.claude/hooks/` 目录存在
+- 如不满足，提示用户先运行 `/story-setup`
+
+### 执行方式
+
+```bash
+bash .claude/skills/story-graph/scripts/deploy-graph.sh <项目根目录>
+```
+
+部署脚本将自动完成：
+1. 复制 skill 定义：**自动识别项目技能形态**——链接形态（`.claude/skills/{name}` 是符号链接，真实文件在 `.agents/skills/`，skills CLI 安装形态）时真实文件入 `.agents/skills/story-graph/`、`.claude/skills/story-graph` 建同款符号链接；真实目录形态直接复制到 `.claude/skills/story-graph/`
+2. 复制 `graph-builder.md` + `story-explorer.md`（图谱增强版）→ `.claude/agents/`。story-explorer 覆盖 story-setup 部署的同名 agent：图可用时走图查询、不可用时降级读文件；**重跑 `/story-setup` 会恢复无图版本，需重跑本部署**
+3. 复制 `session-start-graph.sh` + `graph-update-check.sh` + `story_graph_cli.js` + `story_graph_core.js` + `viz_html.js` → `.claude/hooks/`
+4. 合并 hook 注册到 `.claude/settings.local.json`（按 command 去重，不覆盖用户已有配置）
+5. 添加 `story.db` / `story.db-wal` / `story.db-shm` 到 `.gitignore`
+6. 注入 CLAUDE.md「知识图谱」段（写作循环自动走图的说明）
+7. 安装 `better-sqlite3` 到 **skill 真实目录**的 `node_modules`（`.claude/skills/story-graph/` 或 `.agents/skills/story-graph/`，项目根保持干净；`story_graph_core.js` 按部署拓扑自动解析）
+8. **收口写作流程**（`patch-long-write.js`，幂等）：给已部署的 story-long-write 注入图谱更新步骤 —— SKILL.md 单章流程注入 12b（写完即 `update`），workflow-daily.md 注入批末收尾（一次更新本批全部章节）；hook 的「📊 知识图谱需更新」提示降级为兜底提醒
+
+### 部署后提示
+
+```
+知识图谱增强系统部署完成。
+下一步: 新开 Claude Code 会话 → 运行 /story-graph seed 构建初始图谱。
+```
+
+---
+
+## Seed 流程：全量构建知识图谱
+
+**适用场景**: 开书后、正文前，或已有项目首次启用知识图谱。
+
+### Step 1: 发现项目结构
+
+确认活跃书路径。按以下优先级查找（与 `story_hook_core.js::discoverActiveBook` 同口径）：
+1. `.active-book` 文件首行（**空或指向失效目录时自动回退，不把项目根当书目录**）
+2. 深度≤4 找包含 `追踪/` 目录的目录（长篇）
+3. 找包含 `正文/` 目录的目录
+4. 找含 `正文.md` 的目录（短篇）
+5. 询问用户
+
+### Step 2: 初始化数据库
+
+```bash
+node .claude/hooks/story_graph_cli.js init {书路径}/story.db
+```
+
+### Step 3: 并行读取源文件
+
+一次性读取以下所有文件：
+
+| 类别 | 文件 | 提取内容 |
+|------|------|---------|
+| 角色设定 | `设定/角色/*.md` | PERSON 节点 |
+| 势力设定 | `设定/势力/*.md` | ORG 节点 |
+| 世界观 | `设定/世界观/*.md` | LOCATION 节点 |
+| 关系 | `设定/关系.md` | KIN_TO/ALLIED_WITH/HOSTILE_TO/ROMANTIC_WITH/MENTOR_OF 边 |
+| 卷纲 | `大纲/卷纲_*.md` | CHAPTER 节点、EVENT (draft) 节点 |
+| 细纲 | `大纲/细纲_*.md` | EVENT (draft) 节点、PARTICIPATES_IN 边 |
+| 钩子 | `追踪/伏笔.md` | HOOK 节点 + PLANTS_IN 边（`sync-hooks` 幂等同步） |
+
+### Step 4: 生成并执行 SQL
+
+对于提取到的每一组实体和边，使用 `story_graph_cli.js exec` 写入：
+
+```bash
+node .claude/hooks/story_graph_cli.js exec {dbPath} "INSERT OR REPLACE INTO nodes (id, node_type, label, properties) VALUES ('P_沈栀', 'PERSON', '沈栀', '{\"aliases\":[\"阿栀\"],\"role\":\"protagonist\"}');"
+```
+
+**批量写入策略**: 每 50 条 INSERT 合并为一个事务。
+
+### Step 5: 验证
+
+```bash
+node .claude/hooks/story_graph_cli.js stats {dbPath}
+```
+
+输出摘要：
+```
+知识图谱已初始化:
+  节点: {N}个（PERSON: {x}, LOCATION: {y}, EVENT: {z}, ITEM: {w}, ORG: {v}, CHAPTER: {c}）
+  边:   {M}条（关系: {x}, 因果: {y}, 空间: {z}, 知识: {w}, ...）
+  数据库: {书路径}/story.db
+```
+
+---
+
+## Update 流程：增量更新知识图谱
+
+**适用场景**: 每次日更写完后自动/手动触发。
+
+### Step 1: 检测更新范围
+
+```bash
+node .claude/hooks/story_graph_cli.js stats {dbPath}
+```
+
+获取当前最新章节号，与 `正文/` 目录对比，找出需要处理的章节。
+
+### Step 2: 启动 graph-builder agent
+
+Spawn graph-builder agent，模式: `update`，传入：
+- 待处理的章节号列表
+- 数据库路径
+
+graph-builder 将：
+- 从新章正文提取实体和事件
+- 查重（避免重复创建）
+- 写入 staging → commit
+- 同步钩子（`sync-hooks` 从 `追踪/伏笔.md` 增量同步 HOOK 节点与 PLANTS_IN 边）+ 钩子生命周期扫描
+- 清理 `.claude/.graph-update-pending` 标记（session-status 下次会话也会按章节号自愈清理，双保险）
+- 返回新增/变更摘要
+
+### Step 3: 输出更新摘要
+
+```
+知识图谱已更新:
+  处理章节: 第24-25章
+  新增节点: {N}个（EVENT: {x}, PERSON: {y}）
+  新增边:   {M}条（NARRATES: {x}, PARTICIPATES_IN: {y}, CAUSES: {z}）
+  状态变更: {角色} 位置: L_A → L_B
+```
+
+> 处理范围：与 `正文/` 目录对比找出所有待处理章节；章节积压较多时优先处理最新章节并报告剩余，可重复执行直至无 pending。
+
+---
+
+## 查重与冲突处理原则
+
+- **同名实体**: 先查 `SELECT id FROM nodes WHERE id = ?`，已存在则 update，不重复创建
+- **能力/状态升级**: 角色的能力从「医术lv3」升级到「医术lv4」时，更新 PERSON 节点的 properties.abilities
+- **位置变更**: 角色的 LOCATED_AT 变更时，旧边的 valid_until 设为当前时间点，新边从当前时间点开始
+- **龙套升级**: 之前作为背景的出现，后来成为重要角色时，为其创建 PERSON 节点，并在 properties 中标注 `promoted_from: "background"`
+
+---
+
+## 时间点管理
+
+**核心设计**: 时间是 TIME_POINT 的属性。开书时设定时间原点，后续每个时间点手动设 `epoch`（绝对时间戳），事件通过 OCCURS_AT 自动继承。
+
+```bash
+# 设置时间点纪元
+node .claude/hooks/story_graph_cli.js set-timepoint-time <db> T_穿越时刻 45113 "星辰历123年7月8日" day
+
+# 查看按 epoch 排序的完整时间线
+node .claude/hooks/story_graph_cli.js timeline <db>
+
+# 查看时间空白区间（可插入新内容）
+node .claude/hooks/story_graph_cli.js time-gaps <db>
+
+# 修复/补全时间信息（补 BEFORE 边、story_offset、OCCURS_AT）
+node .claude/hooks/story_graph_cli.js repair-timeline <db>
+```
+
+`epoch` 是数值，单位由你定（day/hour/second）。同一 epoch 内的事件通过 `story_offset` 区分顺序。
+
+---
+
+## 图查询
+
+当用户进行关系/状态/时间线查询时，**优先使用 story-explorer agent**（`.claude/agents/story-explorer.md` 可用时 spawn；不可用时降级主线程直接执行查询）。story-explorer 是图谱增强版：story.db 存在时内部通过 `story_graph_cli.js` 走图查询，图不可用时自动降级读文件（`追踪/` + `设定/`），两种来源输出同一套 schema，标注 `source: graph` 或 `source: fallback: file-read`。
+
+story-explorer 在图上支持以下查询类型（详见其 agent 定义）:
+- `time_slice` — 时间切片状态（state-at-time）
+- `hook_radar` — 钩子雷达（hook-radar）
+- `causal_chain` — 因果链（causal-chain）
+- `knowledge_gap` — 知识缺口（knowledge-gap）
+- `shortest_path` — 最短关系路径（shortest-path）
+- `flashback_opportunities` — 闪回/叙事债务建议（flashback-opps）
+- `time_gaps` — 时间空白区间（time-gaps）
+- `state_window` — 时空窗口批量查询（state-window）
+- `context_load` — 综合上下文加载（进度/钩子/时间线走图，细纲与上一章仍读文件）
+
+既有查询类型（character_status / foreshadow_list / timeline / progress / relationship）在图可用时同样优先走图，schema 不变。
+
+> 设计说明：图谱查询能力已并入 story-explorer（单一 agent、单一 schema、单一路由入口），不再单独部署独立查询 agent；写作流程（story-long-write context_load/benchmark_style_load 快捷路径）与 story 路由无需改动即获得图谱能力。
+
+---
+
+## 快照导出（已实现）
+
+每次 `/story-graph update` 自动导出文本快照到 `设定/知识图谱快照/snapshot-{timestamp}/`；也可手动执行：
+
+```bash
+node .claude/hooks/story_graph_cli.js export-snapshot <db> <输出目录>
+```
+
+导出文件纯文本、按行结构化，`git diff` 直接可读（按实际存在的类型生成，钩子状态含在 `nodes_hook.txt` 的状态列中）：
+
+```
+设定/知识图谱快照/snapshot-{timestamp}/
+├── nodes_{person|location|event|item|org|time-point|chapter|hook}.txt  ← "P_沈栀 | 沈栀 | active | role=protagonist"
+├── edges_{边类型}.txt     ← "沈栀 --[KIN_TO]--> 沈父 [T_穿越时刻 → 至今]"
+├── timeline_merged.txt    ← 物理时间线 + 叙事顺序线合并视图
+└── SUMMARY.md             ← 统计 + 人物 + 最近事件摘要
+```
+
+---
+
+## 注意事项
+
+- `story.db` 不进 git（需在 `.gitignore` 中添加）
+- 知识图谱是增强功能，不是替代追踪/文件——两者共存
+- 图不可用时所有降级路径都能正常工作
+- 上游仓库更新不影响 story-graph skill（独立目录）

--- a/skills/story-graph/USAGE.md
+++ b/skills/story-graph/USAGE.md
@@ -1,0 +1,286 @@
+# 叙事知识图谱 — 完整使用指南
+
+## 一、系统概述
+
+知识图谱增强系统用 SQLite 图数据库管理故事的人、地、事、物、组织及其关系，提供传统文件读取做不到的多跳查询、时间切片、钩子雷达和因果链遍历。
+
+**查询入口统一**：图谱查询能力并入 **story-explorer**（图谱增强版）——story.db 存在时内部走图查询，不可用时自动降级读文件，两种来源输出同一套 schema。写作流程、路由不需要感知图谱是否存在。
+
+**和现有追踪/文件的关系**：增强，不是替代。`追踪/伏笔.md`、`追踪/时间线.md`、`追踪/角色状态.md` 照常更新（文件是权威源），图是额外的查询加速层；钩子数据由 `sync-hooks` 从 `追踪/伏笔.md` 同步进图。
+
+---
+
+## 二、安装（只需一次）
+
+### 前提
+
+写作项目已运行过 `/story-setup`（`.claude/agents/` 和 `.claude/hooks/` 已存在）。
+
+### 步骤
+
+```bash
+# 1. 从 oh-story-claudecode 仓库复制 story-graph skill 到写作项目
+#    （项目技能统一位于 .claude/skills/，与 story-setup 部署布局一致）
+cp -r <oh-story-claudecode路径>/skills/story-graph/ <写作项目>/.claude/skills/story-graph/
+
+# 2. 进入写作项目，运行部署
+cd <写作项目>
+bash .claude/skills/story-graph/scripts/deploy-graph.sh
+```
+
+部署脚本自动完成：
+
+| 操作 | 细节 |
+|------|------|
+| Skill 注册 | 自动识别项目技能形态：链接形态（`.claude/skills/{name}` 是符号链接、真实文件在 `.agents/skills/`）时，真实文件复制到 `.agents/skills/story-graph/`，`.claude/skills/story-graph` 建同款符号链接；真实目录形态直接复制 → `/story-graph` 命令可用（需新开会话） |
+| Agent 部署 | `graph-builder.md` + `story-explorer.md`（图谱增强版）→ `.claude/agents/`（覆盖 story-setup 同名 agent；**重跑 story-setup 后 story-explorer 会恢复为无图版本，需重跑本部署**） |
+| Hook 部署 | `session-start-graph.sh` + `graph-update-check.sh` + `story_graph_cli.js` + `story_graph_core.js` + `viz_html.js` → `.claude/hooks/` |
+| Hook 注册 | 合并到 `.claude/settings.local.json`（按 command 去重，不覆盖用户已有配置） |
+| .gitignore | 添加 `story.db` / `story.db-wal` / `story.db-shm` |
+| CLAUDE.md | 注入「知识图谱」段（写作循环自动走图的说明） |
+| 依赖 | `npm install better-sqlite3 --no-save` 装进 **skill 真实目录**的 `node_modules`（项目根保持干净；`story_graph_core.js` 按部署拓扑自动解析） |
+| 写作流程收口 | `patch-long-write.js`（幂等）给已部署 story-long-write 注入图谱更新步骤：SKILL.md 单章流程 12b（写完即 update）+ workflow-daily.md 批末收尾（一次更新本批全部章节）；hook 提示降级为兜底 |
+
+### 3. 新开会话
+
+部署后必须新开 Claude Code 会话，让 agents 和 hooks 注册生效。
+
+---
+
+## 三、开书时：构建初始知识图谱
+
+### 时机
+
+完成 `/story-setup` 和 `/story-graph setup` 后，设定和大纲已写好，正文还没开始写。
+
+### 执行
+
+```
+/story-graph seed
+```
+
+**内部流程**：
+1. graph-builder agent（Sonnet）被 spawn
+2. 并行读取 `设定/角色/*.md`、`设定/势力/*.md`、`设定/世界观/*.md`
+3. 读取 `设定/关系.md` 提取人物关系
+4. 读取 `大纲/卷纲_*.md`、`大纲/细纲_*.md` 提取事件和章节点
+5. 读取 `追踪/伏笔.md` → `sync-hooks` 同步 HOOK 节点与 PLANTS_IN 边
+6. 写入 `story.db`，`stats` 验证
+
+**输出示例**：
+```
+知识图谱已初始化:
+  节点: 67个（PERSON: 8, LOCATION: 5, EVENT: 30, ITEM: 3, ORG: 2, CHAPTER: 15, TIME_POINT: 4）
+  边:   120条（NARRATES: 30, PARTICIPATES_IN: 45, KIN_TO: 5, ALLIED_WITH: 3, ...）
+  数据库: 故事名/story.db
+```
+
+### 如果已有正文
+
+如果项目已经写了很多章再启用图谱，seed 会从设定文件构建初始骨架，然后需要逐章跑 `/story-graph update` 把正文章节的事件数据追加进去。
+
+---
+
+## 四、日更写作时：增量更新
+
+### 自动触发（推荐）
+
+正文落盘后触发图更新（**写作流程已收口**，hook 只是兜底）：
+
+1. **主触发（写作流程内）**：部署时 `patch-long-write.js` 已把图更新注入写作流程 —— 单章场景在 SKILL.md Step 12b 写完即执行 `/story-graph update`；日更批量在 workflow-daily.md 批末收尾一次更新本批全部章节。
+2. **兜底提醒（hook）**：正文落盘后 `graph-update-check.sh` 自动检测并提示：
+
+```
+📊 知识图谱需更新 — 第25章已写入。
+  当前图谱: 89节点/178边
+  请运行 /story-graph update 将新章实体和事件增量写入图谱。
+```
+
+看到此提示说明写作流程的图更新步骤被跳过或尚未执行，执行 `/story-graph update` 即可（幂等）。
+
+### 手动触发
+
+```
+/story-graph update
+```
+
+**内部流程**：
+1. graph-builder agent 被 spawn，模式: update
+2. 读取最新章正文 + 细纲 + `追踪/伏笔.md`
+3. 增量提取新事件、新实体、角色状态变更、新埋设钩子
+4. 查重（已有实体不重复创建）
+5. 写入 staging → 验证 → commit
+6. `sync-hooks` 同步 `追踪/伏笔.md`（已埋→dormant、已回收→resolved、废弃→abandoned，幂等）
+7. 钩子雷达扫描 → 自动触发/解决符合条件的钩子 + 依赖环检测
+8. 清理 `.claude/.graph-update-pending` 标记（session-status 下次会话也会自愈清理）
+9. 导出文本快照到 `设定/知识图谱快照/`
+
+**输出示例**：
+```
+知识图谱已更新:
+  处理章节: 第24-25章
+  新增: +8节点（EVENT: 6, ITEM: 1, TIME_POINT: 1）
+  新增: +15边（NARRATES: 6, PARTICIPATES_IN: 7, CAUSES: 2）
+  钩子: H_玉佩秘密 已触发（第25章，评分85）
+  快照: 设定/知识图谱快照/snapshot-20260725-103000/
+```
+
+---
+
+## 五、写作中查询
+
+### 通过 story-explorer agent（日常使用）
+
+写作时，当你问这些问题，AI 会自动 spawn story-explorer agent（Haiku，只读）。story-explorer 是图谱增强版：story.db 存在时内部通过 `story_graph_cli.js` 走图查询（下述类型全部可用），图不可用时自动降级读文件 —— **写作流程、路由、schema 都不需要感知图谱是否存在**：
+
+| 你的问题 | 查询类型 | 示例 |
+|---------|---------|------|
+| "沈栀现在在哪？有什么物品？" | time_slice / character_status | 返回时间点完整状态 |
+| "第25章可以触发哪些钩子？" | hook_radar | 返回匹配钩子列表+建议 |
+| "发现玉佩这件事导致了什么？" | causal_chain | 沿因果边遍历 |
+| "沈栀怎么知道陆衍止身份的？" | knowledge_gap | 追溯知识来源链 |
+| "沈栀和陆衍止之间什么关系？" | shortest_path | 最短关系路径 |
+| "第20-30章按时间线发生了什么？" | timeline / state_window | 时间线事件序列 |
+| "本章有没有该解释的因果缺口？" | flashback_opportunities | 闪回/叙事债务建议 |
+| "故事时间里有哪些空白？" | time_gaps | 可插入新内容的区间 |
+| "帮我准备写第30章的上下文" | context_load | 进度/钩子/时间线走图 + 细纲与上一章读文件 |
+
+### 降级安全
+
+如果 `story.db` 不存在或为空，story-explorer **自动降级为读文件**（`追踪/` + `设定/`），标注 `"source": "fallback: file-read"`。不会报错。两种来源输出同一套 schema，图数据与文件冲突时以文件为准。
+
+### 手动 CLI 查询
+
+```bash
+cd <写作项目>
+
+# 时间切片
+node .claude/hooks/story_graph_cli.js state-at-time <书名>/story.db P_沈栀 T_星辰历1025年春
+
+# 钩子雷达
+node .claude/hooks/story_graph_cli.js hook-radar <书名>/story.db '["P_沈栀","I_玉佩"]' L_断魂崖 T_星辰历1025年秋 25
+
+# 图统计
+node .claude/hooks/story_graph_cli.js stats <书名>/story.db
+```
+
+---
+
+## 六、钩子管理
+
+### 自动管理（增量更新时）
+
+graph-builder 的增量更新会自动执行：
+
+- **同步**：`sync-hooks` 从 `追踪/伏笔.md` 幂等同步（已埋→dormant、已回收→resolved、废弃→abandoned），`追踪/伏笔.md` 是钩子状态的权威源
+- **触发**：评分≥70 的 dormant 钩子 → `triggered`
+- **解决**：谜底在本章揭示 → `resolved`
+- **告警**：超过 50 章未触发 → 标记建议废弃
+- **依赖环检测**：创建 PREREQUISITE_FOR 边前自动检查
+
+### 手动管理
+
+```bash
+# 从 追踪/伏笔.md 手动同步（幂等）
+node .claude/hooks/story_graph_cli.js sync-hooks <书名>/story.db <书名>/追踪/伏笔.md
+
+# 查看所有钩子状态
+node .claude/hooks/story_graph_cli.js hook-summary <书名>/story.db
+
+# 手动触发
+node .claude/hooks/story_graph_cli.js trigger-hook <书名>/story.db H_玉佩秘密 25
+
+# 手动解决
+node .claude/hooks/story_graph_cli.js resolve-hook <书名>/story.db H_玉佩秘密 30
+
+# 废弃
+node .claude/hooks/story_graph_cli.js abandon-hook <书名>/story.db H_废弃伏笔 "主线已改，此伏笔作废"
+```
+
+---
+
+## 七、快照审阅
+
+每次 `/story-graph update` 自动导出文本快照到 `设定/知识图谱快照/snapshot-{timestamp}/`。
+
+```bash
+# 也可手动导出
+node .claude/hooks/story_graph_cli.js export-snapshot <书名>/story.db 设定/知识图谱快照/snapshot-manual/
+```
+
+导出文件纯文本、按行结构化，`git diff` 直接可读：
+
+```
+设定/知识图谱快照/snapshot-20260725-103000/
+├── nodes_person.txt        ← "P_沈栀 | 沈栀 | active | role=protagonist"
+├── nodes_event.txt         ← 按时间排序
+├── nodes_item.txt
+├── nodes_location.txt
+├── edges_narrates.txt      ← "第25章 --[NARRATES]--> 沈栀发现密信"
+├── edges_causes.txt        ← "发现密信 --[CAUSES]--> 进入秘境"
+├── edges_hostile-to.txt
+├── timeline_merged.txt     ← 物理+叙事双时间线
+└── SUMMARY.md              ← 人类可读摘要（统计+人物+近期事件）
+```
+
+---
+
+## 八、完整日更工作流（从开书到日更）
+
+```
+┌─ 开书前 ──────────────────────────────────────────────────────────┐
+│                                                                     │
+│  1. /story-setup              ← 部署写作环境（hooks+agents+rules）   │
+│  2. bash .claude/skills/story-graph/scripts/deploy-graph.sh         │
+│                                ← 部署知识图谱增强（只需一次）        │
+│  3. /story-long-write 开书     ← Phase 1-3：选题→设定→大纲           │
+│  4. /story-graph seed         ← 从设定+大纲+伏笔构建初始图谱          │
+│                                                                     │
+├─ 日更循环 ──────────────────────────────────────────────────────────┤
+│                                                                     │
+│  5. /story-long-write 日更     ← Phase 4：写正文（2-3章）            │
+│  6. 批末自动 /story-graph update ← 流程已收口（增量+钩子同步+快照）   │
+│     （hook 的 📊 提示仅是兜底提醒）                                  │
+│  7. 继续写...                 ← 查询时 story-explorer 自动走图/文件  │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 九、命令速查
+
+| 命令 | 功能 | 谁执行 |
+|------|------|--------|
+| `/story-graph setup` | 部署知识图谱增强系统 | 一次性 |
+| `/story-graph seed` | 从设定+大纲+`追踪/伏笔.md`（钩子）全量构建图 | 开书时 |
+| `/story-graph update` | 增量更新新章（含钩子同步与生命周期扫描） | 日更后（可自动） |
+| `/story-graph`（裸调用） | 显示图统计+可用操作 | 随时 |
+| （自然语言查询） | 角色状态/钩子/因果链/时间线 | story-explorer 自动处理（图优先，文件降级） |
+
+---
+
+## 十、常见问题
+
+**Q: story.db 被误删了怎么办？**
+A: 重新运行 `/story-graph seed` 重建。设定文件和正文都在，不会丢数据。
+
+**Q: 重跑 /story-setup 会破坏图增强吗？**
+A: 部分会。`settings.local.json` 按 command 去重合并、CLAUDE.md 按 section 合并，graph hooks 和 CLAUDE.md 段不受影响；但 `/story-setup` 会把它管理的 **story-explorer.md 覆盖回无图版本**（graph-builder.md 不受影响）。重跑 story-setup 后需**重跑一次部署脚本**恢复图谱增强版 story-explorer。
+
+**Q: better-sqlite3 装不上？**
+A: 部署脚本会把它装进 skill 真实目录的 `node_modules`（`.claude/skills/story-graph/` 或 `.agents/skills/story-graph/`），不需要项目根有 package.json。若安装失败，手动执行：
+```bash
+cd <写作项目>/.claude/skills/story-graph   # 链接形态项目用 .agents/skills/story-graph
+npm install better-sqlite3 --no-save
+```
+如果没有 Node.js，先装 Node.js。
+
+**Q: 知识图谱和追踪/文件的数据不一致怎么办？**
+A: 文件的更新（Phase 4 Step 12）和图更新（`/story-graph update`）是独立路径。图是查询加速层，以文件为权威。如有不一致，以文件为准，重新 seed 即可。
+
+**Q: 短篇能用吗？**
+A: 短篇也可以。seed 从设定+大纲构建，update 从正文.md 增量更新。但短篇章节少、数据稀疏，图的多跳查询优势不如长篇明显。
+
+**Q: 多书切换时怎么处理？**
+A: 图谱数据库是按书存放的（`{书名}/story.db`）。不同书有独立的图（连接按路径隔离，同进程多书不串库）。活跃书发现走回退链：`.active-book` 首行 → 找 `追踪/` 目录（长篇）→ 找 `正文/` → 找 `正文.md`（短篇）；`.active-book` 为空或指向失效目录时自动回退，不会把项目根误当书目录。

--- a/skills/story-graph/references/schema.sql
+++ b/skills/story-graph/references/schema.sql
@@ -1,0 +1,210 @@
+-- 叙事知识图谱 Schema v1.0
+-- 故事实体与关系的完整 DDL
+
+-----------------------------------------------------------
+-- 1. 节点表
+-----------------------------------------------------------
+CREATE TABLE IF NOT EXISTS nodes (
+    id          TEXT PRIMARY KEY,       -- P_沈栀 / L_青云城 / E_获得戒指 / I_盘龙戒指 / G_天机阁 / T_星辰历1024年春 / C_015 / H_玉佩秘密
+    node_type   TEXT NOT NULL,          -- PERSON / LOCATION / EVENT / ITEM / ORG / TIME_POINT / CHAPTER / HOOK
+    label       TEXT NOT NULL,          -- 人类可读名称
+    properties  TEXT NOT NULL DEFAULT '{}',  -- JSON blob，动态属性
+    status      TEXT DEFAULT 'active',  -- active / draft / archived / dead / lost
+    created_at  TEXT DEFAULT (datetime('now')),
+    updated_at  TEXT DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_nodes_type ON nodes(node_type);
+CREATE INDEX IF NOT EXISTS idx_nodes_status ON nodes(status);
+
+-----------------------------------------------------------
+-- 各类型 properties 规范（注释）
+--
+-- PERSON:
+--   {"aliases": ["阿栀"], "gender": "女", "age": 22, "role": "protagonist",
+--    "abilities": ["医术lv3"], "motivation": "为父报仇", "backstory_knowledge": ["祖传玉佩的秘密"]}
+--
+-- LOCATION:
+--   {"type": "city|building|wilderness|realm", "parent": "L_玉兰大陆", "owner": "G_巴鲁克家族"}
+--
+-- EVENT:
+--   {"event_type": "conflict|revelation|transition|action|dialogue|state_change",
+--    "summary": "沈栀在断魂崖发现黑衣人留下的密信",
+--    "chapter": 15, "narrative_order": 15,
+--    "participants": ["P_沈栀", "P_黑衣人"], "emotional_tone": "suspense"}
+--
+-- ITEM:
+--   {"item_type": "weapon|artifact|consumable|clue|currency",
+--    "owner": "P_沈栀", "location": "L_青云城", "significance": "critical|supporting|background"}
+--
+-- ORG:
+--   {"org_type": "sect|family|empire|guild|clan", "leader": "P_掌门", "headquarters": "L_天机阁"}
+--
+-- TIME_POINT:
+--   {"time_unit": "absolute|relative", "reference": null,
+--    "description": "大战后第三日黄昏"}
+--
+-- CHAPTER:
+--   {"chapter_number": 15, "title": "断魂崖之谜", "word_count": 3200}
+--
+-- HOOK:
+--   {"hook_type": "mystery|foreshadow|red_herring|promise",
+--    "priority": 7, "complexity": 5,
+--    "expected_trigger_window": "20-30",
+--    "planted_chapter": 3, "planted_time": null,
+--    "triggered_chapter": null, "resolved_chapter": null}
+-----------------------------------------------------------
+
+-----------------------------------------------------------
+-- 2. 边表
+-----------------------------------------------------------
+CREATE TABLE IF NOT EXISTS edges (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    from_node     TEXT NOT NULL,
+    edge_type     TEXT NOT NULL,        -- 字符串类型，支持动态扩展
+    to_node       TEXT NOT NULL,
+    properties    TEXT NOT NULL DEFAULT '{}',  -- JSON: {confidence, reason, ...}
+    valid_since   TEXT,                 -- 物理时间锚点 ID 或时间字符串
+    valid_until   TEXT,                 -- NULL = 至今有效
+    created_by    TEXT DEFAULT 'graph-builder',  -- graph-builder / manual / hook-engine
+    created_at    TEXT DEFAULT (datetime('now')),
+    FOREIGN KEY (from_node) REFERENCES nodes(id),
+    FOREIGN KEY (to_node) REFERENCES nodes(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_edges_from ON edges(from_node, edge_type);
+CREATE INDEX IF NOT EXISTS idx_edges_to ON edges(to_node, edge_type);
+CREATE INDEX IF NOT EXISTS idx_edges_type ON edges(edge_type);
+CREATE INDEX IF NOT EXISTS idx_edges_valid ON edges(valid_since, valid_until);
+
+-----------------------------------------------------------
+-- 边类型目录（注释）
+--
+-- 叙事层:
+--   NEXT_CHAPTER  CHAPTER → CHAPTER        阅读顺序
+--   NARRATES      CHAPTER → EVENT          本章讲述了某事件
+--   FLASHBACK_TO  CHAPTER → TIME_POINT     本章倒叙到某时间点
+--
+-- 物理时间:
+--   BEFORE        TIME_POINT → TIME_POINT  物理时间先后
+--   OCCURS_AT     EVENT → TIME_POINT       事件发生的物理时间
+--
+-- 空间:
+--   LOCATED_AT    PERSON/ITEM/EVENT → LOCATION  在某地
+--
+-- 所有权:
+--   OWNS          PERSON/ORG → ITEM        持有物品
+--   BELONGS_TO    PERSON → ORG             从属组织
+--
+-- 事件参与:
+--   PARTICIPATES_IN  PERSON/ITEM/ORG → EVENT  参与事件
+--
+-- 因果:
+--   CAUSES        EVENT → EVENT            事件A导致事件B
+--
+-- 人物关系:
+--   KIN_TO        PERSON → PERSON          亲属
+--   ALLIED_WITH   PERSON → PERSON          同盟
+--   HOSTILE_TO    PERSON → PERSON          敌对
+--   ROMANTIC_WITH PERSON → PERSON          爱慕
+--   MENTOR_OF     PERSON → PERSON          师徒
+--
+-- 知识:
+--   WITNESS       PERSON → EVENT           亲眼所见
+--   INFORMED_BY   PERSON → EVENT           被人告知
+--   KNOWS_ABOUT   PERSON → NODE            聚合知识边（查询用）
+--
+-- 钩子:
+--   PLANTS_IN         HOOK → CHAPTER       埋设在某章
+--   CONCERNS          HOOK → NODE          关联某实体
+--   TRIGGERS_ON_ENTITY   HOOK → NODE       触发条件：实体出现
+--   TRIGGERS_ON_LOCATION HOOK → LOCATION   触发条件：到达某地
+--   TRIGGERS_ON_TIME     HOOK → TIME_POINT 触发条件：到达某时间
+--   TRIGGERS_ON_STATE    HOOK → NODE       触发条件：状态变更
+--   PREREQUISITE_FOR     HOOK → HOOK       钩子A是钩子B的前提
+--   TRIGGERED_IN         HOOK → CHAPTER    在某一章被触发
+--   RESOLVED_IN          HOOK → CHAPTER    在某一章被解决
+--
+-- 技能/能力:
+--   COUNTERS      ABILITY → ABILITY        克制关系
+--   POSSESSES     PERSON → ABILITY         拥有能力
+-----------------------------------------------------------
+
+-----------------------------------------------------------
+-- 3. 知识来源追踪表
+-----------------------------------------------------------
+CREATE TABLE IF NOT EXISTS knowledge_sources (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    person_id    TEXT NOT NULL,          -- 谁知道
+    target_id    TEXT NOT NULL,          -- 知道了什么 (NODE ID)
+    source_type  TEXT NOT NULL,          -- WITNESS / INFORMED_BY / DEDUCTION / BACKSTORY
+    source_event TEXT,                   -- 如果是 WITNESS/INFORMED_BY，指向具体的 EVENT
+    source_person TEXT,                  -- 如果是 INFORMED_BY，谁告诉的
+    acquired_at  TEXT,                   -- 物理时间点
+    confidence   REAL DEFAULT 1.0,       -- 0.0-1.0
+    FOREIGN KEY (person_id) REFERENCES nodes(id),
+    FOREIGN KEY (target_id) REFERENCES nodes(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ks_person ON knowledge_sources(person_id);
+CREATE INDEX IF NOT EXISTS idx_ks_target ON knowledge_sources(target_id);
+
+-----------------------------------------------------------
+-- 4. 钩子触发条件表
+-----------------------------------------------------------
+CREATE TABLE IF NOT EXISTS hook_conditions (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    hook_id      TEXT NOT NULL,
+    condition_type TEXT NOT NULL,        -- entity/location/time/state/combo
+    target_id    TEXT,                   -- 条件目标 NODE ID
+    logic_op     TEXT DEFAULT 'ANY',     -- ANY / AND / OR / NOT
+    combo_group  INTEGER DEFAULT 0,      -- 组合条件分组号
+    FOREIGN KEY (hook_id) REFERENCES nodes(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_hc_hook ON hook_conditions(hook_id);
+
+-----------------------------------------------------------
+-- 5. Staging 表（graph-builder 增量写入用）
+-----------------------------------------------------------
+CREATE TABLE IF NOT EXISTS staging_nodes (
+    id          TEXT PRIMARY KEY,
+    node_type   TEXT NOT NULL,
+    label       TEXT NOT NULL,
+    properties  TEXT NOT NULL DEFAULT '{}',
+    status      TEXT DEFAULT 'draft',
+    source_chapter TEXT,
+    action      TEXT DEFAULT 'create'   -- create / update / delete
+);
+
+CREATE TABLE IF NOT EXISTS staging_edges (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    from_node     TEXT NOT NULL,
+    edge_type     TEXT NOT NULL,
+    to_node       TEXT NOT NULL,
+    properties    TEXT NOT NULL DEFAULT '{}',
+    valid_since   TEXT,
+    valid_until   TEXT,
+    source_chapter TEXT,
+    action        TEXT DEFAULT 'create'   -- create / update / delete
+);
+
+-----------------------------------------------------------
+-- 6. 通用视图：边连接展开
+-- 注：SQLite 视图无法参数化，时间窗口过滤请用 stateAtTime() / stateWindow()
+--     函数（epoch 数值比较，见 story_graph_core.js）；本视图不做有效性过滤。
+-----------------------------------------------------------
+CREATE VIEW IF NOT EXISTS v_state_at_time AS
+SELECT
+    n.id AS entity_id,
+    n.label AS entity_label,
+    n.node_type,
+    e.edge_type,
+    e.to_node AS related_node,
+    n2.label AS related_label,
+    n2.node_type AS related_type,
+    e.valid_since,
+    e.valid_until
+FROM nodes n
+JOIN edges e ON n.id = e.from_node
+JOIN nodes n2 ON e.to_node = n2.id;

--- a/skills/story-graph/references/seed-workflow.md
+++ b/skills/story-graph/references/seed-workflow.md
@@ -1,0 +1,128 @@
+# Graph Builder - Seed 工作流
+
+## Seed 模式：从设定文件全量构建知识图谱
+
+### 概述
+
+Seed 模式从已有项目文件（设定/角色/、设定/势力/、设定/世界观/、设定/关系.md、大纲/）一次性提取所有实体和关系，构建完整的初始知识图谱。
+
+### 适用场景
+
+1. 开书后、正文前——设定和大纲已完成，准备开始正文写作
+2. 已有项目首次启用知识图谱——已有大量章节，需要一次性从文件重建图
+
+### 执行方式
+
+Seed 通过 graph-builder agent（Sonnet）执行。主会话 spawn graph-builder agent，传入全量文件内容。
+
+### 输入数据源
+
+按优先级和并行度分三组：
+
+**Group A — 并行读取（独立文件，互不依赖）**:
+- `设定/角色/*.md` → PERSON 节点
+- `设定/势力/*.md` → ORG 节点
+- `设定/世界观/*.md` → LOCATION 节点
+- `大纲/卷纲_*.md` → CHAPTER 节点、卷级 EVENT 节点
+
+**Group B — 关系文件（依赖 Group A 的实体 ID）**:
+- `设定/关系.md` → KIN_TO / ALLIED_WITH / HOSTILE_TO / ROMANTIC_WITH / MENTOR_OF 边
+
+**Group C — 大纲文件（依赖 Group B 的角色关系）**:
+- `大纲/细纲_*.md` → 章节级 EVENT 节点、PARTICIPATES_IN 边、NARRATES 边
+
+### 提取流程
+
+```
+Phase 1: 并行读取 Group A 文件
+  ├── 角色文件 → 提取：名字、别名、性别、年龄、角色定位、能力、动机、背景知识
+  ├── 势力文件 → 提取：名称、类型、首领、总部、成员列表
+  ├── 世界观文件 → 提取：地点名称、类型、层级关系
+  └── 卷纲文件 → 提取：卷号、章节范围、剧情单元、情绪弧线
+
+Phase 2: 读取关系文件
+  └── 关系.md → 按关系类型提取边（人物A --[关系类型]--> 人物B）
+
+Phase 3: 读取细纲文件（可分批处理）
+  └── 每章细纲 → 提取：事件摘要、事件类型、参与者、本章角色出场列表
+
+Phase 4: 生成 SQL 并写入
+  ├── 生成所有节点 INSERT 语句
+  ├── 生成所有边 INSERT 语句
+  ├── 分批执行（50条/批）
+  └── 提交事务
+
+Phase 5: 验证
+  └── node story_graph_cli.js stats <dbPath>
+```
+
+### 实体 ID 生成规则
+
+| 节点类型 | ID 格式 | 示例 |
+|---------|--------|------|
+| PERSON | `P_{角色名}` | `P_沈栀` |
+| LOCATION | `L_{地名}` | `L_青云城` |
+| EVENT | `E_{章节}_{简短描述}` | `E_003_沈栀发现玉佩` |
+| ITEM | `I_{物品名}` | `I_盘龙戒指` |
+| ORG | `G_{组织名}` | `G_天机阁` |
+| TIME_POINT | `T_{描述}` | `T_星辰历1024年春` |
+| CHAPTER | `C_{三位章节号}` | `C_015` |
+
+### 角色关系提取规则
+
+从 `设定/关系.md` 中提取人物关系时，按以下关键词映射边类型：
+
+| 关系描述关键词 | edge_type |
+|-------------|-----------|
+| 兄弟/姐妹/父子/母女/亲属/血缘 | KIN_TO |
+| 盟友/朋友/同盟/合作/伙伴 | ALLIED_WITH |
+| 敌对/仇人/宿敌/对手/对立 | HOSTILE_TO |
+| 爱慕/暗恋/恋人/夫妻/情侣 | ROMANTIC_WITH |
+| 师父/徒弟/老师/学生/导师 | MENTOR_OF |
+
+### 事件提取规则
+
+从大纲/细纲中提取事件时：
+
+**事件类型映射**:
+- "冲突/战斗/对抗/对决" → event_type: conflict
+- "揭示/发现/得知/真相/秘密" → event_type: revelation
+- "转折/变局/逆转/突变" → event_type: transition
+- "行动/出发/前往/执行" → event_type: action
+- "对话/交谈/谈判/摊牌" → event_type: dialogue
+- "升级/突破/觉醒/获得能力" → event_type: state_change
+
+**参与者提取**:
+- 细纲的"出场角色"列表 → PARTICIPATES_IN 边
+- 每章自动建立 NARRATES 边（CHAPTER → 本章所有 EVENT）
+
+### 验证检查清单
+
+Seed 完成后，graph-builder 必须验证：
+
+1. [ ] 所有 `设定/角色/` 中的角色都已创建 PERSON 节点
+2. [ ] 所有 `设定/势力/` 中的组织都已创建 ORG 节点
+3. [ ] `设定/关系.md` 中每条关系都有对应的边
+4. [ ] 所有 `大纲/细纲_*.md` 中描述的章都有 CHAPTER 节点
+5. [ ] 所有章节的出场角色都建立了 PARTICIPATES_IN 边
+6. [ ] 节点 ID 无冲突、无重复
+7. [ ] properties JSON 格式有效
+
+### 输出格式
+
+Seed 完成后，graph-builder 向主会话返回：
+
+```json
+{
+  "mode": "seed",
+  "status": "completed",
+  "db_path": "故事名/story.db",
+  "stats": {
+    "nodes": { "PERSON": 12, "LOCATION": 8, "EVENT": 45, "ITEM": 5, "ORG": 3, "CHAPTER": 30, "TIME_POINT": 4 },
+    "edges": { "total": 156 },
+    "relationships": { "KIN_TO": 5, "ALLIED_WITH": 8, "HOSTILE_TO": 3, "ROMANTIC_WITH": 2, "MENTOR_OF": 6 },
+    "warnings": []
+  },
+  "issues": []
+}
+```

--- a/skills/story-graph/scripts/deploy-graph.js
+++ b/skills/story-graph/scripts/deploy-graph.js
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * deploy-graph.js — 知识图谱增强系统部署（跨平台 Node.js 版）
+ *
+ * 部署 graph agents、hook 脚本、Node.js 核心库到写作项目，
+ * 注册 hooks 到 settings.local.json，注入 CLAUDE.md 段，更新 .gitignore。
+ *
+ * 使用: node deploy-graph.js [项目根目录]
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+const SKILL_DIR = path.resolve(__dirname, "..");
+const ROOT = path.resolve(process.argv[2] || ".");
+
+function log(msg) { console.log("[graph] " + msg); }
+function fail(msg) { console.error("[graph] ERROR: " + msg); process.exit(1); }
+
+log("部署知识图谱增强系统 → " + ROOT);
+
+// ── 0. 部署 skill 定义 ──────────────────────
+// 尊重 skills CLI 安装形态：.agents/skills/ 是真实文件存储，
+// .claude/skills/{name} 是指向 ../../.agents/skills/{name} 的符号链接。
+let skillDst = path.join(ROOT, ".claude", "skills", "story-graph");
+const linkProbe = path.join(ROOT, ".claude", "skills", "story");
+let isLinkLayout = false;
+try { isLinkLayout = fs.lstatSync(linkProbe).isSymbolicLink(); } catch (e) {}
+if (isLinkLayout) {
+  const linkTarget = fs.readlinkSync(linkProbe);            // ../../.agents/skills/story
+  const linkDir = linkTarget.split("/").slice(0, -1).join("/"); // ../../.agents/skills
+  const store = path.join(ROOT, ".agents", "skills", "story-graph");
+  try { fs.rmSync(store, { recursive: true, force: true }); } catch (e) {}
+  try { fs.rmSync(skillDst, { force: true }); } catch (e) {}
+  fs.mkdirSync(store, { recursive: true });
+  copyDir(SKILL_DIR, store, [".git", "node_modules"]);
+  try {
+    fs.symlinkSync(linkDir + "/story-graph", skillDst, "dir");
+    log("skill 定义（符号链接形态，真实文件）→ " + store);
+  } catch (e) {
+    // Windows 无符号链接权限：退化为真实目录
+    copyDir(SKILL_DIR, skillDst, [".git", "node_modules"]);
+    log("⚠ 无法创建符号链接，已退化为真实目录 → " + skillDst);
+  }
+  skillDst = store;
+} else {
+  try { fs.rmSync(skillDst, { recursive: true, force: true }); } catch (e) {}
+  fs.mkdirSync(skillDst, { recursive: true });
+  copyDir(SKILL_DIR, skillDst, [".git", "node_modules"]);
+  log("skill 定义 → " + skillDst);
+}
+
+// ── 1. 部署 Agents ──────────────────────────
+const agentsDst = path.join(ROOT, ".claude", "agents");
+if (!fs.existsSync(agentsDst)) fail(".claude/agents/ 不存在，请先运行 /story-setup");
+const agentsSrc = path.join(SKILL_DIR, "templates", "agents");
+for (const f of fs.readdirSync(agentsSrc)) {
+  fs.copyFileSync(path.join(agentsSrc, f), path.join(agentsDst, f));
+}
+log("agents: graph-builder + story-explorer（图谱增强版）→ " + agentsDst);
+log("⚠ story-explorer.md 覆盖 story-setup 同名 agent（图可用走图、不可用降级文件）；重跑 /story-setup 后需重跑本部署");
+
+// ── 2. 部署 Hook 脚本 ──────────────────────
+const hooksDst = path.join(ROOT, ".claude", "hooks");
+if (!fs.existsSync(hooksDst)) fail(".claude/hooks/ 不存在，请先运行 /story-setup");
+const hookFiles = ["story_graph_core.js", "story_graph_cli.js", "viz_html.js",
+                   "session-start-graph.sh", "graph-update-check.sh", "deploy-graph.sh"];
+for (const f of hookFiles) {
+  const src = path.join(SKILL_DIR, "scripts", f);
+  if (fs.existsSync(src)) {
+    fs.copyFileSync(src, path.join(hooksDst, f));
+    if (f.endsWith(".sh")) fs.chmodSync(path.join(hooksDst, f), 0o755);
+  }
+}
+log("hooks → " + hooksDst);
+
+// ── 3. 注册 Hooks ───────────────────────────
+const mergeScript = path.join(SKILL_DIR, "scripts", "merge-hook-registration.js");
+const settingsPath = path.join(ROOT, ".claude", "settings.local.json");
+let settings = {};
+if (fs.existsSync(settingsPath)) {
+  try { settings = JSON.parse(fs.readFileSync(settingsPath, "utf8")); } catch (e) {}
+}
+if (!settings.hooks) settings.hooks = {};
+if (!settings.hooks.SessionStart) settings.hooks.SessionStart = [{ hooks: [] }];
+if (!settings.hooks.PostToolUse) settings.hooks.PostToolUse = [];
+
+const ssGroup = settings.hooks.SessionStart[0];
+if (!ssGroup.hooks) ssGroup.hooks = [];
+if (!ssGroup.hooks.some(h => h.command && h.command.includes("session-start-graph.sh"))) {
+  ssGroup.hooks.push({
+    type: "command",
+    command: `bash "$CLAUDE_PROJECT_DIR"/.claude/hooks/session-start-graph.sh`,
+    timeout: 10
+  });
+  log("注册 SessionStart: session-start-graph.sh");
+}
+
+let ptGroup = settings.hooks.PostToolUse.find(g => g.matcher === "Write|Edit|MultiEdit");
+if (!ptGroup) { ptGroup = { matcher: "Write|Edit|MultiEdit", hooks: [] }; settings.hooks.PostToolUse.push(ptGroup); }
+if (!ptGroup.hooks) ptGroup.hooks = [];
+if (!ptGroup.hooks.some(h => h.command && h.command.includes("graph-update-check.sh"))) {
+  ptGroup.hooks.push({
+    type: "command",
+    command: `bash "$CLAUDE_PROJECT_DIR"/.claude/hooks/graph-update-check.sh`,
+    timeout: 10
+  });
+  log("注册 PostToolUse: graph-update-check.sh");
+}
+
+fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n", "utf8");
+log("hooks 已注册到 settings.local.json");
+
+// ── 4. 更新 .gitignore ─────────────────────
+const giPath = path.join(ROOT, ".gitignore");
+const giLines = fs.existsSync(giPath) ?
+  fs.readFileSync(giPath, "utf8").split("\n") : [];
+const giNeeded = ["story.db", "story.db-wal", "story.db-shm"];
+let changed = false;
+for (const n of giNeeded) {
+  if (!giLines.some(l => l.trim() === n)) {
+    giLines.push(n);
+    changed = true;
+  }
+}
+if (changed) {
+  fs.writeFileSync(giPath, giLines.join("\n") + "\n", "utf8");
+  log(".gitignore 已更新 (story.db)");
+}
+
+// ── 5. 注入 CLAUDE.md ──────────────────────
+const claudePath = path.join(ROOT, "CLAUDE.md");
+if (fs.existsSync(claudePath)) {
+  const graphSection = `## 知识图谱
+
+\`story.db\` 存在时，写作循环自动走图（story-explorer 是图谱增强版查询 agent，图不可用自动降级读文件）：
+- 写前：spawn story-explorer 做 context_load，获取角色状态/钩子/闪回建议/时空位置
+- 写中：根据 context_load 结果决定内容——角色在哪写哪、钩子触发写触发、闪回评分高就插回忆
+- 写后：每批次完成后自动 \`/story-graph update\`
+- 图不可用时 story-explorer 降级读文件，不影响写作
+
+\`/story-graph seed\`（初始化）· \`/story-graph update\`（增量）· \`/story-graph\`（统计）`;
+
+  let content = fs.readFileSync(claudePath, "utf8");
+  const re = /^## 知识图谱\n[\s\S]*?(?=^## |\n## |\n*$)/m;
+  if (re.test(content)) {
+    content = content.replace(re, graphSection);
+    log("CLAUDE.md 知识图谱段已更新");
+  } else {
+    const idx = content.indexOf("## Compact");
+    if (idx > 0) {
+      content = content.slice(0, idx) + graphSection + "\n\n" + content.slice(idx);
+    } else {
+      content += "\n" + graphSection + "\n";
+    }
+    log("CLAUDE.md 已追加知识图谱段");
+  }
+  fs.writeFileSync(claudePath, content, "utf8");
+}
+
+// ── 6. 安装依赖（装进 skill 目录，项目根保持干净）─────────
+// 写作项目根通常没有 package.json；依赖统一装到 .claude/skills/story-graph/node_modules，
+// story_graph_core.js 按部署拓扑解析（.claude/hooks → ../skills/story-graph/node_modules）。
+const skillDeps = path.join(skillDst, "node_modules", "better-sqlite3");
+if (fs.existsSync(skillDeps)) {
+  log("better-sqlite3 已安装（skill 目录）");
+} else {
+  log("正在安装 better-sqlite3 到 skill 目录...");
+  try {
+    execSync("npm install better-sqlite3 --no-save --no-package-lock", { cwd: skillDst, stdio: "pipe" });
+    log("better-sqlite3 已安装 → " + path.join(skillDst, "node_modules"));
+  } catch (e2) {
+    log("⚠ npm install 失败，请手动安装: cd " + skillDst + " && npm install better-sqlite3 --no-save");
+  }
+}
+
+// ── 7. 写作流程收口 ─────────────────────────
+// 给已部署的 story-long-write 注入图谱更新步骤（幂等）
+log("收口写作流程（story-long-write 注入图谱更新步骤）...");
+try {
+  execSync(process.execPath + " " + JSON.stringify(path.join(SKILL_DIR, "scripts", "patch-long-write.js")) + " " + JSON.stringify(ROOT), { stdio: "pipe" });
+  log("写作流程收口完成（未部署 story-long-write 时跳过）");
+} catch (e) {
+  log("⚠ 写作流程收口失败（需 node 可用）");
+}
+
+console.log("\n部署完成。新开会话后生效。");
+console.log("  1. /story-graph seed — 构建初始图谱");
+console.log("  2. 写作时 story-explorer 自动处理上下文（图优先，文件降级）");
+console.log("  3. 正文落盘后系统自动提示增量更新（写作流程已收口，提示仅是兜底）");
+
+// ── helpers ─────────────────────────────────
+function copyDir(src, dst, exclude) {
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    if (exclude && exclude.includes(entry.name)) continue;
+    const s = path.join(src, entry.name), d = path.join(dst, entry.name);
+    if (entry.isDirectory()) { fs.mkdirSync(d, { recursive: true }); copyDir(s, d, exclude); }
+    else fs.copyFileSync(s, d);
+  }
+}

--- a/skills/story-graph/scripts/deploy-graph.sh
+++ b/skills/story-graph/scripts/deploy-graph.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+# deploy-graph.sh — 部署知识图谱增强系统到写作项目
+#
+# 将 graph agents、hook 脚本、Node.js 核心库部署到项目本地目录，
+# 并注册 hooks 到 settings.local.json，更新 .gitignore。
+#
+# 使用方式:
+#   bash deploy-graph.sh <项目根目录>
+#
+# 由 /story-graph setup 调用。也可手动运行。
+set -euo pipefail
+
+ROOT="${1:-$(pwd)}"
+ROOT="$(cd "$ROOT" && pwd)"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+echo "=== 知识图谱增强系统部署 ==="
+echo "项目: $ROOT"
+
+# ── 0. 部署 Skill 本身（让 /story-graph 命令可用） ──────────
+# 尊重项目既有形态（skills CLI 安装形态）：.agents/skills/ 是真实文件存储，
+# .claude/skills/{name} 是指向 ../../.agents/skills/{name} 的符号链接。
+# 检测：.claude/skills/story 是符号链接 → 走链接形态；否则真实目录形态。
+SKILL_DST="$ROOT/.claude/skills/story-graph"
+
+echo "[graph] 部署 skill 定义..."
+if [ -L "$ROOT/.claude/skills/story" ]; then
+  # 链接形态：真实文件放 .agents/skills/story-graph，.claude/skills 只建同款链接
+  LINK_PATTERN="$(readlink "$ROOT/.claude/skills/story")"   # 如 ../../.agents/skills/story
+  LINK_DIR="$(dirname "$LINK_PATTERN")"                      # 如 ../../.agents/skills
+  SKILL_STORE="$ROOT/.agents/skills/story-graph"
+  echo "[graph] 检测到 .claude/skills 为符号链接形态（真实目录 .agents/skills/）"
+  rm -rf "$SKILL_STORE" 2>/dev/null || true
+  rm -f "$SKILL_DST" 2>/dev/null || true
+  mkdir -p "$SKILL_STORE"
+  cp "$SKILL_DIR/SKILL.md" "$SKILL_STORE/SKILL.md"
+  cp -r "$SKILL_DIR/references" "$SKILL_STORE/references"
+  cp -r "$SKILL_DIR/scripts" "$SKILL_STORE/scripts"
+  cp -r "$SKILL_DIR/templates" "$SKILL_STORE/templates"
+  ln -sfn "$LINK_DIR/story-graph" "$SKILL_DST"
+  echo "  → 真实文件 $SKILL_STORE；$SKILL_DST → $LINK_DIR/story-graph"
+  SKILL_DST="$SKILL_STORE"
+else
+  # 真实目录形态：直接复制到 .claude/skills/story-graph
+  rm -rf "$SKILL_DST" 2>/dev/null || true
+  mkdir -p "$SKILL_DST"
+  cp "$SKILL_DIR/SKILL.md" "$SKILL_DST/SKILL.md"
+  cp -r "$SKILL_DIR/references" "$SKILL_DST/references"
+  cp -r "$SKILL_DIR/scripts" "$SKILL_DST/scripts"
+  cp -r "$SKILL_DIR/templates" "$SKILL_DST/templates"
+  echo "  → $SKILL_DST"
+fi
+
+# ── 1. 部署 Agents ──────────────────────────────────────────
+AGENTS_SRC="$SKILL_DIR/templates/agents"
+AGENTS_DST="$ROOT/.claude/agents"
+
+if [ ! -d "$AGENTS_DST" ]; then
+  echo "[graph] .claude/agents/ 不存在，请先运行 /story-setup"
+  exit 1
+fi
+
+echo "[graph] 部署 agents..."
+cp "$AGENTS_SRC/graph-builder.md" "$AGENTS_DST/graph-builder.md"
+cp "$AGENTS_SRC/story-explorer.md" "$AGENTS_DST/story-explorer.md"
+echo "  → graph-builder.md, story-explorer.md（图谱增强版）→ $AGENTS_DST"
+echo "  ⚠ story-explorer.md 会覆盖 story-setup 部署的同名 agent（图可用时走图、不可用降级文件）；"
+echo "    重跑 /story-setup 后会恢复为无图版本，需重新运行本部署脚本。"
+
+# ── 2. 部署 Hook 脚本 ──────────────────────────────────────
+HOOKS_DST="$ROOT/.claude/hooks"
+
+if [ ! -d "$HOOKS_DST" ]; then
+  echo "[graph] .claude/hooks/ 不存在，请先运行 /story-setup"
+  exit 1
+fi
+
+echo "[graph] 部署 hook 脚本..."
+cp "$SKILL_DIR/scripts/session-start-graph.sh" "$HOOKS_DST/session-start-graph.sh"
+cp "$SKILL_DIR/scripts/graph-update-check.sh" "$HOOKS_DST/graph-update-check.sh"
+cp "$SKILL_DIR/scripts/story_graph_cli.js" "$HOOKS_DST/story_graph_cli.js"
+cp "$SKILL_DIR/scripts/story_graph_core.js" "$HOOKS_DST/story_graph_core.js"
+cp "$SKILL_DIR/scripts/viz_html.js" "$HOOKS_DST/viz_html.js"
+cp "$SKILL_DIR/scripts/deploy-graph.js" "$HOOKS_DST/deploy-graph.js"
+chmod +x "$HOOKS_DST/session-start-graph.sh"
+chmod +x "$HOOKS_DST/graph-update-check.sh"
+echo "  → session-start-graph.sh, graph-update-check.sh, story_graph_cli.js, story_graph_core.js → $HOOKS_DST"
+
+# ── 3. 注册 Hooks ──────────────────────────────────────────
+echo "[graph] 注册 hooks 到 settings.local.json..."
+node "$SKILL_DIR/scripts/merge-hook-registration.js" "$ROOT"
+
+# ── 4. 更新 .gitignore ─────────────────────────────────────
+GITIGNORE="$ROOT/.gitignore"
+if [ -f "$GITIGNORE" ]; then
+  if ! grep -q "^story.db$" "$GITIGNORE" 2>/dev/null; then
+    echo "" >> "$GITIGNORE"
+    echo "# 知识图谱数据库（不进 git）" >> "$GITIGNORE"
+    echo "story.db" >> "$GITIGNORE"
+    echo "story.db-wal" >> "$GITIGNORE"
+    echo "story.db-shm" >> "$GITIGNORE"
+    echo "[graph] 已添加 story.db 到 .gitignore"
+  else
+    echo "[graph] story.db 已在 .gitignore 中，跳过"
+  fi
+else
+  echo "story.db" > "$GITIGNORE"
+  echo "story.db-wal" >> "$GITIGNORE"
+  echo "story.db-shm" >> "$GITIGNORE"
+  echo "[graph] 已创建 .gitignore（story.db）"
+fi
+
+# ── 5. 注入 CLAUDE.md 知识图谱段 ────────────────────────────
+CLAUDE_MD="$ROOT/CLAUDE.md"
+GRAPH_SECTION="## 知识图谱
+
+\`story.db\` 存在时，写作循环自动走图（story-explorer 是图谱增强版查询 agent，图不可用自动降级读文件）：
+- 写前：spawn story-explorer 做 context_load，获取角色状态/钩子/闪回建议/时空位置
+- 写中：根据 context_load 结果决定内容——角色在哪写哪、钩子触发写触发、闪回评分高就插回忆
+- 写后：每批次完成后自动 \`/story-graph update\`
+- 图不可用时 story-explorer 降级读文件，不影响写作
+
+\`/story-graph seed\`（初始化）· \`/story-graph update\`（增量）· \`/story-graph\`（统计）"
+
+if [ -f "$CLAUDE_MD" ]; then
+  if grep -q "^## 知识图谱$" "$CLAUDE_MD" 2>/dev/null; then
+    # 已存在则替换
+    node -e "
+      const fs = require('fs');
+      const content = fs.readFileSync('$CLAUDE_MD', 'utf8');
+      const section = process.argv[1];
+      const re = /^## 知识图谱\n[\s\S]*?(?=^## |\n## |\n*$)/m;
+      const updated = content.replace(re, section);
+      fs.writeFileSync('$CLAUDE_MD', updated);
+      console.log('[graph] CLAUDE.md 知识图谱段已更新');
+    " "$GRAPH_SECTION"
+  else
+    # 不存在则追加在 Compact 段之前
+    node -e "
+      const fs = require('fs');
+      let content = fs.readFileSync('$CLAUDE_MD', 'utf8');
+      const section = process.argv[1];
+      const compactIdx = content.indexOf('## Compact');
+      if (compactIdx > 0) {
+        content = content.slice(0, compactIdx) + section + '\n\n' + content.slice(compactIdx);
+      } else {
+        content += '\n' + section + '\n';
+      }
+      fs.writeFileSync('$CLAUDE_MD', content);
+      console.log('[graph] CLAUDE.md 已追加知识图谱段');
+    " "$GRAPH_SECTION"
+  fi
+else
+  echo "[graph] CLAUDE.md 不存在，跳过（请先运行 /story-setup）"
+fi
+
+# ── 6. 安装依赖（装进 skill 目录，项目根保持干净）──────────
+# 写作项目根通常没有 package.json；依赖统一装到 .claude/skills/story-graph/node_modules，
+# story_graph_core.js 会按部署拓扑解析（.claude/hooks → ../skills/story-graph/node_modules）。
+echo ""
+echo "[graph] 安装 better-sqlite3 到 skill 目录（项目根保持干净）..."
+if [ -d "$SKILL_DST/node_modules/better-sqlite3" ]; then
+  echo "[graph] better-sqlite3 已安装"
+else
+  if (cd "$SKILL_DST" && npm install better-sqlite3 --no-save --no-package-lock 2>/dev/null); then
+    echo "[graph] better-sqlite3 已安装 → $SKILL_DST/node_modules"
+  else
+    echo "[graph] ⚠ npm install 失败。请手动运行: cd \"$SKILL_DST\" && npm install better-sqlite3 --no-save"
+  fi
+fi
+
+# ── 7. 写作流程收口：给已部署的 story-long-write 技能注入图谱更新步骤 ──
+# 写作流程原本不含图更新步骤（依赖 hook 提示 + AI 自觉）；部署图谱时收口：
+# SKILL.md Step 12 后注入 12b（单章写完即更新），workflow-daily.md 注入批量收尾。
+echo ""
+echo "[graph] 收口写作流程（story-long-write 注入图谱更新步骤，幂等）..."
+if node "$SKILL_DIR/scripts/patch-long-write.js" "$ROOT" >/dev/null 2>&1; then
+  echo "[graph] 写作流程收口完成（story-long-write 已注入图谱更新步骤；未部署时自动跳过）"
+else
+  echo "[graph] ⚠ 写作流程收口失败（需 node 可用）"
+fi
+
+echo ""
+echo "=== 部署完成 ==="
+echo ""
+echo "下一步:"
+echo "  1. 新开 Claude Code 会话，让 agents 和 hooks 生效"
+echo "  2. 运行 /story-graph seed 从设定和大纲构建初始知识图谱"
+echo "  3. 写作时 story-explorer agent 可查询时间切片、钩子雷达等（图优先，文件降级）"
+echo "  4. 正文落盘后系统会自动提示增量更新图谱（写作流程已收口，提示仅是兜底）"

--- a/skills/story-graph/scripts/graph-update-check.sh
+++ b/skills/story-graph/scripts/graph-update-check.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# graph-update-check.sh — PostToolUse 正文落盘后检测知识图谱更新
+# 设计: 薄壳，业务逻辑在 story_graph_core.js::checkGraphUpdate()
+set -euo pipefail
+export LC_ALL=C
+
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+node -e "" >/dev/null 2>&1 || exit 0
+CLI="$HOOK_DIR/story_graph_cli.js"
+[ -f "$CLI" ] || exit 0
+
+# 从 hook input 提取目标文件路径
+TARGET=""
+HOOK_INPUT="${CLAUDE_TOOL_INPUT:-}"
+if [ -z "$HOOK_INPUT" ] && [ ! -t 0 ]; then
+  HOOK_INPUT="$(cat)"
+fi
+
+if [ -n "$HOOK_INPUT" ]; then
+  TARGET=$(printf '%s' "$HOOK_INPUT" | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' 2>/dev/null | head -1 | sed 's/.*"\([^"]*\)"$/\1/' || true)
+  [ -z "$TARGET" ] && TARGET=$(printf '%s' "$HOOK_INPUT" | grep -o '"filePath"[[:space:]]*:[[:space:]]*"[^"]*"' 2>/dev/null | head -1 | sed 's/.*"\([^"]*\)"$/\1/' || true)
+fi
+
+[ -z "$TARGET" ] && exit 0
+
+node "$CLI" prose-check _ "$TARGET" "$ROOT" 2>/dev/null || true

--- a/skills/story-graph/scripts/merge-hook-registration.js
+++ b/skills/story-graph/scripts/merge-hook-registration.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * merge-hook-registration.js — 将知识图谱 hooks 合并到 settings.local.json
+ *
+ * 在现有 hook 注册中追加 graph session-start 和 post-write 检查，
+ * 保持用户已有配置不变（按 command 字符串去重）。
+ *
+ * 使用方式:
+ *   node merge-hook-registration.js <项目根目录>
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const projectRoot = path.resolve(process.argv[2] || ".");
+const settingsPath = path.join(projectRoot, ".claude", "settings.local.json");
+
+// ── 要注册的 hooks ──────────────────────────────────────────
+
+const GRAPH_HOOKS = {
+  SessionStart: {
+    type: "command",
+    command: `bash "$CLAUDE_PROJECT_DIR"/.claude/hooks/session-start-graph.sh`,
+    timeout: 10
+  },
+  PostToolUse: {
+    matcher: "Write|Edit|MultiEdit",
+    type: "command",
+    command: `bash "$CLAUDE_PROJECT_DIR"/.claude/hooks/graph-update-check.sh`,
+    timeout: 10
+  }
+};
+
+// ── 读取现有配置 ────────────────────────────────────────────
+
+let settings = {};
+if (fs.existsSync(settingsPath)) {
+  try {
+    settings = JSON.parse(fs.readFileSync(settingsPath, "utf8"));
+  } catch (e) {
+    console.error(`[ERROR] 无法解析 ${settingsPath}: ${e.message}`);
+    process.exit(1);
+  }
+}
+
+// 确保 hooks 对象存在
+if (!settings.hooks) settings.hooks = {};
+
+// ── 合并 SessionStart ───────────────────────────────────────
+
+if (!settings.hooks.SessionStart) settings.hooks.SessionStart = [];
+if (settings.hooks.SessionStart.length === 0) {
+  settings.hooks.SessionStart.push({ hooks: [] });
+}
+
+// 在第一个 SessionStart group 中追加 graph hook
+const ssGroup = settings.hooks.SessionStart[0];
+if (!ssGroup.hooks) ssGroup.hooks = [];
+
+// 去重：检查是否已注册
+const ssAlreadyRegistered = ssGroup.hooks.some(
+  h => h.command && h.command.includes("session-start-graph.sh")
+);
+
+if (!ssAlreadyRegistered) {
+  ssGroup.hooks.push(GRAPH_HOOKS.SessionStart);
+  console.log("[graph] 已注册 SessionStart hook: session-start-graph.sh");
+} else {
+  console.log("[graph] SessionStart hook 已存在，跳过");
+}
+
+// ── 合并 PostToolUse ────────────────────────────────────────
+
+if (!settings.hooks.PostToolUse) settings.hooks.PostToolUse = [];
+
+// 找到 matcher 为 Write|Edit|MultiEdit 的 group，追加 graph hook
+let ptGroup = settings.hooks.PostToolUse.find(
+  g => g.matcher === "Write|Edit|MultiEdit"
+);
+
+if (!ptGroup) {
+  ptGroup = { matcher: "Write|Edit|MultiEdit", hooks: [] };
+  settings.hooks.PostToolUse.push(ptGroup);
+}
+
+if (!ptGroup.hooks) ptGroup.hooks = [];
+
+const ptAlreadyRegistered = ptGroup.hooks.some(
+  h => h.command && h.command.includes("graph-update-check.sh")
+);
+
+if (!ptAlreadyRegistered) {
+  ptGroup.hooks.push(GRAPH_HOOKS.PostToolUse);
+  console.log("[graph] 已注册 PostToolUse hook: graph-update-check.sh");
+} else {
+  console.log("[graph] PostToolUse hook 已存在，跳过");
+}
+
+// ── 写回 ────────────────────────────────────────────────────
+
+// 确保目录存在
+const settingsDir = path.dirname(settingsPath);
+if (!fs.existsSync(settingsDir)) fs.mkdirSync(settingsDir, { recursive: true });
+
+fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n", "utf8");
+console.log(`[graph] 配置已写入 ${settingsPath}`);

--- a/skills/story-graph/scripts/patch-long-write.js
+++ b/skills/story-graph/scripts/patch-long-write.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * patch-long-write.js — 给已部署的 story-long-write 技能注入图谱更新步骤（幂等）
+ *
+ * 写作流程原本不含知识图谱步骤（图更新依赖 hook 提示 + AI 自觉执行 /story-graph update）。
+ * 本脚本在部署图谱时收口写作流程：
+ *   - SKILL.md Phase 4 单章流程 Step 12 之后注入 12b（单章场景写完即更新图）
+ *   - workflow-daily.md Step 3/4 之间注入批量收尾（日更批末一次更新全部章节）
+ * 注入块带 `<!-- story-graph:update-step -->` 标记，重复执行自动跳过；
+ * 文件缺失（未部署 story-long-write）时跳过并在结果中标注。
+ *
+ * 用法: node patch-long-write.js <项目根目录>
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const ROOT = path.resolve(process.argv[2] || ".");
+const SKILL_MD = path.join(ROOT, ".claude", "skills", "story-long-write", "SKILL.md");
+const DAILY_MD = path.join(ROOT, ".claude", "skills", "story-long-write", "references", "workflow-daily.md");
+
+const MARKER = "story-graph:update-step";
+
+const SKILL_STEP = `<!-- story-graph:update-step -->
+12b. **知识图谱更新**（story-graph 已部署时）：若 \`{书}/story.db\` 存在，执行 \`/story-graph update\` —— 增量提取本章实体/事件/钩子（幂等；与追踪文件同步更新，hook 的「📊 知识图谱需更新」提示仅是兜底提醒）。
+<!-- /story-graph:update-step -->`;
+
+const DAILY_STEP = `<!-- story-graph:update-step -->
+> **批量收尾（story-graph 已部署时）**：若 \`{书}/story.db\` 存在，本批全部章节写完后执行 \`/story-graph update\`（一次更新本批全部章节，幂等；单章场景已由 SKILL.md Step 12b 更新，此处可跳过）。
+<!-- /story-graph:update-step -->`;
+
+/**
+ * 在 anchor 之前注入 step；文件不存在 → {reason: "missing"}；已含标记 → {reason: "already"}
+ */
+function patch(target, step, anchor) {
+  if (!fs.existsSync(target)) return { patched: false, reason: "missing", target };
+  let text = fs.readFileSync(target, "utf8");
+  if (text.includes(MARKER)) return { patched: false, reason: "already", target };
+  const idx = text.indexOf(anchor);
+  if (idx >= 0) {
+    text = text.slice(0, idx) + step + "\n\n" + text.slice(idx);
+  } else {
+    text += "\n\n" + step;
+  }
+  fs.writeFileSync(target, text, "utf8");
+  return { patched: true, target };
+}
+
+const results = {
+  skill: patch(SKILL_MD, SKILL_STEP, "13. **中途快照**"),
+  daily: patch(DAILY_MD, DAILY_STEP, "## Step 4：进度摘要"),
+};
+
+process.stdout.write(JSON.stringify(results, null, 2) + "\n");

--- a/skills/story-graph/scripts/session-start-graph.sh
+++ b/skills/story-graph/scripts/session-start-graph.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# session-start-graph.sh — 会话启动时显示知识图谱状态
+# 设计: 薄壳，业务逻辑在 story_graph_core.js::sessionStatus()
+set -euo pipefail
+
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+# node 不可用时静默退出
+node -e "" >/dev/null 2>&1 || exit 0
+
+CLI="$HOOK_DIR/story_graph_cli.js"
+[ -f "$CLI" ] || exit 0
+
+node "$CLI" session-status _ "$ROOT" 2>/dev/null || true

--- a/skills/story-graph/scripts/story_graph_cli.js
+++ b/skills/story-graph/scripts/story_graph_cli.js
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+"use strict";
+
+const core = require("./story_graph_core");
+const viz = require("./viz_html");
+const path = require("path");
+
+function resolveDb(p) {
+  return path.resolve(p || "story.db");
+}
+
+const cmd = process.argv[2];
+const dbPath = resolveDb(process.argv[3]);
+
+function out(obj) {
+  process.stdout.write(JSON.stringify(obj, null, 2) + "\n");
+}
+
+function fail(msg) {
+  process.stderr.write(msg + "\n");
+  process.exit(1);
+}
+
+try {
+  switch (cmd) {
+    case "init": {
+      core.initSchema(dbPath);
+      out({ status: "ok", message: "Schema initialized", db: dbPath });
+      break;
+    }
+
+    case "stats": {
+      const db = core.open(dbPath);
+      const stats = core.graphStats(db);
+      out(stats);
+      break;
+    }
+
+    case "state-at-time": {
+      const entityId = process.argv[4], timePointId = process.argv[5];
+      if (!entityId || !timePointId) fail("Usage: state-at-time <db> <entityId> <timePointId>");
+      out(core.stateAtTime(entityId, timePointId, core.open(dbPath)));
+      break;
+    }
+
+    case "hook-radar": {
+      // entities 支持两种形态：数组 ["P_x"]，或对象 {"entities":[...],"states":[...]}
+      const raw = process.argv[4] || "[]";
+      let entities = [];
+      let states = [];
+      try {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed)) entities = parsed;
+        else if (parsed && typeof parsed === "object") {
+          entities = parsed.entities || [];
+          states = parsed.states || [];
+        }
+      } catch (e) {}
+      const location = process.argv[5] || null;
+      const timePoint = process.argv[6] || null;
+      const chapter = parseInt(process.argv[7]) || 0;
+      out(core.hookRadar({ entities, states, location, timePoint }, chapter, core.open(dbPath)));
+      break;
+    }
+
+    case "causal-chain": {
+      const eventId = process.argv[4], direction = process.argv[5] || "forward";
+      const maxDepth = parseInt(process.argv[6]) || 5;
+      if (!eventId) fail("Usage: causal-chain <db> <eventId> [forward|backward] [depth]");
+      out(core.causalChain(eventId, direction, maxDepth, core.open(dbPath)));
+      break;
+    }
+
+    case "knowledge-gap": {
+      const personId = process.argv[4], factId = process.argv[5];
+      if (!personId || !factId) fail("Usage: knowledge-gap <db> <personId> <factId>");
+      out(core.knowledgeGap(personId, factId, core.open(dbPath)));
+      break;
+    }
+
+    case "shortest-path": {
+      const fromPerson = process.argv[4], toPerson = process.argv[5];
+      if (!fromPerson || !toPerson) fail("Usage: shortest-path <db> <fromPerson> <toPerson>");
+      const db = core.open(dbPath);
+      const result = core.shortestRelationshipPath(fromPerson, toPerson, null, db);
+      out(result || { found: false, message: "未找到路径" });
+      break;
+    }
+
+    case "trigger-hook": {
+      const hookId = process.argv[4], ch = parseInt(process.argv[5]) || 0;
+      if (!hookId || !ch) fail("Usage: trigger-hook <db> <hookId> <chapterNum>");
+      out(core.triggerHook(hookId, ch, core.open(dbPath)));
+      break;
+    }
+
+    case "resolve-hook": {
+      const hookId = process.argv[4], ch = parseInt(process.argv[5]) || 0;
+      if (!hookId || !ch) fail("Usage: resolve-hook <db> <hookId> <chapterNum>");
+      out(core.resolveHook(hookId, ch, core.open(dbPath)));
+      break;
+    }
+
+    case "abandon-hook": {
+      const hookId = process.argv[4], reason = process.argv[5] || "作者废弃";
+      if (!hookId) fail("Usage: abandon-hook <db> <hookId> [reason]");
+      out(core.abandonHook(hookId, reason, core.open(dbPath)));
+      break;
+    }
+
+    case "hook-summary": {
+      out(core.hookLifecycleSummary(core.open(dbPath)));
+      break;
+    }
+
+    case "state-window": {
+      const ts = process.argv[4], te = process.argv[5], loc = process.argv[6] || null;
+      if (!ts || !te) fail("Usage: state-window <db> <timeStart> <timeEnd> [location]");
+      out(core.stateWindow({ timeStart: ts, timeEnd: te, location: loc }, null, core.open(dbPath)));
+      break;
+    }
+
+    case "detect-debts": {
+      const ch = parseInt(process.argv[4]) || 0;
+      if (!ch) fail("Usage: detect-debts <db> <chapterNum>");
+      out(core.detectNarrativeDebts(ch, core.open(dbPath)));
+      break;
+    }
+
+    case "flashback-opps": {
+      const ch = parseInt(process.argv[4]) || 0;
+      const entities = JSON.parse(process.argv[5] || "[]");
+      if (!ch) fail("Usage: flashback-opps <db> <chapterNum> <entitiesJSON>");
+      out(core.flashbackOpportunities(ch, { entities }, core.open(dbPath)));
+      break;
+    }
+
+    case "repay-debt": {
+      const debtId = parseInt(process.argv[4]) || 0, ch = parseInt(process.argv[5]) || 0;
+      if (!debtId || !ch) fail("Usage: repay-debt <db> <debtId> <chapterNum>");
+      out(core.repayDebt(debtId, ch, core.open(dbPath)));
+      break;
+    }
+
+    case "set-chapter-time": {
+      const chId = process.argv[4], timeId = process.argv[5];
+      const day = parseInt(process.argv[6]) || 0, order = parseInt(process.argv[7]) || 0;
+      if (!chId || !timeId || !day) fail("Usage: set-chapter-time <db> <chId> <timeId> <storyDay> <absOrder>");
+      core.setChapterTime(chId, timeId, day, order);
+      out({ status: "ok" });
+      break;
+    }
+
+    case "repair-timeline": {
+      const db = core.open(dbPath);
+      const result = core.repairTimeline(db);
+      out(result);
+      break;
+    }
+
+    case "set-timepoint-time": {
+      const tpId = process.argv[4], ep = parseFloat(process.argv[5]), dl = process.argv[6] || null, u = process.argv[7] || null;
+      if (!tpId || isNaN(ep)) fail("Usage: set-timepoint-time <db> <timePointId> <epoch> [dateLabel] [unit:day|hour|second]");
+      out(core.setTimePointTime(tpId, ep, dl, u, core.open(dbPath)));
+      break;
+    }
+
+    case "set-event-offset": {
+      const evId = process.argv[4], off = parseInt(process.argv[5]) || 0;
+      if (!evId) fail("Usage: set-event-offset <db> <eventId> <offset>");
+      out(core.setEventOffset(evId, off, core.open(dbPath)));
+      break;
+    }
+
+    case "timeline": {
+      out(core.getTimeline(core.open(dbPath)));
+      break;
+    }
+
+    case "time-gaps": {
+      out(core.getTimeGaps(core.open(dbPath)));
+      break;
+    }
+
+    case "story-timeline": {
+      out(core.getStoryTimeline(core.open(dbPath)));
+      break;
+    }
+
+    case "session-status": {
+      const projectRoot = process.argv[4] || process.cwd();
+      const result = core.sessionStatus(projectRoot);
+      if (result.message) process.stdout.write(result.message + "\n");
+      else out(result);
+      break;
+    }
+
+    case "prose-check": {
+      // 注意: CLI 全局 dbPath 占用了 argv[3]，所以 targetFile 从 argv[4] 取
+      const targetFile = process.argv[4];
+      const projectRoot = process.argv[5] || process.cwd();
+      if (!targetFile) fail("Usage: prose-check _ <targetFile> [projectRoot]");
+      const result = core.checkGraphUpdate(targetFile, projectRoot);
+      if (result.message) process.stdout.write(result.message + "\n");
+      else out(result);
+      break;
+    }
+
+    case "viz": {
+      const outFile = process.argv[4];
+      if (!outFile) fail("Usage: viz <db> <outFile>");
+      const db = core.open(dbPath);
+      const fs = require("fs");
+
+      const nodes = db.prepare("SELECT id, node_type, label, properties, status FROM nodes WHERE status != 'deleted'").all();
+      const edges = db.prepare(`
+        SELECT e.from_node, e.edge_type, e.to_node, n1.label AS from_label, n2.label AS to_label
+        FROM edges e JOIN nodes n1 ON e.from_node = n1.id JOIN nodes n2 ON e.to_node = n2.id
+      `).all();
+
+      const graphData = { nodes: [], edges: [] };
+      for (const n of nodes) {
+        graphData.nodes.push({ id: n.id, label: n.label, type: n.node_type, status: n.status, props: JSON.parse(n.properties || "{}") });
+      }
+      for (const e of edges) {
+        graphData.edges.push({ from: e.from_node, to: e.to_node, type: e.edge_type, fromLabel: e.from_label, toLabel: e.to_label });
+      }
+
+      const html = viz.generateVizHTML(graphData, dbPath);
+      fs.writeFileSync(outFile, html, "utf8");
+      out({ status: "ok", file: outFile, nodes: graphData.nodes.length, edges: graphData.edges.length });
+      break;
+    }
+
+    case "export-snapshot": {
+      const outDir = process.argv[4];
+      if (!outDir) fail("Usage: export-snapshot <db> <outDir>");
+      const db = core.open(dbPath);
+      const snapshot = core.exportFullSnapshot(db);
+      const fs = require("fs"), p = require("path");
+      if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
+      for (const [filename, content] of Object.entries(snapshot)) {
+        fs.writeFileSync(p.join(outDir, filename), content, "utf8");
+      }
+      out({ status: "ok", snapshot_dir: outDir, files: Object.keys(snapshot) });
+      break;
+    }
+
+    case "sync-hooks": {
+      const filePath = process.argv[4];
+      if (!filePath) fail("Usage: sync-hooks <db> <foreshadowFile>");
+      out(core.syncHooksFromForeshadowFile(core.open(dbPath), filePath));
+      break;
+    }
+
+    case "exec": {
+      const sql = process.argv[4];
+      if (!sql) fail("Usage: exec <db> <sql>");
+      const db = core.open(dbPath);
+      const trimmed = sql.trim().toUpperCase();
+      if (trimmed.startsWith("SELECT") || trimmed.startsWith("WITH") || trimmed.startsWith("PRAGMA")) {
+        out({ rows: db.prepare(sql).all(), count: db.prepare("SELECT changes()").get() });
+      } else {
+        const result = db.prepare(sql).run();
+        out({ changes: result.changes, lastInsertRowid: result.lastInsertRowid });
+      }
+      break;
+    }
+
+    default:
+      fail("Commands: init stats state-at-time state-window hook-radar causal-chain knowledge-gap shortest-path trigger-hook resolve-hook abandon-hook hook-summary detect-debts flashback-opps repay-debt set-chapter-time set-timepoint-time set-event-offset repair-timeline timeline time-gaps story-timeline session-status prose-check sync-hooks viz export-snapshot exec");
+  }
+} catch (err) {
+  fail("Error: " + err.message);
+} finally {
+  core.close();
+}

--- a/skills/story-graph/scripts/story_graph_core.js
+++ b/skills/story-graph/scripts/story_graph_core.js
@@ -1,0 +1,1953 @@
+"use strict";
+
+/**
+ * story_graph_core.js — 叙事知识图谱核心操作库
+ *
+ * 提供 SQLite 数据库的 DDL 建表、CRUD、时间切片查询、钩子雷达等能力。
+ * 被 graph-builder agent（写入）、story-explorer agent（查询）和 hook 脚本共用。
+ *
+ * 依赖: better-sqlite3（同步 SQLite 驱动）
+ * 安装: npm install better-sqlite3
+ */
+
+const path = require("path");
+const fs = require("fs");
+
+// ─── better-sqlite3 驱动解析 ─────────────────────────────────
+// 写作项目根通常没有 package.json / node_modules，不能依赖 Node 默认向上解析。
+// 按部署拓扑依次尝试：
+//   1. .claude/hooks/ 的兄弟目录 .claude/skills/story-graph/node_modules（deploy-graph 把
+//      依赖装进 skill 目录，项目根保持干净）
+//   2. 本文件所在目录逐级向上的 node_modules（仓库内开发/测试，repo/node_modules）
+//   3. Node 默认解析（项目根有 node_modules 或全局安装时）
+function requireBetterSqlite3() {
+  const candidates = [
+    // 链接形态（skills CLI 安装）：core 在 .claude/hooks/ → .agents/skills/story-graph/node_modules
+    path.join(path.dirname(path.dirname(__dirname)), ".agents", "skills", "story-graph", "node_modules"),
+    // 真实目录形态：core 在 .claude/hooks/ → .claude/skills/story-graph/node_modules
+    path.join(path.dirname(__dirname), "skills", "story-graph", "node_modules"),
+    // 仓库内开发/测试：scripts → story-graph → skills → repo/node_modules
+    path.join(__dirname, "..", "..", "..", "node_modules"),
+  ];
+  try {
+    return require(require.resolve("better-sqlite3", { paths: candidates }));
+  } catch (e) {
+    return require("better-sqlite3");
+  }
+}
+
+const Database = requireBetterSqlite3();
+
+// ─── 活跃书发现（与 story_hook_core.js::discoverActiveBook 同口径） ──
+// 回退链：.active-book 首行（有效目录）→ 深度≤4 找「追踪/」目录（长篇）
+//       → 找「正文/」目录 → 找「正文.md」文件（短篇）。
+// 空/失效的 .active-book 绝不把项目根当书目录（否则 story.db 会建错位置）。
+function findFirst(base, maxDepth, predicate) {
+  if (maxDepth < 0) return null;
+  let entries = [];
+  try { entries = fs.readdirSync(base, { withFileTypes: true }); } catch { return null; }
+  for (const entry of entries) {
+    if (entry.name.startsWith(".") || entry.name === "node_modules") continue;
+    const full = path.join(base, entry.name);
+    if (predicate(full, entry)) return full;
+  }
+  if (maxDepth === 0) return null;
+  for (const entry of entries) {
+    if (!entry.isDirectory() || entry.name.startsWith(".") || entry.name === "node_modules") continue;
+    const found = findFirst(path.join(base, entry.name), maxDepth - 1, predicate);
+    if (found) return found;
+  }
+  return null;
+}
+
+function discoverBookDir(projectRoot) {
+  const activeBookPath = path.join(projectRoot, ".active-book");
+  if (fs.existsSync(activeBookPath)) {
+    const declared = fs.readFileSync(activeBookPath, "utf8").split(/\r?\n/, 1)[0].trim();
+    if (declared) {
+      const candidate = path.resolve(projectRoot, declared);
+      if (fs.existsSync(candidate) && fs.statSync(candidate).isDirectory()) return candidate;
+    }
+    // 空/失效声明：继续回退，不用项目根顶替
+  }
+  const tracking = findFirst(projectRoot, 4, (_full, entry) => entry.isDirectory() && entry.name === "追踪");
+  if (tracking) return path.dirname(tracking);
+  const body = findFirst(projectRoot, 4, (_full, entry) => entry.isDirectory() && entry.name === "正文");
+  if (body) return path.dirname(body);
+  const bodyFile = findFirst(projectRoot, 4, (_full, entry) => entry.isFile() && entry.name === "正文.md");
+  return bodyFile ? path.dirname(bodyFile) : null;
+}
+
+// ─── 数据库连接管理 ──────────────────────────────────────────
+// 按 dbPath 索引的连接池：同一进程可同时打开多本书的 story.db
+// （session-status / prose-check 按书发现库，不能共享单例，否则串库）。
+const _dbs = new Map();
+
+/**
+ * 打开（或创建）story.db
+ * @param {string} dbPath - 数据库文件路径
+ * @returns {import("better-sqlite3").Database}
+ */
+function open(dbPath) {
+  if (_dbs.has(dbPath)) return _dbs.get(dbPath);
+  const dir = path.dirname(dbPath);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  const db = new Database(dbPath);
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+  _dbs.set(dbPath, db);
+  return db;
+}
+
+function close() {
+  for (const db of _dbs.values()) db.close();
+  _dbs.clear();
+}
+
+function getDb() {
+  if (_dbs.size === 0) throw new Error("数据库未打开，请先调用 open(dbPath)");
+  return _dbs.values().next().value;
+}
+
+// ─── DDL 建表 ────────────────────────────────────────────────
+
+const SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS nodes (
+    id          TEXT PRIMARY KEY,
+    node_type   TEXT NOT NULL,
+    label       TEXT NOT NULL,
+    properties  TEXT NOT NULL DEFAULT '{}',
+    status      TEXT DEFAULT 'active',
+    created_at  TEXT DEFAULT (datetime('now')),
+    updated_at  TEXT DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_nodes_type ON nodes(node_type);
+CREATE INDEX IF NOT EXISTS idx_nodes_status ON nodes(status);
+
+CREATE TABLE IF NOT EXISTS edges (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    from_node     TEXT NOT NULL,
+    edge_type     TEXT NOT NULL,
+    to_node       TEXT NOT NULL,
+    properties    TEXT NOT NULL DEFAULT '{}',
+    valid_since   TEXT,
+    valid_until   TEXT,
+    created_by    TEXT DEFAULT 'graph-builder',
+    created_at    TEXT DEFAULT (datetime('now')),
+    FOREIGN KEY (from_node) REFERENCES nodes(id),
+    FOREIGN KEY (to_node) REFERENCES nodes(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_edges_from ON edges(from_node, edge_type);
+CREATE INDEX IF NOT EXISTS idx_edges_to ON edges(to_node, edge_type);
+CREATE INDEX IF NOT EXISTS idx_edges_type ON edges(edge_type);
+CREATE INDEX IF NOT EXISTS idx_edges_valid ON edges(valid_since, valid_until);
+
+CREATE TABLE IF NOT EXISTS knowledge_sources (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    person_id    TEXT NOT NULL,
+    target_id    TEXT NOT NULL,
+    source_type  TEXT NOT NULL,
+    source_event TEXT,
+    source_person TEXT,
+    acquired_at  TEXT,
+    confidence   REAL DEFAULT 1.0,
+    FOREIGN KEY (person_id) REFERENCES nodes(id),
+    FOREIGN KEY (target_id) REFERENCES nodes(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ks_person ON knowledge_sources(person_id);
+CREATE INDEX IF NOT EXISTS idx_ks_target ON knowledge_sources(target_id);
+
+CREATE TABLE IF NOT EXISTS hook_conditions (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    hook_id      TEXT NOT NULL,
+    condition_type TEXT NOT NULL,
+    target_id    TEXT,
+    logic_op     TEXT DEFAULT 'ANY',
+    combo_group  INTEGER DEFAULT 0,
+    FOREIGN KEY (hook_id) REFERENCES nodes(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_hc_hook ON hook_conditions(hook_id);
+
+CREATE TABLE IF NOT EXISTS staging_nodes (
+    id          TEXT PRIMARY KEY,
+    node_type   TEXT NOT NULL,
+    label       TEXT NOT NULL,
+    properties  TEXT NOT NULL DEFAULT '{}',
+    status      TEXT DEFAULT 'draft',
+    source_chapter TEXT,
+    action      TEXT DEFAULT 'create'
+);
+
+CREATE TABLE IF NOT EXISTS staging_edges (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    from_node     TEXT NOT NULL,
+    edge_type     TEXT NOT NULL,
+    to_node       TEXT NOT NULL,
+    properties    TEXT NOT NULL DEFAULT '{}',
+    valid_since   TEXT,
+    valid_until   TEXT,
+    source_chapter TEXT,
+    action        TEXT DEFAULT 'create'
+);
+
+CREATE TABLE IF NOT EXISTS narrative_physical_map (
+    chapter_id      TEXT NOT NULL,
+    physical_time   TEXT,
+    story_day       INTEGER,
+    absolute_order  INTEGER,
+    PRIMARY KEY (chapter_id),
+    FOREIGN KEY (chapter_id) REFERENCES nodes(id),
+    FOREIGN KEY (physical_time) REFERENCES nodes(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_npm_story_day ON narrative_physical_map(story_day);
+CREATE INDEX IF NOT EXISTS idx_npm_abs_order ON narrative_physical_map(absolute_order);
+
+-- 边连接展开视图：SQLite 视图无法参数化，时间窗口过滤请用
+-- stateAtTime() / stateWindow() 函数；本视图不做有效性过滤。
+CREATE VIEW IF NOT EXISTS v_state_at_time AS
+SELECT
+    n.id AS entity_id,
+    n.label AS entity_label,
+    n.node_type,
+    e.edge_type,
+    e.to_node AS related_node,
+    n2.label AS related_label,
+    n2.node_type AS related_type,
+    e.valid_since,
+    e.valid_until
+FROM nodes n
+JOIN edges e ON n.id = e.from_node
+JOIN nodes n2 ON e.to_node = n2.id;
+
+CREATE TABLE IF NOT EXISTS narrative_debts (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    question        TEXT NOT NULL,
+    answer_event    TEXT,
+    answer_time     TEXT,
+    triggered_by    TEXT,
+    character_id    TEXT,
+    priority        INTEGER DEFAULT 5,
+    suggested_window TEXT,
+    status          TEXT DEFAULT 'pending',
+    repaid_chapter  INTEGER,
+    created_at      TEXT DEFAULT (datetime('now')),
+    FOREIGN KEY (answer_event) REFERENCES nodes(id),
+    FOREIGN KEY (triggered_by) REFERENCES nodes(id),
+    FOREIGN KEY (character_id) REFERENCES nodes(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_nd_status ON narrative_debts(status);
+CREATE INDEX IF NOT EXISTS idx_nd_char ON narrative_debts(character_id);
+`;
+
+function initSchema(dbPath) {
+  const db = open(dbPath);
+  db.exec(SCHEMA_SQL);
+  return db;
+}
+
+// ─── 节点 CRUD ───────────────────────────────────────────────
+
+function upsertNode(node, db) {
+  const d = db || getDb();
+  const stmt = d.prepare(`
+    INSERT INTO nodes (id, node_type, label, properties, status, updated_at)
+    VALUES (@id, @node_type, @label, @properties, @status, datetime('now'))
+    ON CONFLICT(id) DO UPDATE SET
+      node_type=excluded.node_type,
+      label=excluded.label,
+      properties=excluded.properties,
+      status=excluded.status,
+      updated_at=datetime('now')
+  `);
+  return stmt.run({
+    id: node.id,
+    node_type: node.node_type,
+    label: node.label,
+    properties: typeof node.properties === "string" ? node.properties : JSON.stringify(node.properties || {}),
+    status: node.status || "active"
+  });
+}
+
+function upsertNodes(nodes, db) {
+  const d = db || getDb();
+  const insert = d.transaction((items) => {
+    for (const node of items) upsertNode(node, d);
+  });
+  insert(nodes);
+}
+
+function getNode(id, db) {
+  const d = db || getDb();
+  const row = d.prepare("SELECT * FROM nodes WHERE id = ?").get(id);
+  if (row) row.properties = JSON.parse(row.properties || "{}");
+  return row;
+}
+
+function getNodesByType(nodeType, db) {
+  const d = db || getDb();
+  const rows = d.prepare("SELECT * FROM nodes WHERE node_type = ? AND status = 'active'").all(nodeType);
+  for (const r of rows) r.properties = JSON.parse(r.properties || "{}");
+  return rows;
+}
+
+function getAllNodes(db) {
+  const d = db || getDb();
+  const rows = d.prepare("SELECT * FROM nodes WHERE status = 'active'").all();
+  for (const r of rows) r.properties = JSON.parse(r.properties || "{}");
+  return rows;
+}
+
+function deleteNode(id, db) {
+  const d = db || getDb();
+  d.prepare("DELETE FROM nodes WHERE id = ?").run(id);
+  d.prepare("DELETE FROM edges WHERE from_node = ? OR to_node = ?").run(id, id);
+}
+
+// ─── 边 CRUD ─────────────────────────────────────────────────
+
+function upsertEdge(edge, db) {
+  const d = db || getDb();
+  const stmt = d.prepare(`
+    INSERT INTO edges (from_node, edge_type, to_node, properties, valid_since, valid_until, created_by, created_at)
+    VALUES (@from_node, @edge_type, @to_node, @properties, @valid_since, @valid_until, @created_by, datetime('now'))
+  `);
+  return stmt.run({
+    from_node: edge.from_node,
+    edge_type: edge.edge_type,
+    to_node: edge.to_node,
+    properties: typeof edge.properties === "string" ? edge.properties : JSON.stringify(edge.properties || {}),
+    valid_since: edge.valid_since || null,
+    valid_until: edge.valid_until || null,
+    created_by: edge.created_by || "graph-builder"
+  });
+}
+
+function upsertEdges(edges, db) {
+  const d = db || getDb();
+  const insert = d.transaction((items) => {
+    for (const edge of items) upsertEdge(edge, d);
+  });
+  insert(edges);
+}
+
+/**
+ * 删除并重建某实体的所有出边（用于增量更新时替换边集合）
+ */
+function replaceEdgesFrom(fromNode, edgeType, newEdges, db) {
+  const d = db || getDb();
+  const del = d.transaction(() => {
+    d.prepare("DELETE FROM edges WHERE from_node = ? AND edge_type = ?").run(fromNode, edgeType);
+    for (const edge of newEdges) {
+      edge.from_node = fromNode;
+      edge.edge_type = edgeType;
+      upsertEdge(edge, d);
+    }
+  });
+  del();
+}
+
+function getEdgesFrom(fromNode, edgeType, db) {
+  const d = db || getDb();
+  let sql = "SELECT * FROM edges WHERE from_node = ?";
+  const params = [fromNode];
+  if (edgeType) { sql += " AND edge_type = ?"; params.push(edgeType); }
+  const rows = d.prepare(sql).all(...params);
+  for (const r of rows) r.properties = JSON.parse(r.properties || "{}");
+  return rows;
+}
+
+function getEdgesTo(toNode, edgeType, db) {
+  const d = db || getDb();
+  let sql = "SELECT * FROM edges WHERE to_node = ?";
+  const params = [toNode];
+  if (edgeType) { sql += " AND edge_type = ?"; params.push(edgeType); }
+  const rows = d.prepare(sql).all(...params);
+  for (const r of rows) r.properties = JSON.parse(r.properties || "{}");
+  return rows;
+}
+
+// ─── 聚合查询：时间切片 ─────────────────────────────────────
+
+/**
+ * 解析 TIME_POINT 节点的 epoch（无该字段返回 null）
+ */
+function resolveTimePointEpoch(d, tpId) {
+  if (!tpId) return null;
+  const row = d.prepare(
+    "SELECT json_extract(properties, '$.epoch') AS epoch FROM nodes WHERE id = ? AND node_type = 'TIME_POINT'"
+  ).get(tpId);
+  return row && row.epoch != null ? Number(row.epoch) : null;
+}
+
+/**
+ * 判定边在给定时间点是否有效。
+ *
+ * 语义：valid_since <= time_point < valid_until（端点开区间）。
+ * 时间锚点能解析成 epoch 时按数值比较；查询点无 epoch，或端点锚点无 epoch
+ * 时退化为 ID 字符串比较（尽力而为，兼容旧数据），无法验证的端点按有效放行。
+ *
+ * @param {object} d
+ * @param {object} edge - 含 valid_since / valid_until（TIME_POINT ID）
+ * @param {string} timePointId - 查询时间点 ID
+ * @param {number|null} timePointEpoch - 查询时间点 epoch（可缓存复用）
+ */
+function edgeValidInWindow(d, edge, timePointId, timePointEpoch) {
+  const sinceEpoch = edge.valid_since != null ? resolveTimePointEpoch(d, edge.valid_since) : null;
+  const untilEpoch = edge.valid_until != null ? resolveTimePointEpoch(d, edge.valid_until) : null;
+  if (timePointEpoch != null) {
+    const sinceOk = sinceEpoch == null || sinceEpoch <= timePointEpoch;
+    const untilOk = untilEpoch == null || untilEpoch > timePointEpoch;
+    return sinceOk && untilOk;
+  }
+  const sinceOk = edge.valid_since == null || edge.valid_since <= timePointId;
+  const untilOk = edge.valid_until == null || edge.valid_until > timePointId;
+  return sinceOk && untilOk;
+}
+
+/**
+ * 判定边的有效区间是否与 [timeStart, timeEnd] 窗口相交。
+ * 端点能解析成 epoch 时数值比较；否则退化 ID 字符串比较。
+ */
+function edgeOverlapsWindow(d, edge, timeStartId, timeStartEpoch, timeEndId, timeEndEpoch) {
+  const sinceEpoch = edge.valid_since != null ? resolveTimePointEpoch(d, edge.valid_since) : null;
+  const untilEpoch = edge.valid_until != null ? resolveTimePointEpoch(d, edge.valid_until) : null;
+  if (timeStartEpoch != null && timeEndEpoch != null) {
+    const sinceOk = sinceEpoch == null || sinceEpoch < timeEndEpoch;
+    const untilOk = untilEpoch == null || untilEpoch > timeStartEpoch;
+    return sinceOk && untilOk;
+  }
+  const sinceOk = edge.valid_since == null || edge.valid_since < timeEndId;
+  const untilOk = edge.valid_until == null || edge.valid_until > timeStartId;
+  return sinceOk && untilOk;
+}
+
+/**
+ * 判定边的有效区间是否完整覆盖 [timeStart, timeEnd] 窗口（窗口内全程有效）。
+ */
+function edgeCoversWindow(d, edge, timeStartId, timeStartEpoch, timeEndId, timeEndEpoch) {
+  const sinceEpoch = edge.valid_since != null ? resolveTimePointEpoch(d, edge.valid_since) : null;
+  const untilEpoch = edge.valid_until != null ? resolveTimePointEpoch(d, edge.valid_until) : null;
+  if (timeStartEpoch != null && timeEndEpoch != null) {
+    const sinceOk = sinceEpoch == null || sinceEpoch <= timeStartEpoch;
+    const untilOk = untilEpoch == null || untilEpoch > timeEndEpoch;
+    return sinceOk && untilOk;
+  }
+  const sinceOk = edge.valid_since == null || edge.valid_since <= timeStartId;
+  const untilOk = edge.valid_until == null || edge.valid_until > timeEndId;
+  return sinceOk && untilOk;
+}
+
+/**
+ * 查询某时间点的角色/实体状态快照
+ *
+ * 语义：沿物理时间线，取 valid_since <= time_point < valid_until 的所有边。
+ *
+ * @param {string} entityId - 实体 ID，如 "P_沈栀"
+ * @param {string} timePointId - 时间点节点 ID，如 "T_星辰历1025年春"
+ * @param {object} db
+ * @returns {object} 状态快照
+ */
+function stateAtTime(entityId, timePointId, db) {
+  const d = db || getDb();
+  const timePointEpoch = resolveTimePointEpoch(d, timePointId);
+
+  const allEdges = d.prepare(`
+    SELECT e.edge_type, e.to_node, n2.label AS related_label, n2.node_type AS related_type,
+           e.properties, e.valid_since, e.valid_until
+    FROM edges e
+    JOIN nodes n2 ON e.to_node = n2.id
+    WHERE e.from_node = ?
+    ORDER BY e.edge_type
+  `).all(entityId).filter((edge) => edgeValidInWindow(d, edge, timePointId, timePointEpoch));
+
+  const result = {
+    entity_id: entityId,
+    time_point: timePointId,
+    location: null,
+    holding: [],
+    knows: [],
+    relationships: [],
+    abilities: [],
+    org: null
+  };
+
+  for (const e of allEdges) {
+    const props = JSON.parse(e.properties || "{}");
+    switch (e.edge_type) {
+      case "LOCATED_AT":
+        result.location = { id: e.to_node, label: e.related_label, since: e.valid_since };
+        break;
+      case "OWNS":
+        result.holding.push({ id: e.to_node, label: e.related_label, since: e.valid_since });
+        break;
+      case "KNOWS_ABOUT":
+        result.knows.push({ id: e.to_node, label: e.related_label, via: props.via || "unknown" });
+        break;
+      case "BELONGS_TO":
+        result.org = { id: e.to_node, label: e.related_label };
+        break;
+      case "POSSESSES":
+        result.abilities.push({ id: e.to_node, label: e.related_label });
+        break;
+      case "KIN_TO":
+      case "ALLIED_WITH":
+      case "HOSTILE_TO":
+      case "ROMANTIC_WITH":
+      case "MENTOR_OF":
+        result.relationships.push({
+          target: { id: e.to_node, label: e.related_label },
+          type: e.edge_type,
+          since: e.valid_since
+        });
+        break;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * 时空窗口批量查询 — 一次查询某时空范围内的所有实体状态
+ *
+ * @param {{timeStart: string, timeEnd: string, location: string|null}} window
+ * @param {string[]} entityTypes - ['PERSON', 'ITEM', ...] 默认所有
+ * @param {object} db
+ * @returns {object} 窗口内每类实体的完整状态
+ */
+function stateWindow(window, entityTypes, db) {
+  const d = db || getDb();
+  const types = entityTypes || ["PERSON", "ITEM", "EVENT"];
+
+  // 时间窗口解析一次，避免逐实体重复查 TIME_POINT
+  const timeStartEpoch = resolveTimePointEpoch(d, window.timeStart);
+  const timeEndEpoch = resolveTimePointEpoch(d, window.timeEnd);
+
+  const result = {};
+
+  for (const nodeType of types) {
+    const entities = d.prepare(`
+      SELECT id, label, properties FROM nodes
+      WHERE node_type = ? AND status = 'active'
+    `).all(nodeType);
+
+    for (const entity of entities) {
+      // 检查此实体是否在时空窗口内存在：有指向窗口地点的边，
+      // 或有效区间与窗口相交（端点 epoch 数值比较；无 epoch 退化 ID 字符串）
+      const relevantEdges = d.prepare(`
+        SELECT * FROM edges e
+        WHERE e.from_node = ?
+          AND e.edge_type IN ('LOCATED_AT','OCCURS_AT','PARTICIPATES_IN')
+      `).all(entity.id);
+      const relevant = relevantEdges.some((edge) => {
+        if (window.location && edge.to_node === window.location) return true;
+        return edgeOverlapsWindow(d, edge, window.timeStart, timeStartEpoch, window.timeEnd, timeEndEpoch);
+      });
+
+      if (!relevant) continue;
+
+      // 获取该实体的窗口内状态：有效区间覆盖整个窗口的边
+      const state = d.prepare(`
+        SELECT e.edge_type, e.to_node, n2.label AS related_label, n2.node_type AS related_type,
+               e.properties, e.valid_since, e.valid_until
+        FROM edges e
+        JOIN nodes n2 ON e.to_node = n2.id
+        WHERE e.from_node = ?
+        ORDER BY e.edge_type
+      `).all(entity.id).filter((edge) =>
+        edgeCoversWindow(d, edge, window.timeStart, timeStartEpoch, window.timeEnd, timeEndEpoch),
+      );
+
+      const entityState = {
+        id: entity.id,
+        label: entity.label,
+        type: nodeType,
+        location: null,
+        holding: [],
+        knows: [],
+        relationships: [],
+        involved_events: []
+      };
+
+      for (const e of state) {
+        switch (e.edge_type) {
+          case "LOCATED_AT":
+            entityState.location = { id: e.to_node, label: e.related_label };
+            break;
+          case "OWNS":
+            entityState.holding.push({ id: e.to_node, label: e.related_label });
+            break;
+          case "KNOWS_ABOUT":
+            entityState.knows.push({ id: e.to_node, label: e.related_label });
+            break;
+          case "PARTICIPATES_IN":
+            entityState.involved_events.push({ id: e.to_node, label: e.related_label });
+            break;
+          case "KIN_TO": case "ALLIED_WITH": case "HOSTILE_TO":
+          case "ROMANTIC_WITH": case "MENTOR_OF":
+            entityState.relationships.push({
+              target: { id: e.to_node, label: e.related_label },
+              type: e.edge_type
+            });
+            break;
+        }
+      }
+
+      if (!result[nodeType]) result[nodeType] = [];
+      result[nodeType].push(entityState);
+    }
+  }
+
+  // 添加时间窗口内的事件列表（按 OCCURS_AT → TIME_POINT.epoch 过滤，
+  // 不再比较时间点 ID 字符串；无 epoch 的时间点无法验证，保留）
+  const events = d.prepare(`
+    SELECT n.id, n.label, json_extract(n.properties, '$.chapter') AS ch,
+           json_extract(n.properties, '$.event_type') AS ev_type,
+           json_extract(tp.properties, '$.epoch') AS epoch,
+           COALESCE(json_extract(n.properties, '$.story_offset'), json_extract(n.properties, '$.narrative_order'), 0) AS offset
+    FROM nodes n
+    JOIN edges e ON n.id = e.from_node AND e.edge_type = 'OCCURS_AT'
+    JOIN nodes tp ON e.to_node = tp.id
+    WHERE n.node_type = 'EVENT' AND n.status = 'active'
+    ORDER BY CAST(json_extract(tp.properties, '$.epoch') AS REAL), offset
+  `).all().filter((ev) => {
+    const ep = ev.epoch == null ? null : Number(ev.epoch);
+    if (ep == null) return true;
+    if (timeStartEpoch != null && ep < timeStartEpoch) return false;
+    if (timeEndEpoch != null && ep > timeEndEpoch) return false;
+    return true;
+  });
+
+  result.EVENTS = events;
+
+  return {
+    window: { timeStart: window.timeStart, timeEnd: window.timeEnd, location: window.location },
+    entities: result
+  };
+}
+
+// ─── 聚合查询：因果链 ───────────────────────────────────────
+
+/**
+ * 从某事件沿 CAUSES 边向下游（或上游）遍历
+ * @param {string} eventId
+ * @param {'forward'|'backward'} direction
+ * @param {number} maxDepth
+ * @param {object} db
+ * @returns {Array<{from: string, to: string, depth: number, event_label: string}>}
+ */
+function causalChain(eventId, direction, maxDepth, db) {
+  const d = db || getDb();
+  if (maxDepth == null) maxDepth = 5;
+  if (!direction) direction = "forward";
+
+  const fromCol = direction === "forward" ? "from_node" : "to_node";
+  const toCol = direction === "forward" ? "to_node" : "from_node";
+
+  const rows = d.prepare(`
+    WITH RECURSIVE chain AS (
+        SELECT e.from_node, e.edge_type, e.to_node, 1 AS depth
+        FROM edges e
+        WHERE e.${fromCol} = ? AND e.edge_type = 'CAUSES'
+
+        UNION ALL
+
+        SELECT e.from_node, e.edge_type, e.to_node, c.depth + 1
+        FROM edges e
+        JOIN chain c ON e.${fromCol} = c.${toCol}
+        WHERE e.edge_type = 'CAUSES' AND c.depth < ?
+    )
+    SELECT c.from_node, c.to_node, c.depth, n.label AS event_label
+    FROM chain c
+    JOIN nodes n ON c.to_node = n.id
+    ORDER BY c.depth
+  `).all(eventId, maxDepth);
+
+  return rows;
+}
+
+// ─── 聚合查询：最短关系路径 ─────────────────────────────────
+
+/**
+ * 两个角色之间的最短关系路径
+ */
+function shortestRelationshipPath(fromPerson, toPerson, maxDepth, db) {
+  const d = db || getDb();
+  if (maxDepth == null) maxDepth = 4;
+
+  const rows = d.prepare(`
+    WITH RECURSIVE path AS (
+        SELECT from_node, to_node, edge_type, 1 AS depth,
+               from_node || '--[' || edge_type || ']-->' || to_node AS path_str
+        FROM edges
+        WHERE from_node = ?
+
+        UNION ALL
+
+        SELECT e.from_node, e.to_node, e.edge_type, p.depth + 1,
+               p.path_str || '--[' || e.edge_type || ']-->' || e.to_node
+        FROM edges e
+        JOIN path p ON e.from_node = p.to_node
+        WHERE p.depth < ? AND e.from_node != ?
+    )
+    SELECT * FROM path WHERE to_node = ?
+    ORDER BY depth LIMIT 1
+  `).all(fromPerson, maxDepth, toPerson, toPerson);
+
+  return rows.length > 0 ? rows[0] : null;
+}
+
+// ─── 聚合查询：钩子雷达 ─────────────────────────────────────
+
+/**
+ * 给定场景实体，计算所有活跃钩子的匹配分数
+ *
+ * @param {{ entities: string[], states: string[], location: string|null, timePoint: string|null }} scene
+ *   states — 场景中已发生的状态变更 NODE ID 列表（state 条件按它匹配）
+ * @param {number} currentChapter - 当前章节号，用于遗忘惩罚计算
+ * @param {object} db
+ * @returns {Array<{hook_id: string, hook_label: string, score: number, reason: string}>}
+ */
+function hookRadar(scene, currentChapter, db) {
+  const d = db || getDb();
+
+  const hooks = d.prepare(`
+    SELECT * FROM nodes WHERE node_type = 'HOOK' AND status IN ('active', 'dormant')
+  `).all();
+
+  const results = [];
+
+  for (const hook of hooks) {
+    const props = JSON.parse(hook.properties || "{}");
+    let score = 0;
+    const reasons = [];
+
+    // 基础优先级分
+    score += (props.priority || 5) * 5;
+
+    // 遗忘惩罚：超过 30 章未触发
+    if (props.planted_chapter && currentChapter - props.planted_chapter > 30) {
+      score += 15;
+      reasons.push(`埋设于第${props.planted_chapter}章，已过${currentChapter - props.planted_chapter}章未触发`);
+    }
+
+    // 检查触发条件
+    const conditions = d.prepare("SELECT * FROM hook_conditions WHERE hook_id = ?").all(hook.id);
+
+    for (const cond of conditions) {
+      if (cond.condition_type === "entity" && scene.entities && scene.entities.includes(cond.target_id)) {
+        score += 30;
+        reasons.push(`实体匹配: ${cond.target_id}`);
+      }
+      if (cond.condition_type === "location" && scene.location === cond.target_id) {
+        score += 25;
+        reasons.push(`地点匹配: ${cond.target_id}`);
+      }
+      if (cond.condition_type === "time" && scene.timePoint === cond.target_id) {
+        score += 20;
+        reasons.push(`时间匹配: ${cond.target_id}`);
+      }
+      // state 条件必须与场景传入的状态变更列表匹配才加分，不得无条件命中
+      if (cond.condition_type === "state" && scene.states && scene.states.includes(cond.target_id)) {
+        score += 35;
+        reasons.push(`状态变更触发: ${cond.target_id}`);
+      }
+    }
+
+    results.push({
+      hook_id: hook.id,
+      hook_label: hook.label,
+      hook_type: props.hook_type || "unknown",
+      score,
+      planted_chapter: props.planted_chapter,
+      expected_trigger_window: props.expected_trigger_window,
+      match_reason: reasons.join("; ") || "基础匹配"
+    });
+  }
+
+  results.sort((a, b) => b.score - a.score);
+  return results;
+}
+
+// ─── 聚合查询：知识缺口检测 ─────────────────────────────────
+
+/**
+ * 检查某角色是否知道某事实，以及知识来源
+ */
+function knowledgeGap(personId, factId, db) {
+  const d = db || getDb();
+
+  const ks = d.prepare(`
+    SELECT * FROM knowledge_sources
+    WHERE person_id = ? AND target_id = ?
+    ORDER BY confidence DESC LIMIT 1
+  `).get(personId, factId);
+
+  if (ks) {
+    return {
+      person_id: personId,
+      fact_id: factId,
+      knows: true,
+      source_type: ks.source_type,
+      source_event: ks.source_event,
+      source_person: ks.source_person,
+      acquired_at: ks.acquired_at,
+      confidence: ks.confidence
+    };
+  }
+
+  // 检查是否有 KNOWS_ABOUT 边
+  const edge = d.prepare(`
+    SELECT * FROM edges WHERE from_node = ? AND to_node = ? AND edge_type = 'KNOWS_ABOUT'
+  `).get(personId, factId);
+
+  if (edge) {
+    return {
+      person_id: personId,
+      fact_id: factId,
+      knows: true,
+      source_type: "edge",
+      properties: JSON.parse(edge.properties || "{}")
+    };
+  }
+
+  return {
+    person_id: personId,
+    fact_id: factId,
+    knows: false,
+    gap: "角色表现出知道此信息，但无法追溯到 WITNESS/INFORMED_BY/DEDUCTION/BACKSTORY"
+  };
+}
+
+// ─── 钩子生命周期管理 ────────────────────────────────────────
+
+/**
+ * 钩子状态机: dormant → triggered → resolved
+ *              dormant/triggered → abandoned
+ */
+
+/**
+ * 触发钩子: dormant → triggered
+ */
+function triggerHook(hookId, chapterNum, db) {
+  const d = db || getDb();
+  const node = d.prepare("SELECT * FROM nodes WHERE id = ? AND node_type = 'HOOK'").get(hookId);
+  if (!node) throw new Error(`钩子不存在: ${hookId}`);
+  if (node.status !== "active" && node.status !== "dormant") {
+    throw new Error(`钩子 ${hookId} 当前状态为 ${node.status}，无法触发（需为 active/dormant）`);
+  }
+
+  d.prepare("UPDATE nodes SET status = 'triggered', updated_at = datetime('now') WHERE id = ?").run(hookId);
+
+  const props = JSON.parse(node.properties || "{}");
+  props.triggered_chapter = chapterNum;
+  d.prepare("UPDATE nodes SET properties = ? WHERE id = ?").run(JSON.stringify(props), hookId);
+
+  // 创建 TRIGGERED_IN 边
+  d.prepare("DELETE FROM edges WHERE from_node = ? AND edge_type = 'TRIGGERED_IN'").run(hookId);
+  d.prepare(`INSERT INTO edges (from_node, edge_type, to_node, properties, created_by)
+    VALUES (?, 'TRIGGERED_IN', ?, '{}', 'hook-engine')`).run(hookId, `C_${String(chapterNum).padStart(3, '0')}`);
+
+  return { hook_id: hookId, new_status: "triggered", triggered_chapter: chapterNum };
+}
+
+/**
+ * 解决钩子: triggered → resolved
+ */
+function resolveHook(hookId, chapterNum, db) {
+  const d = db || getDb();
+  const node = d.prepare("SELECT * FROM nodes WHERE id = ? AND node_type = 'HOOK'").get(hookId);
+  if (!node) throw new Error(`钩子不存在: ${hookId}`);
+  if (node.status !== "triggered") {
+    throw new Error(`钩子 ${hookId} 当前状态为 ${node.status}，无法解决（需为 triggered）`);
+  }
+
+  d.prepare("UPDATE nodes SET status = 'resolved', updated_at = datetime('now') WHERE id = ?").run(hookId);
+
+  const props = JSON.parse(node.properties || "{}");
+  props.resolved_chapter = chapterNum;
+  d.prepare("UPDATE nodes SET properties = ? WHERE id = ?").run(JSON.stringify(props), hookId);
+
+  // 创建 RESOLVED_IN 边
+  d.prepare("DELETE FROM edges WHERE from_node = ? AND edge_type = 'RESOLVED_IN'").run(hookId);
+  d.prepare(`INSERT INTO edges (from_node, edge_type, to_node, properties, created_by)
+    VALUES (?, 'RESOLVED_IN', ?, '{}', 'hook-engine')`).run(hookId, `C_${String(chapterNum).padStart(3, '0')}`);
+
+  return { hook_id: hookId, new_status: "resolved", resolved_chapter: chapterNum };
+}
+
+/**
+ * 放弃钩子: any → abandoned
+ */
+function abandonHook(hookId, reason, db) {
+  const d = db || getDb();
+  const node = d.prepare("SELECT * FROM nodes WHERE id = ? AND node_type = 'HOOK'").get(hookId);
+  if (!node) throw new Error(`钩子不存在: ${hookId}`);
+  if (node.status === "resolved") {
+    throw new Error(`钩子 ${hookId} 已解决，无法放弃`);
+  }
+
+  const props = JSON.parse(node.properties || "{}");
+  props.abandoned_reason = reason || "作者废弃";
+  d.prepare("UPDATE nodes SET status = 'abandoned', properties = ?, updated_at = datetime('now') WHERE id = ?")
+    .run(JSON.stringify(props), hookId);
+
+  return { hook_id: hookId, new_status: "abandoned", reason: props.abandoned_reason };
+}
+
+/**
+ * 钩子生命周期汇总
+ */
+function hookLifecycleSummary(db) {
+  const d = db || getDb();
+  const rows = d.prepare(`
+    SELECT id, label, status, properties FROM nodes WHERE node_type = 'HOOK' ORDER BY status, id
+  `).all();
+
+  const summary = { dormant: [], active: [], triggered: [], resolved: [], abandoned: [] };
+  for (const r of rows) {
+    const props = JSON.parse(r.properties || "{}");
+    summary[r.status] = summary[r.status] || [];
+    summary[r.status].push({
+      id: r.id, label: r.label,
+      hook_type: props.hook_type,
+      priority: props.priority,
+      planted_chapter: props.planted_chapter,
+      triggered_chapter: props.triggered_chapter,
+      resolved_chapter: props.resolved_chapter,
+      expected_trigger_window: props.expected_trigger_window
+    });
+  }
+  return summary;
+}
+
+/**
+ * 检测钩子依赖环（PREREQUISITE_FOR 边）
+ */
+function checkHookDependencyCycle(newPrerequisiteId, newHookId, db) {
+  const d = db || getDb();
+  const row = d.prepare(`
+    WITH RECURSIVE dep AS (
+        SELECT from_node, to_node, 1 AS depth
+        FROM edges
+        WHERE edge_type = 'PREREQUISITE_FOR' AND from_node = ?
+
+        UNION ALL
+
+        SELECT e.from_node, e.to_node, d.depth + 1
+        FROM edges e
+        JOIN dep d ON e.from_node = d.to_node
+        WHERE e.edge_type = 'PREREQUISITE_FOR' AND d.depth < 50
+    )
+    SELECT 1 FROM dep WHERE to_node = ? LIMIT 1
+  `).get(newPrerequisiteId, newHookId);
+
+  return row ? { cycle_detected: true, message: `添加 ${newPrerequisiteId} → ${newHookId} 会产生依赖环` }
+             : { cycle_detected: false };
+}
+
+// ─── 伏笔文件同步（钩子数据源） ──────────────────────────────
+
+/**
+ * 解析 追踪/伏笔.md 状态表。
+ *
+ * 表格格式（与 detect-story-gaps.sh / story-explorer 的解析口径一致）：
+ *   | ID | 伏笔内容 | 埋设章节 | 预计回收章节 | 状态 | 重要度 |
+ * 状态取值：已埋 / 已回收 / 未埋 / 废弃。
+ *
+ * @param {string} filePath - 伏笔.md 绝对路径
+ * @returns {Array<{id: string, summary: string, planted_chapter: number|null,
+ *                   expected_recovery: string|null, status: string, importance: string}>}
+ */
+function parseForeshadowFile(filePath) {
+  const fs = require("fs");
+  let text;
+  try {
+    text = fs.readFileSync(filePath, "utf8");
+  } catch {
+    return [];
+  }
+  const rows = [];
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line.startsWith("|")) continue;
+    const cells = line.split("|").map((cell) => cell.trim());
+    // | ID | 内容 | 埋设章节 | 预计回收章节 | 状态 | 重要度 | → 7 个段（首尾空段）
+    if (cells.length < 7) continue;
+    const id = cells[1];
+    const summary = cells[2];
+    const plantedRaw = cells[3];
+    const recoveryRaw = cells[4];
+    const status = cells[5];
+    const importance = cells[6];
+    if (!id || /^-+$/.test(id) || /^ID$/i.test(id) || !summary) continue;
+    const chapterMatch = String(plantedRaw).match(/第\s*(\d+)\s*章/);
+    rows.push({
+      id,
+      summary,
+      planted_chapter: chapterMatch ? Number(chapterMatch[1]) : null,
+      expected_recovery: String(recoveryRaw).match(/第\s*(\d+)\s*章/) ? String(recoveryRaw) : null,
+      status,
+      importance,
+    });
+  }
+  return rows;
+}
+
+const FORESHADOW_STATUS_TO_NODE = {
+  "已埋": "dormant",
+  "未埋": "draft",
+  "已回收": "resolved",
+  "废弃": "abandoned",
+};
+const FORESHADOW_IMPORTANCE_PRIORITY = { "高": 9, "中": 5, "低": 2 };
+
+/**
+ * 将 追踪/伏笔.md 同步为 HOOK 节点 + PLANTS_IN 边（幂等，可重复执行）。
+ *
+ * - 每个伏笔行 → HOOK 节点（id = H_{ID}），status 按状态映射；
+ *   已埋→dormant、未埋→draft、已回收→resolved、废弃→abandoned。
+ * - 手动管理保护：文件中为「已埋」但图中已是 triggered/resolved/abandoned 的
+ *   钩子不降级（保留手动状态）；「已回收」则统一置 resolved。
+ * - 埋设章节可解析时，幂等重建 PLANTS_IN → C_{三位章号} 边（章节点不存在则跳过）。
+ * - 文件是钩子状态的权威源；手动 trigger/resolve/abandon 与文件状态冲突时
+ *   以文件为准（「已埋」除外，见上）。
+ *
+ * @param {object} db
+ * @param {string} foreshadowFilePath - 追踪/伏笔.md 路径
+ * @returns {{created: number, updated: number, resolved: number, kept_manual: number, total: number, hooks: Array<{id: string, status: string}>}}
+ */
+function syncHooksFromForeshadowFile(db, foreshadowFilePath) {
+  const d = db || getDb();
+  const rows = parseForeshadowFile(foreshadowFilePath);
+  const summary = { created: 0, updated: 0, resolved: 0, kept_manual: 0, total: rows.length, hooks: [] };
+
+  const plantStmt = d.prepare("DELETE FROM edges WHERE from_node = ? AND edge_type = 'PLANTS_IN'");
+  const insertPlantStmt = d.prepare(`
+    INSERT INTO edges (from_node, edge_type, to_node, properties, created_by)
+    VALUES (?, 'PLANTS_IN', ?, '{}', 'graph-builder')
+  `);
+
+  const tx = d.transaction(() => {
+    for (const row of rows) {
+      const hookId = `H_${row.id}`;
+      const targetStatus = FORESHADOW_STATUS_TO_NODE[row.status] || "dormant";
+      const priority = FORESHADOW_IMPORTANCE_PRIORITY[row.importance] || 5;
+      const existing = d.prepare("SELECT * FROM nodes WHERE id = ? AND node_type = 'HOOK'").get(hookId);
+
+      let effectiveStatus = targetStatus;
+      let mode = "created";
+      if (existing) {
+        // 手动管理保护：已埋 不降级已触发/已解决/已废弃的钩子
+        if (targetStatus === "dormant" && ["triggered", "resolved", "abandoned"].includes(existing.status)) {
+          effectiveStatus = existing.status;
+          mode = "kept_manual";
+        } else if (targetStatus === "resolved" && existing.status !== "resolved") {
+          effectiveStatus = "resolved";
+          mode = "resolved";
+        } else if (targetStatus !== existing.status) {
+          effectiveStatus = targetStatus;
+          mode = "updated";
+        } else {
+          mode = "unchanged";
+        }
+      }
+
+      const props = {
+        hook_type: "foreshadow",
+        summary: row.summary,
+        priority,
+        source: "伏笔.md",
+      };
+      if (row.planted_chapter != null) props.planted_chapter = row.planted_chapter;
+      if (row.expected_recovery != null) props.expected_trigger_window = row.expected_recovery;
+
+      upsertNode({
+        id: hookId,
+        node_type: "HOOK",
+        label: row.summary.length > 40 ? `${row.summary.slice(0, 40)}…` : row.summary,
+        properties: props,
+        status: effectiveStatus,
+      }, d);
+
+      if (summary[mode] == null) summary[mode] = 0;
+      summary[mode] += 1;
+      summary.hooks.push({ id: hookId, status: effectiveStatus });
+
+      // 幂等重建 PLANTS_IN 边
+      if (row.planted_chapter != null) {
+        const chapterId = `C_${String(row.planted_chapter).padStart(3, "0")}`;
+        const chapterExists = d.prepare("SELECT 1 FROM nodes WHERE id = ?").get(chapterId);
+        if (chapterExists) {
+          plantStmt.run(hookId);
+          insertPlantStmt.run(hookId, chapterId);
+        }
+      }
+    }
+  });
+  tx();
+
+  return summary;
+}
+
+// ─── 快照导出 ────────────────────────────────────────────────
+
+/**
+ * 导出节点为文本表格（按类型分组）
+ */
+function exportNodesText(db) {
+  const d = db || getDb();
+  const types = ["PERSON", "LOCATION", "EVENT", "ITEM", "ORG", "TIME_POINT", "CHAPTER", "HOOK"];
+  const result = {};
+
+  for (const t of types) {
+    const rows = d.prepare("SELECT id, label, status, properties FROM nodes WHERE node_type = ? ORDER BY id").all(t);
+    if (rows.length === 0) continue;
+    const lines = [];
+    lines.push(`# ${t}`);
+    for (const r of rows) {
+      const props = JSON.parse(r.properties || "{}");
+      const brief = Object.entries(props)
+        .filter(([k]) => !["aliases", "backstory_knowledge"].includes(k))
+        .map(([k, v]) => typeof v === "string" ? `${k}=${v}` : `${k}=${JSON.stringify(v)}`)
+        .join(" | ");
+      lines.push(`${r.id} | ${r.label} | ${r.status} | ${brief}`);
+    }
+    result[`nodes_${t.toLowerCase()}.txt`] = lines.join("\n") + "\n";
+  }
+
+  return result;
+}
+
+/**
+ * 导出边为文本表格（按类型分组）
+ */
+function exportEdgesText(db) {
+  const d = db || getDb();
+  const edgeTypes = d.prepare("SELECT DISTINCT edge_type FROM edges ORDER BY edge_type").all();
+  const result = {};
+
+  for (const { edge_type } of edgeTypes) {
+    const rows = d.prepare(`
+      SELECT e.from_node, e.to_node, e.valid_since, e.valid_until,
+             n1.label AS from_label, n2.label AS to_label
+      FROM edges e
+      JOIN nodes n1 ON e.from_node = n1.id
+      JOIN nodes n2 ON e.to_node = n2.id
+      WHERE e.edge_type = ?
+      ORDER BY e.from_node
+    `).all(edge_type);
+
+    const lines = [];
+    lines.push(`# ${edge_type}`);
+    for (const r of rows) {
+      const period = r.valid_since ? ` [${r.valid_since} → ${r.valid_until || "至今"}]` : "";
+      lines.push(`${r.from_label} --[${edge_type}]--> ${r.to_label}${period}`);
+    }
+    const key = edge_type.toLowerCase().replace(/_/g, "-");
+    result[`edges_${key}.txt`] = lines.join("\n") + "\n";
+  }
+
+  return result;
+}
+
+/**
+ * 导出双线时间线（物理时间 + 叙事顺序合并视图）
+ */
+function exportTimelineText(db) {
+  const d = db || getDb();
+
+  // 物理时间线
+  const timePoints = d.prepare(`
+    SELECT id, label FROM nodes WHERE node_type = 'TIME_POINT' ORDER BY id
+  `).all();
+
+  const lines = [];
+  lines.push("# 时间线合并视图");
+  lines.push("");
+
+  for (const tp of timePoints) {
+    lines.push(`## ${tp.label} (${tp.id})`);
+    const events = d.prepare(`
+      SELECT n.id, n.label,
+             json_extract(n.properties, '$.chapter') AS chapter,
+             json_extract(n.properties, '$.event_type') AS event_type
+      FROM nodes n
+      JOIN edges e ON n.id = e.from_node AND e.edge_type = 'OCCURS_AT'
+      WHERE e.to_node = ?
+      ORDER BY CAST(json_extract(n.properties, '$.chapter') AS INTEGER)
+    `).all(tp.id);
+
+    for (const ev of events) {
+      lines.push(`  Ch${ev.chapter || "?"}: ${ev.label} [${ev.event_type || "event"}]`);
+    }
+    lines.push("");
+  }
+
+  // 叙事顺序线（按章节）
+  lines.push("## 叙事顺序线（按章节）");
+  lines.push("");
+  const chapters = d.prepare(`
+    SELECT id, label,
+           json_extract(properties, '$.chapter_number') AS num,
+           json_extract(properties, '$.word_count') AS wc
+    FROM nodes WHERE node_type = 'CHAPTER' ORDER BY id
+  `).all();
+
+  for (const ch of chapters) {
+    lines.push(`### ${ch.label}`);
+    const events = d.prepare(`
+      SELECT n.label, json_extract(n.properties, '$.event_type') AS event_type
+      FROM nodes n
+      JOIN edges e ON n.id = e.to_node AND e.edge_type = 'NARRATES'
+      WHERE e.from_node = ?
+      ORDER BY n.id
+    `).all(ch.id);
+
+    for (const ev of events) {
+      lines.push(`  - ${ev.label} [${ev.event_type || "event"}]`);
+    }
+    lines.push("");
+  }
+
+  return { "timeline_merged.txt": lines.join("\n") };
+}
+
+/**
+ * 导出 SUMMARY.md（人类可读摘要）
+ */
+function exportSummary(db) {
+  const d = db || getDb();
+  const stats = graphStats(d);
+
+  const lines = [];
+  lines.push("# 知识图谱快照摘要");
+  lines.push(`> 导出时间: ${new Date().toISOString()}`);
+  lines.push("");
+  lines.push("## 统计");
+  lines.push(`- 总节点: ${stats.total_nodes}`);
+  for (const [type, count] of Object.entries(stats.nodes_by_type)) {
+    lines.push(`  - ${type}: ${count}`);
+  }
+  lines.push(`- 总边: ${stats.total_edges}`);
+  lines.push(`- 活跃钩子: ${stats.active_hooks}`);
+  lines.push(`- 已解决钩子: ${stats.resolved_hooks}`);
+  lines.push("");
+
+  // 人物表
+  const persons = d.prepare("SELECT id, label, properties FROM nodes WHERE node_type = 'PERSON' AND status = 'active' ORDER BY id").all();
+  if (persons.length > 0) {
+    lines.push("## 人物");
+    for (const p of persons) {
+      const props = JSON.parse(p.properties || "{}");
+      lines.push(`- **${p.label}** (${p.id}): ${props.role || ""} ${props.motivation ? `— ${props.motivation}` : ""}`);
+    }
+    lines.push("");
+  }
+
+  // 事件数（最近10个）
+  const recentEvents = d.prepare(`
+    SELECT label, json_extract(properties, '$.chapter') AS chapter
+    FROM nodes WHERE node_type = 'EVENT' AND status = 'active'
+    ORDER BY id DESC LIMIT 10
+  `).all();
+  if (recentEvents.length > 0) {
+    lines.push("## 最近事件");
+    for (const ev of recentEvents) {
+      lines.push(`- Ch${ev.chapter || "?"}: ${ev.label}`);
+    }
+    lines.push("");
+  }
+
+  return { "SUMMARY.md": lines.join("\n") };
+}
+
+/**
+ * 完整快照导出：返回 {filename: content} 映射
+ */
+function exportFullSnapshot(db) {
+  const d = db || getDb();
+  return {
+    ...exportNodesText(d),
+    ...exportEdgesText(d),
+    ...exportTimelineText(d),
+    ...exportSummary(d)
+  };
+}
+
+// ─── 叙事债务管理 ────────────────────────────────────────────
+
+/**
+ * 创建叙事债务: 物理因果链有答案但叙事尚未交代
+ */
+function upsertNarrativeDebt(debt, db) {
+  const d = db || getDb();
+  const stmt = d.prepare(`
+    INSERT INTO narrative_debts (question, answer_event, answer_time, triggered_by, character_id, priority, suggested_window, status)
+    VALUES (@question, @answer_event, @answer_time, @triggered_by, @character_id, @priority, @suggested_window, @status)
+    ON CONFLICT DO NOTHING
+  `);
+  return stmt.run(debt);
+}
+
+/**
+ * 检测未偿还的叙事债务 — 在因果链中寻找有前因但叙事未交代的事件
+ *
+ * 算法: 对新增章节中每个有 CAUSES 关系的事件，追溯其物理因果链。
+ * 如果前因事件在物理时间线中存在但还没有在任何章节被NARRATES — 创建叙事债务。
+ */
+function detectNarrativeDebts(chapterNum, db) {
+  const d = db || getDb();
+  const debts = [];
+
+  // 找到本章所有有因果前驱的事件
+  const events = d.prepare(`
+    SELECT n.id, n.label, json_extract(n.properties, '$.chapter') AS chapter,
+           json_extract(n.properties, '$.participants') AS participants
+    FROM nodes n
+    JOIN edges e ON n.id = e.to_node AND e.edge_type = 'CAUSES'
+    WHERE n.node_type = 'EVENT' AND n.status = 'active'
+      AND CAST(json_extract(n.properties, '$.chapter') AS INTEGER) <= ?
+    GROUP BY n.id
+  `).all(chapterNum);
+
+  for (const evt of events) {
+    // 追溯物理因果链中的所有前因事件
+    const causes = d.prepare(`
+      WITH RECURSIVE cause_chain AS (
+          SELECT from_node, to_node, 1 AS depth
+          FROM edges WHERE to_node = ? AND edge_type = 'CAUSES'
+          UNION ALL
+          SELECT e.from_node, e.to_node, c.depth + 1
+          FROM edges e
+          JOIN cause_chain c ON e.to_node = c.from_node
+          WHERE e.edge_type = 'CAUSES' AND c.depth < 10
+      )
+      SELECT DISTINCT cc.from_node AS cause_event_id,
+             n.label AS cause_label,
+             json_extract(n.properties, '$.chapter') AS cause_chapter,
+             json_extract(n.properties, '$.emotional_tone') AS tone
+      FROM cause_chain cc
+      JOIN nodes n ON cc.from_node = n.id
+      WHERE n.node_type = 'EVENT'
+    `).all(evt.id);
+
+    for (const cause of causes) {
+      // 检查这个原因事件是否已经在叙事中被交代
+      const alreadyNarrated = d.prepare(`
+        SELECT 1 FROM edges
+        WHERE from_node LIKE 'C_%' AND edge_type = 'NARRATES' AND to_node = ?
+        LIMIT 1
+      `).get(cause.cause_event_id);
+
+      if (!alreadyNarrated) {
+        // 发现叙事债务: 这个原因事件存在但没有在任何章节叙述过
+        // 检查是否已创建过这笔债务
+        const existing = d.prepare(`
+          SELECT id FROM narrative_debts
+          WHERE answer_event = ? AND triggered_by = ?
+          LIMIT 1
+        `).get(cause.cause_event_id, evt.id);
+
+        if (!existing) {
+          const participants = JSON.parse(evt.participants || "[]");
+          const charId = participants.length > 0 ? participants[0] : null;
+          const priority = cause.tone === "shock" || cause.tone === "ominous" ? 9 :
+                          cause.tone === "revelation" ? 7 : 5;
+          const startWindow = Math.max(chapterNum, 10);
+          const endWindow = Math.min(chapterNum + 80, 200);
+
+          debts.push({
+            question: `为什么${evt.label}？原因追溯到: ${cause.cause_label}`,
+            answer_event: cause.cause_event_id,
+            answer_time: null,
+            triggered_by: evt.id,
+            character_id: charId,
+            priority: priority,
+            suggested_window: `${startWindow}-${endWindow}`,
+            status: "pending"
+          });
+        }
+      }
+    }
+  }
+
+  // 批量写入
+  for (const debt of debts) {
+    upsertNarrativeDebt(debt, d);
+  }
+
+  return { chapter: chapterNum, new_debts: debts.length, debts: debts };
+}
+
+/**
+ * 闪回建议 — 当前章可以偿还哪些叙事债务
+ *
+ * 返回: 评分排序的债务列表，AI 根据节奏、情绪、场景自由决定是否偿还
+ */
+function flashbackOpportunities(chapterNum, scene, db) {
+  const d = db || getDb();
+
+  const debts = d.prepare(`
+    SELECT nd.*,
+           n.label AS answer_label,
+           json_extract(n.properties, '$.summary') AS answer_summary
+    FROM narrative_debts nd
+    LEFT JOIN nodes n ON nd.answer_event = n.id
+    WHERE nd.status = 'pending'
+    ORDER BY nd.priority DESC, nd.created_at ASC
+  `).all();
+
+  const results = [];
+
+  for (const debt of debts) {
+    let score = 0;
+    const reasons = [];
+
+    // 优先级基础分
+    score += (debt.priority || 5) * 7;
+
+    // 窗口匹配: 当前章在建议窗口内
+    if (debt.suggested_window) {
+      const [lo, hi] = debt.suggested_window.split("-").map(Number);
+      if (chapterNum >= lo && chapterNum <= hi) {
+        score += 25;
+        reasons.push(`在建议窗口内(${debt.suggested_window})`);
+      }
+    }
+
+    // 角色匹配: 债务涉及的角色在当前场景中
+    if (debt.character_id && scene && scene.entities &&
+        scene.entities.includes(debt.character_id)) {
+      score += 20;
+      reasons.push(`场景中有相关角色: ${debt.character_id}`);
+    }
+
+    // 未偿还时间惩罚
+    const debtAge = chapterNum - (debt.repaid_chapter || 0);
+    if (debtAge > 30) {
+      score += 15;
+      reasons.push(`已等待${debtAge}章未偿还`);
+    }
+
+    results.push({
+      debt_id: debt.id,
+      question: debt.question,
+      answer_event: debt.answer_event,
+      answer_label: debt.answer_label,
+      answer_summary: debt.answer_summary,
+      score: score,
+      priority: debt.priority,
+      suggested_window: debt.suggested_window,
+      reasons: reasons.join("; ") || "基础匹配",
+      suggested_action: score >= 70 ? "建议偿还: 可在本章插入闪回" :
+                        score >= 50 ? "关注: 可铺垫暗示" :
+                        score >= 30 ? "观察: 等待更合适时机" : "暂缓"
+    });
+  }
+
+  results.sort((a, b) => b.score - a.score);
+  return results;
+}
+
+/**
+ * 偿还叙事债务: pending → repaid
+ */
+function repayDebt(debtId, chapterNum, db) {
+  const d = db || getDb();
+  d.prepare(`
+    UPDATE narrative_debts SET status = 'repaid', repaid_chapter = ?
+    WHERE id = ?
+  `).run(chapterNum, debtId);
+  return { debt_id: debtId, status: "repaid", chapter: chapterNum };
+}
+
+// ─── 叙事-物理时间对齐 ──────────────────────────────────────
+
+/**
+ * 设置章节的物理时间映射
+ */
+function setChapterTime(chapterId, physicalTime, storyDay, absoluteOrder, db) {
+  const d = db || getDb();
+  d.prepare(`
+    INSERT OR REPLACE INTO narrative_physical_map (chapter_id, physical_time, story_day, absolute_order)
+    VALUES (?, ?, ?, ?)
+  `).run(chapterId, physicalTime, storyDay, absoluteOrder);
+}
+
+/**
+ * 查询叙事-物理时间对齐表: 回答"穿越后过了几天？"
+ */
+function getStoryTimeline(db) {
+  const d = db || getDb();
+  return d.prepare(`
+    SELECT chapter_id, physical_time, story_day, absolute_order
+    FROM narrative_physical_map
+    ORDER BY absolute_order
+  `).all();
+}
+
+// ─── Staging 管理 ────────────────────────────────────────────
+
+function commitStaging(db) {
+  const d = db || getDb();
+  const commit = d.transaction(() => {
+    // 提交 create/update 节点
+    const insertNodes = d.prepare(`
+      INSERT OR REPLACE INTO nodes (id, node_type, label, properties, status, created_at, updated_at)
+      SELECT id, node_type, label, properties, status, datetime('now'), datetime('now')
+      FROM staging_nodes WHERE action != 'delete'
+    `);
+    insertNodes.run();
+
+    // 删除标记为 delete 的节点
+    d.prepare(`
+      DELETE FROM nodes WHERE id IN (SELECT id FROM staging_nodes WHERE action = 'delete')
+    `).run();
+
+    // 提交 create 边
+    d.prepare(`
+      INSERT INTO edges (from_node, edge_type, to_node, properties, valid_since, valid_until, created_by, created_at)
+      SELECT from_node, edge_type, to_node, properties, valid_since, valid_until, 'graph-builder', datetime('now')
+      FROM staging_edges WHERE action = 'create'
+    `).run();
+
+    // 提交 update 边（删旧插新）
+    d.prepare(`
+      DELETE FROM edges WHERE id IN (SELECT id FROM staging_edges WHERE action = 'update')
+    `).run();
+    d.prepare(`
+      INSERT INTO edges (from_node, edge_type, to_node, properties, valid_since, valid_until, created_by, created_at)
+      SELECT from_node, edge_type, to_node, properties, valid_since, valid_until, 'graph-builder', datetime('now')
+      FROM staging_edges WHERE action = 'update'
+    `).run();
+
+    // 清空 staging
+    d.prepare("DELETE FROM staging_nodes").run();
+    d.prepare("DELETE FROM staging_edges").run();
+  });
+  commit();
+}
+
+function clearStaging(db) {
+  const d = db || getDb();
+  d.prepare("DELETE FROM staging_nodes").run();
+  d.prepare("DELETE FROM staging_edges").run();
+}
+
+// ─── 统计信息 ────────────────────────────────────────────────
+
+function graphStats(db) {
+  const d = db || getDb();
+
+  const nodeCounts = {};
+  const nodeRows = d.prepare(`
+    SELECT node_type, COUNT(*) as cnt FROM nodes WHERE status = 'active' GROUP BY node_type
+  `).all();
+  for (const r of nodeRows) nodeCounts[r.node_type] = r.cnt;
+
+  const edgeCount = d.prepare("SELECT COUNT(*) as cnt FROM edges").get().cnt;
+  const hookCount = d.prepare("SELECT COUNT(*) as cnt FROM nodes WHERE node_type = 'HOOK' AND status IN ('active','dormant')").get().cnt;
+  const resolvedHookCount = d.prepare("SELECT COUNT(*) as cnt FROM nodes WHERE node_type = 'HOOK' AND status = 'resolved'").get().cnt;
+
+  return {
+    total_nodes: Object.values(nodeCounts).reduce((a, b) => a + b, 0),
+    nodes_by_type: nodeCounts,
+    total_edges: edgeCount,
+    active_hooks: hookCount,
+    resolved_hooks: resolvedHookCount
+  };
+}
+
+// ─── 时间系统 ────────────────────────────────────────────────
+
+/*
+ * 时间模型（对标时空大数据系统: 统一时间戳 + 偏移 + 粒度自由）
+ *
+ *   TIME_POINT 携带:
+ *     epoch       — 从纪元起算的绝对时间值 (整数/浮点, 单位由用户定义)
+ *     date_label  — 人类可读标签, 如 "星辰历123年7月8日"
+ *     time_unit   — 单位标识: "day"|"hour"|"second"
+ *
+ *   EVENT 携带:
+ *     story_offset — 同一 epoch 内的偏移 (同一天内第几件事, 用于区分顺序)
+ *
+ *   排序规则:
+ *     ORDER BY tp.epoch, COALESCE(ev.story_offset, ev.narrative_order, 0)
+ *
+ *   规则很简单:
+ *     - 开书时, 选定时间原点。第一个 TIME_POINT 的 epoch=0
+ *     - 后续每个 TIME_POINT 手动设定 epoch 值
+ *     - 如果两个事件同一天: 设 story_offset=1,2,3 区分先后
+ *     - 如果不设 story_offset: 默认按 narrative_order 排序 (先叙述的先发生)
+ *     - repairTimeline() 自动补全缺失值
+ *     - getTimeline()  返回按时间排序的完整事件列表
+ *     - getTimeGaps()  检测时间空白 (可插入新内容的区间)
+ */
+function repairTimeline(db) {
+  const d = db || getDb();
+
+  // 1. TIME_POINT: 补全 epoch（从 narrative_physical_map.story_day 取初始值）
+  const tps = d.prepare(`SELECT n.id, n.properties FROM nodes n WHERE n.node_type = 'TIME_POINT'`).all();
+  const updateTP = d.transaction(() => {
+    for (const tp of tps) {
+      const props = JSON.parse(tp.properties || "{}");
+      if (props.epoch != null) continue;
+      const npm = d.prepare(`SELECT MIN(story_day) AS sd FROM narrative_physical_map WHERE physical_time = ? LIMIT 1`).get(tp.id);
+      if (npm && npm.sd != null) { props.epoch = npm.sd; props.time_unit = "day"; }
+      d.prepare("UPDATE nodes SET properties = ? WHERE id = ?").run(JSON.stringify(props), tp.id);
+    }
+  });
+  updateTP();
+
+  // 清理旧字段
+  d.prepare(`UPDATE nodes SET properties = json_remove(properties, '$.story_time') WHERE json_extract(properties, '$.story_time') IS NOT NULL`).run();
+  d.prepare(`UPDATE nodes SET properties = json_remove(properties, '$.physical_order') WHERE json_extract(properties, '$.physical_order') IS NOT NULL`).run();
+
+  // 2. BEFORE 边
+  const ordered = d.prepare(`SELECT id, CAST(json_extract(properties,'$.epoch') AS REAL) AS ep FROM nodes WHERE node_type='TIME_POINT' AND json_extract(properties,'$.epoch') IS NOT NULL ORDER BY ep`).all();
+  d.prepare("DELETE FROM edges WHERE edge_type = 'BEFORE'").run();
+  for (let i = 0; i < ordered.length - 1; i++) {
+    if (ordered[i].ep === ordered[i+1].ep) continue;
+    d.prepare(`INSERT INTO edges (from_node, edge_type, to_node, properties) VALUES (?, 'BEFORE', ?, '{}')`).run(ordered[i].id, ordered[i+1].id);
+  }
+
+  // 3. 给同 TIME_POINT 的事件自动填充 story_offset
+  const tps2 = d.prepare(`SELECT id FROM nodes WHERE node_type='TIME_POINT'`).all();
+  for (const tp of tps2) {
+    const events = d.prepare(`
+      SELECT e.from_node AS evid, CAST(json_extract(n.properties,'$.narrative_order') AS INTEGER) AS no
+      FROM edges e JOIN nodes n ON e.from_node=n.id
+      WHERE e.edge_type='OCCURS_AT' AND e.to_node=? AND n.node_type='EVENT'
+      ORDER BY CAST(json_extract(n.properties,'$.chapter') AS INTEGER), no
+    `).all(tp.id);
+
+    const stmtUpdate = d.prepare(`UPDATE nodes SET properties = json_set(properties, '$.story_offset', ?) WHERE id = ?`);
+    for (let i = 0; i < events.length; i++) {
+      const offset = i;
+      stmtUpdate.run(offset, events[i].evid);
+    }
+  }
+
+  // 4. 回填缺失 OCCURS_AT
+  const evtMissing = d.prepare(`SELECT n.id, n.properties FROM nodes n WHERE n.node_type='EVENT' AND n.status='active' AND NOT EXISTS (SELECT 1 FROM edges e WHERE e.from_node=n.id AND e.edge_type='OCCURS_AT')`).all();
+  const fill = d.transaction(() => {
+    for (const ev of evtMissing) {
+      const ch = parseInt(JSON.parse(ev.properties||"{}").chapter)||0;
+      if (ch > 0) {
+        const npm = d.prepare(`SELECT physical_time FROM narrative_physical_map WHERE chapter_id=? LIMIT 1`).get(`C_${String(ch).padStart(3,'0')}`);
+        if (npm) d.prepare(`INSERT INTO edges (from_node, edge_type, to_node, properties) VALUES (?, 'OCCURS_AT', ?, '{}')`).run(ev.id, npm.physical_time);
+      }
+    }
+  });
+  fill();
+
+  return { timePoints: tps.length, beforeEdges: ordered.length-1, offsetsFilled: true, occursAtFilled: evtMissing.length };
+}
+
+/**
+ * 设置 TIME_POINT 的绝对时间
+ * @param {number} epoch - 从纪元算起的值 (单位由你定: 天/小时/秒)
+ * @param {string} dateLabel - "星辰历123年7月8日"
+ * @param {string} unit - "day"|"hour"|"second"
+ */
+function setTimePointTime(timePointId, epoch, dateLabel, unit, db) {
+  const d = db || getDb();
+  const node = d.prepare("SELECT properties FROM nodes WHERE id=? AND node_type='TIME_POINT'").get(timePointId);
+  if (!node) throw new Error("TIME_POINT 不存在: " + timePointId);
+  const props = JSON.parse(node.properties || "{}");
+  props.epoch = epoch;
+  if (dateLabel) props.date_label = dateLabel;
+  if (unit) props.time_unit = unit;
+  d.prepare("UPDATE nodes SET properties=? WHERE id=?").run(JSON.stringify(props), timePointId);
+  return { id: timePointId, epoch, date_label: dateLabel, time_unit: unit };
+}
+
+/**
+ * 设置 EVENT 在同时间点内的偏移 (区分同一天的事)
+ */
+function setEventOffset(eventId, offset, db) {
+  const d = db || getDb();
+  d.prepare(`UPDATE nodes SET properties = json_set(properties, '$.story_offset', ?) WHERE id=? AND node_type='EVENT'`).run(offset, eventId);
+  return { id: eventId, story_offset: offset };
+}
+
+/**
+ * 完整时间线: 所有事件按 epoch → offset → narrative_order 排序
+ */
+function getTimeline(db) {
+  const d = db || getDb();
+  return d.prepare(`
+    SELECT n.label, n.id,
+      json_extract(n.properties,'$.chapter') AS ch,
+      json_extract(n.properties,'$.event_type') AS etype,
+      json_extract(n.properties,'$.story_offset') AS off,
+      COALESCE((SELECT n2.label FROM edges e JOIN nodes n2 ON e.to_node=n2.id WHERE e.from_node=n.id AND e.edge_type='OCCURS_AT'),'-') AS tp,
+      COALESCE((SELECT json_extract(n2.properties,'$.epoch') FROM edges e JOIN nodes n2 ON e.to_node=n2.id WHERE e.from_node=n.id AND e.edge_type='OCCURS_AT'),'-') AS epoch,
+      COALESCE((SELECT json_extract(n2.properties,'$.date_label') FROM edges e JOIN nodes n2 ON e.to_node=n2.id WHERE e.from_node=n.id AND e.edge_type='OCCURS_AT'),'-') AS date_label
+    FROM nodes n WHERE n.node_type='EVENT' AND n.status='active'
+    ORDER BY
+      CAST(COALESCE((SELECT json_extract(n2.properties,'$.epoch') FROM edges e JOIN nodes n2 ON e.to_node=n2.id WHERE e.from_node=n.id AND e.edge_type='OCCURS_AT'),'99999999') AS REAL),
+      CAST(COALESCE(json_extract(n.properties,'$.story_offset'), json_extract(n.properties,'$.narrative_order'), '0') AS REAL)
+  `).all();
+}
+
+/**
+ * 检测时间空白: TIME_POINT 之间可以插入新内容的区间
+ */
+function getTimeGaps(db) {
+  const d = db || getDb();
+  const tps = d.prepare(`SELECT id,label,json_extract(properties,'$.epoch') AS ep,json_extract(properties,'$.date_label') AS dl FROM nodes WHERE node_type='TIME_POINT' AND json_extract(properties,'$.epoch') IS NOT NULL ORDER BY CAST(json_extract(properties,'$.epoch') AS REAL)`).all();
+  const gaps = [];
+  for (let i = 0; i < tps.length - 1; i++) {
+    const gap = tps[i+1].ep - tps[i].ep;
+    if (gap > 1) gaps.push({ from: tps[i].label, to: tps[i+1].label, fromDate: tps[i].dl, toDate: tps[i+1].dl, gapSize: gap });
+  }
+  return gaps;
+}
+// ─── Hook 状态查询 ──────────────────────────────────────────
+
+/**
+ * 会话启动时的图状态检查（替代 session-start-graph.sh 的业务逻辑）
+ * @returns {{ message: string, status: string }}
+ */
+function sessionStatus(projectRoot) {
+  const fs = require("fs");
+  const path = require("path");
+
+  // 发现活跃书（回退链：.active-book → 追踪/ → 正文/ → 正文.md）
+  const bookDir = discoverBookDir(projectRoot);
+
+  if (!bookDir) return { status: "no-book", message: "" };
+
+  const dbPath = path.join(bookDir, "story.db");
+  const markerPath = path.join(projectRoot, ".claude", ".graph-update-pending");
+
+  // 检查是否有待处理更新
+  // 标记格式: {时间戳}\t{章节号}\t{文件路径}（checkGraphUpdate 追加写）
+  let pending = false, pendingChapters = "", pendingNumbers = [], pendingTotal = 0;
+  if (fs.existsSync(markerPath)) {
+    pending = true;
+    try {
+      const numbers = [];
+      const labels = [];
+      for (const line of fs.readFileSync(markerPath, "utf8").split("\n")) {
+        const raw = (line.split("\t")[1] || "").trim();
+        if (!raw) continue;
+        labels.push(raw);
+        const num = Number(raw);
+        if (Number.isInteger(num) && num > 0) numbers.push(num);
+      }
+      pendingChapters = labels.join(",");
+      pendingNumbers = numbers;
+      pendingTotal = labels.length;
+    } catch (e) {}
+  }
+
+  // story.db 不存在
+  if (!fs.existsSync(dbPath)) {
+    // 检查是否可以 seed
+    let canSeed = false;
+    try {
+      const charDir = path.join(bookDir, "设定", "角色");
+      const outlineDir = path.join(bookDir, "大纲");
+      if ((fs.existsSync(charDir) && fs.readdirSync(charDir).some(f => f.endsWith(".md")))) canSeed = true;
+      if (fs.existsSync(outlineDir)) canSeed = true;
+    } catch (e) {}
+    return { status: "no-db", canSeed, message: "未初始化知识图谱。运行 /story-graph seed" };
+  }
+
+  // 打开数据库查统计
+  let db = null;
+  let stats = null;
+  try {
+    db = open(dbPath);
+    stats = graphStats(db);
+  } catch (e) {
+    return { status: "db-error", message: "story.db 读取失败: " + e.message };
+  }
+
+  if (pending) {
+    // 自愈：标记中所有章节号都已入库（≤ 图内最新章节号，且全部可解析为数字）
+    // → 标记是上次 /story-graph update 的残留，清理并返回就绪，避免反复提示
+    const maxChapter = db.prepare(
+      "SELECT MAX(CAST(json_extract(properties, '$.chapter_number') AS INTEGER)) AS m FROM nodes WHERE node_type = 'CHAPTER'",
+    ).get().m;
+    const allProcessed = pendingTotal > 0
+      && pendingNumbers.length === pendingTotal
+      && maxChapter != null
+      && pendingNumbers.every((n) => n <= maxChapter);
+    if (allProcessed) {
+      try { fs.unlinkSync(markerPath); } catch (e) {}
+      return {
+        status: "ready",
+        nodes: stats.total_nodes,
+        edges: stats.total_edges,
+        activeHooks: stats.active_hooks,
+        resolvedHooks: stats.resolved_hooks,
+        selfHealed: true,
+        message: `知识图谱就绪（待更新标记已清理）: ${stats.total_nodes}节点 / ${stats.total_edges}边 / ${stats.active_hooks}活跃钩子`
+      };
+    }
+    return {
+      status: "pending-update",
+      nodes: stats.total_nodes,
+      edges: stats.total_edges,
+      pendingChapters,
+      message: `知识图谱需更新 — 第${pendingChapters}章。当前: ${stats.total_nodes}节点/${stats.total_edges}边。运行 /story-graph update`
+    };
+  }
+
+  // 清理残留标记
+  try { fs.unlinkSync(markerPath); } catch (e) {}
+
+  return {
+    status: "ready",
+    nodes: stats.total_nodes,
+    edges: stats.total_edges,
+    activeHooks: stats.active_hooks,
+    resolvedHooks: stats.resolved_hooks,
+    message: `知识图谱就绪: ${stats.total_nodes}节点 / ${stats.total_edges}边 / ${stats.active_hooks}活跃钩子 → story-explorer 可用（图查询）`
+  };
+}
+
+/**
+ * 正文落盘后检测是否需要增量更新（替代 graph-update-check.sh 的业务逻辑）
+ * @returns {{ needsUpdate: boolean, message: string }}
+ */
+function checkGraphUpdate(targetFile, projectRoot) {
+  const fs = require("fs");
+  const path = require("path");
+
+  // 发现活跃书（回退链：.active-book → 追踪/ → 正文/ → 正文.md）
+  const bookDir = discoverBookDir(projectRoot);
+  if (!bookDir) return { needsUpdate: false, message: "" };
+
+  const dbPath = path.join(bookDir, "story.db");
+  if (!fs.existsSync(dbPath)) {
+    return { needsUpdate: false, message: "未初始化知识图谱。运行 /story-graph seed" };
+  }
+
+  // 判断是否是正文文件
+  const base = path.basename(targetFile);
+  const parent = path.basename(path.dirname(targetFile));
+  let isProse = false;
+  if (base === "正文.md" && fs.existsSync(path.join(path.dirname(targetFile), "设定.md"))) isProse = true;
+  if (base.startsWith("第") && base.includes("章") && base.endsWith(".md") && parent === "正文") isProse = true;
+  if (!isProse) return { needsUpdate: false, message: "" };
+
+  // 写标记文件
+  const markerPath = path.join(projectRoot, ".claude", ".graph-update-pending");
+  const chapterNum = (base.match(/\d+/) || ["?"])[0];
+  const stamp = new Date().toISOString().slice(0, 19);
+  try {
+    const markersDir = path.dirname(markerPath);
+    if (!fs.existsSync(markersDir)) fs.mkdirSync(markersDir, { recursive: true });
+    fs.appendFileSync(markerPath, `${stamp}\t${chapterNum}\t${targetFile}\n`, "utf8");
+  } catch (e) {}
+
+  // 读统计
+  let statsStr = "";
+  try {
+    const db = open(dbPath);
+    const s = graphStats(db);
+    statsStr = `${s.total_nodes}节点/${s.total_edges}边/${s.active_hooks}活跃钩子`;
+  } catch (e) {}
+
+  return {
+    needsUpdate: true,
+    chapterNum,
+    stats: statsStr,
+    message: `知识图谱需更新 — 第${chapterNum}章已写入。当前: ${statsStr}。请运行 /story-graph update`
+  };
+}
+
+// ─── 导出 ────────────────────────────────────────────────────
+
+module.exports = {
+  open,
+  close,
+  getDb,
+  initSchema,
+
+  // 节点
+  upsertNode,
+  upsertNodes,
+  getNode,
+  getNodesByType,
+  getAllNodes,
+  deleteNode,
+
+  // 边
+  upsertEdge,
+  upsertEdges,
+  replaceEdgesFrom,
+  getEdgesFrom,
+  getEdgesTo,
+
+  // 聚合查询
+  stateAtTime,
+  stateWindow,
+  causalChain,
+  shortestRelationshipPath,
+  hookRadar,
+  knowledgeGap,
+
+  // 时间窗口判定（导出供测试）
+  resolveTimePointEpoch,
+  edgeValidInWindow,
+  edgeOverlapsWindow,
+  edgeCoversWindow,
+
+  // 钩子生命周期
+  triggerHook,
+  resolveHook,
+  abandonHook,
+  hookLifecycleSummary,
+  checkHookDependencyCycle,
+
+  // 伏笔文件同步
+  parseForeshadowFile,
+  syncHooksFromForeshadowFile,
+
+  // 叙事债务
+  upsertNarrativeDebt,
+  detectNarrativeDebts,
+  flashbackOpportunities,
+  repayDebt,
+
+  // 叙事-物理时间对齐
+  setChapterTime,
+  getStoryTimeline,
+
+  // 快照导出
+  exportNodesText,
+  exportEdgesText,
+  exportTimelineText,
+  exportSummary,
+  exportFullSnapshot,
+
+  // Staging
+  commitStaging,
+  clearStaging,
+
+  // 统计
+  graphStats,
+
+  // Hook 状态
+  sessionStatus,
+  checkGraphUpdate,
+  discoverBookDir,
+
+  // 时间线
+  repairTimeline,
+  setTimePointTime,
+  setEventOffset,
+  getTimeline,
+  getTimeGaps,
+};

--- a/skills/story-graph/scripts/viz_html.js
+++ b/skills/story-graph/scripts/viz_html.js
@@ -1,0 +1,122 @@
+"use strict";
+
+/**
+ * 生成自包含的交互式知识图谱可视化 HTML 文件
+ */
+
+const NODE_COLORS = {
+  PERSON:     { bg: "#4A90D9", border: "#2E6AB0", shape: "dot", size: 25 },
+  LOCATION:   { bg: "#50B86C", border: "#338A4A", shape: "diamond", size: 20 },
+  EVENT:      { bg: "#F5A623", border: "#C07D10", shape: "dot", size: 15 },
+  ITEM:       { bg: "#9B59B6", border: "#7D3C98", shape: "triangle", size: 18 },
+  ORG:        { bg: "#E74C3C", border: "#B8312A", shape: "square", size: 22 },
+  TIME_POINT: { bg: "#1ABC9C", border: "#148F77", shape: "hexagon", size: 14 },
+  CHAPTER:    { bg: "#95A5A6", border: "#6C7A7B", shape: "square", size: 16 },
+  HOOK:       { bg: "#E67E22", border: "#B5611A", shape: "star", size: 20 }
+};
+
+const EDGE_COLORS = {
+  CAUSES: "#E74C3C", NARRATES: "#95A5A6", PARTICIPATES_IN: "#3498DB",
+  LOCATED_AT: "#50B86C", OWNS: "#9B59B6", BELONGS_TO: "#E74C3C",
+  ALLIED_WITH: "#2ECC71", HOSTILE_TO: "#E74C3C", KIN_TO: "#F39C12",
+  ROMANTIC_WITH: "#E91E63", MENTOR_OF: "#8BC34A", KNOWS_ABOUT: "#1ABC9C",
+  WITNESS: "#F5A623", INFORMED_BY: "#3498DB", OCCURS_AT: "#1ABC9C",
+  TRIGGERED_IN: "#E67E22", RESOLVED_IN: "#27AE60",
+  PREREQUISITE_FOR: "#F39C12", FLASHBACK_TO: "#9B59B6"
+};
+const DEFAULT_EDGE = "#BDC3C7";
+
+/**
+ * @param {object} graphData - { nodes: [{id, label, type, status, props}], edges: [{from, to, type, fromLabel, toLabel}] }
+ * @param {string} dbPath
+ * @returns {string} 完整的 HTML 文件内容
+ */
+function generateVizHTML(graphData, dbPath) {
+  // Build vis-network nodes
+  const visNodes = graphData.nodes.map(n => {
+    const c = NODE_COLORS[n.type] || { bg: "#BDC3C7", border: "#888", shape: "dot", size: 16 };
+    const propsStr = JSON.stringify(n.props || {})
+      .replace(/[{}"]/g, "").replace(/,/g, "<br>").substring(0, 300);
+    return {
+      id: n.id, label: n.label, group: n.type,
+      color: { background: c.bg, border: c.border },
+      shape: c.shape, size: c.size,
+      title: "<b>" + n.type + "</b>: " + n.label + "<br>" + propsStr,
+      font: { size: 11, face: "sans-serif" }
+    };
+  });
+
+  // Build vis-network edges
+  const visEdges = graphData.edges.map(e => ({
+    from: e.from, to: e.to, label: e.type,
+    color: { color: EDGE_COLORS[e.type] || DEFAULT_EDGE, opacity: 0.7 },
+    arrows: "to", font: { size: 8, align: "middle" },
+    title: e.fromLabel + " --[" + e.type + "]--> " + e.toLabel
+  }));
+
+  // Build legend HTML
+  var legendHTML = Object.entries(NODE_COLORS).map(function(entry) {
+    var type = entry[0], c = entry[1];
+    return '<div class="item"><span class="swatch" style="background:' + c.bg + '"></span>' + type + '</div>';
+  }).join("");
+
+  // Build filter checkboxes
+  var filtersHTML = Object.entries(NODE_COLORS).map(function(entry) {
+    var type = entry[0], c = entry[1];
+    return '<label style="border-color:' + c.bg + '"><input type="checkbox" data-type="' + type + '" checked onchange="toggleType(\'' + type + '\',this.checked)"> ' + type + '</label>';
+  }).join("");
+
+  var nodesJSON = JSON.stringify(visNodes);
+  var edgesJSON = JSON.stringify(visEdges);
+
+  return '<!DOCTYPE html>\n<html lang="zh">\n<head>\n<meta charset="UTF-8">\n<meta name="viewport" content="width=device-width, initial-scale=1.0">\n<title>叙事知识图谱</title>\n' +
+    '<style>\n' +
+    '* { margin: 0; padding: 0; box-sizing: border-box; }\n' +
+    'body { font-family: -apple-system, "Microsoft YaHei", sans-serif; background: #1a1a2e; color: #eee; overflow: hidden; height: 100vh; }\n' +
+    '#toolbar { position: absolute; top: 0; left: 0; right: 0; z-index: 10; background: rgba(26,26,46,0.95); padding: 8px 16px; display: flex; align-items: center; gap: 10px; border-bottom: 1px solid #2d2d4a; flex-wrap: wrap; }\n' +
+    '#toolbar h2 { font-size: 16px; color: #fff; margin-right: 8px; white-space: nowrap; }\n' +
+    '#toolbar label { font-size: 11px; cursor: pointer; display: flex; align-items: center; gap: 4px; padding: 3px 8px; border-radius: 4px; border: 1px solid #3d3d5a; user-select: none; white-space: nowrap; }\n' +
+    '#toolbar label:hover { background: #2d2d4a; }\n' +
+    '#network { position: absolute; top: 48px; left: 0; right: 0; bottom: 0; }\n' +
+    '#legend { position: absolute; bottom: 12px; left: 12px; background: rgba(26,26,46,0.9); padding: 10px 14px; border-radius: 6px; font-size: 11px; z-index: 11; border: 1px solid #3d3d5a; }\n' +
+    '#legend .item { display: flex; align-items: center; gap: 6px; margin: 3px 0; }\n' +
+    '#legend .swatch { width: 14px; height: 14px; border-radius: 50%; flex-shrink: 0; }\n' +
+    '.info-panel { position: absolute; top: 60px; right: 12px; background: rgba(26,26,46,0.92); padding: 12px 16px; border-radius: 6px; font-size: 12px; z-index: 11; border: 1px solid #3d3d5a; max-width: 300px; display: none; }\n' +
+    '.info-panel.visible { display: block; }\n' +
+    '.info-panel h3 { font-size: 14px; margin-bottom: 6px; }\n' +
+    '.info-panel .prop { margin: 2px 0; color: #aaa; word-break: break-all; }\n' +
+    '</style>\n</head>\n<body>\n' +
+    '<div id="toolbar"><h2>叙事知识图谱</h2>' + filtersHTML +
+    ' <span style="color:#888;font-size:11px;margin-left:8px">拖拽 | 滚轮缩放 | 点击查看详情</span></div>\n' +
+    '<div id="network"></div>\n' +
+    '<div id="legend">' + legendHTML + '</div>\n' +
+    '<div id="info" class="info-panel"></div>\n' +
+    '<script src="https://unpkg.com/vis-network@9.1.9/dist/vis-network.min.js"></script>\n' +
+    '<script>\n' +
+    'var nodes = new vis.DataSet(' + nodesJSON + ');\n' +
+    'var edges = new vis.DataSet(' + edgesJSON + ');\n' +
+    'var container = document.getElementById("network");\n' +
+    'var data = { nodes: nodes, edges: edges };\n' +
+    'var options = {\n' +
+    '  physics: { solver: "forceAtlas2Based", forceAtlas2Based: { gravitationalConstant: -45, centralGravity: 0.01, springLength: 150, springConstant: 0.08 }, stabilization: { iterations: 200 } },\n' +
+    '  edges: { smooth: { type: "continuous" }, width: 1.5 },\n' +
+    '  interaction: { hover: true, tooltipDelay: 100 }\n' +
+    '};\n' +
+    'var network = new vis.Network(container, data, options);\n' +
+    'network.on("click", function(p) {\n' +
+    '  var info = document.getElementById("info");\n' +
+    '  if (p.nodes.length) {\n' +
+    '    var n = nodes.get(p.nodes[0]);\n' +
+    '    var parts = n.title.split("<br>").filter(Boolean);\n' +
+    '    info.innerHTML = "<h3>" + n.group + ": " + n.label + "</h3><div class=prop>" + parts.slice(1).join("</div><div class=prop>") + "</div>";\n' +
+    '    info.classList.add("visible");\n' +
+    '  } else { info.classList.remove("visible"); }\n' +
+    '});\n' +
+    'function toggleType(type, visible) {\n' +
+    '  var list = nodes.get({ filter: function(n) { return n.group === type; } });\n' +
+    '  nodes.update(list.map(function(n) { return { id: n.id, hidden: !visible }; }));\n' +
+    '}\n' +
+    '</script>\n</body>\n</html>\n';
+}
+
+module.exports = { generateVizHTML, NODE_COLORS, EDGE_COLORS };

--- a/skills/story-graph/templates/agents/graph-builder.md
+++ b/skills/story-graph/templates/agents/graph-builder.md
@@ -1,0 +1,448 @@
+---
+name: graph-builder
+description: |
+  叙事知识图谱构建 agent。从项目文件（设定/角色/、设定/关系.md、大纲/、正文/）中提取
+  实体（人物/地点/事件/物品/组织）和关系，写入 story.db 的 SQLite 图数据库。
+  支持全量构建（seed 模式，从设定+大纲初始化图）和增量更新（update 模式，
+  从新写章节追加实体和边）。
+
+  被 story-graph skill（/story-graph seed、/story-graph update）调用。
+  需要访问项目文件系统和 story_graph_cli.js 脚本（story_graph_core.js 是其库实现）。
+tools: [Read, Bash, Glob, Grep]
+disallowedTools: [Write, Edit]
+model: sonnet
+maxTurns: 25
+---
+# Graph Builder — 叙事知识图谱构建器
+
+你是叙事知识图谱的构建 agent。你的任务是从故事项目文件中提取实体和关系，结构化写入 `story.db`。
+
+**你负责构建图，不做评判、不写正文。所有输出都是结构化的数据操作。**
+
+---
+
+## 核心能力
+
+| 操作模式 | 触发词 | 数据来源 | 输出 |
+|---------|--------|---------|------|
+| **全量构建 (seed)** | "seed"、"初始化" | `设定/角色/*.md`、`设定/势力/*.md`、`设定/世界观/*.md`、`设定/关系.md`、`大纲/卷纲_*.md`、`大纲/细纲_*.md` | 完整 nodes + edges |
+| **增量更新 (update)** | "update"、"更新第N章" | `正文/第N章_*.md` + 细纲 | staging → commit |
+| **重构建 (rebuild)** | "rebuild"、"重建" | 删除旧数据 → seed → 逐章 increment | 完整图 |
+
+---
+
+## 脚本工具
+
+项目下有 `.claude/hooks/story_graph_cli.js`（seed/update 也可用 `.claude/skills/story-graph/scripts/story_graph_cli.js`，两处为同一份代码）。使用它操作 SQLite：
+
+```bash
+# 初始化数据库（DDL 建表）
+node .claude/hooks/story_graph_cli.js init <dbPath>
+
+# 统计数据
+node .claude/hooks/story_graph_cli.js stats <dbPath>
+
+# 从 追踪/伏笔.md 同步钩子（幂等，可重复执行）
+node .claude/hooks/story_graph_cli.js sync-hooks <dbPath> <追踪/伏笔.md路径>
+
+# 执行 SQL（仅 SELECT 用于验证；写操作一律走 staging）
+node .claude/hooks/story_graph_cli.js exec <dbPath> "SELECT ..."
+```
+
+> `story_graph_core.js` 是库（无 CLI 入口），所有命令行操作都通过 `story_graph_cli.js`。
+
+---
+
+## 实体提取规则
+
+阅读源文件后，提取满足以下**任一条件**的实体：
+
+### PERSON（人物）
+1. 在 `设定/角色/` 中有独立文件的角色
+2. 在大纲中标注为首要/次要角色的出场人物
+3. 在正文中：首次出现、有名字、且有对话或独立行动
+
+**ID 格式**: `P_{名字}`（如 `P_沈栀`）
+
+**properties 规范**:
+```json
+{
+  "aliases": ["阿栀", "沈小姐"],
+  "gender": "女",
+  "age": 22,
+  "role": "protagonist",
+  "abilities": ["医术lv3", "毒术lv1"],
+  "motivation": "为父报仇",
+  "backstory_knowledge": ["祖传玉佩的秘密"]
+}
+```
+
+**龙套过滤**: 仅被提及、无独立行动、无名字的角色不提取。
+
+### LOCATION（地点）
+1. 在 `设定/世界观/` 中描述的地理实体
+2. 影响剧情推进的地点（角色到达/离开，或事件关键发生地）
+
+**ID 格式**: `L_{地名}`（如 `L_青云城`）
+
+**properties**:
+```json
+{"type": "city|building|wilderness|realm", "parent": "L_玉兰大陆", "owner": "G_巴鲁克家族"}
+```
+
+### EVENT（事件）
+1. 大纲/细纲中的情节点
+2. 正文中发生的具体事件（冲突/揭示/转折/行动/对话/状态变化）
+
+**ID 格式**: `E_{章节}_{简短描述}`（如 `E_015_沈栀发现密信`）
+
+**properties**:
+```json
+{
+  "event_type": "conflict|revelation|transition|action|dialogue|state_change",
+  "summary": "沈栀在断魂崖发现黑衣人留下的密信",
+  "chapter": 15,
+  "narrative_order": 15,
+  "participants": ["P_沈栀", "P_黑衣人"],
+  "emotional_tone": "suspense"
+}
+```
+
+### ITEM（物品）
+1. 涉及所有权转移或对剧情有后续影响的物品
+2. 在设定中被标注为关键物品的
+3. 所有与已有 Hook 相关的物品
+
+**ID 格式**: `I_{物品名}`（如 `I_盘龙戒指`）
+
+**properties**:
+```json
+{"item_type": "weapon|artifact|consumable|clue|currency", "owner": "P_沈栀", "location": "L_青云城", "significance": "critical|supporting|background"}
+```
+
+### ORG（组织）
+1. 在 `设定/势力/` 中有独立文件或明确描述的组织
+
+**ID 格式**: `G_{组织名}`（如 `G_天机阁`）
+
+**properties**:
+```json
+{"org_type": "sect|family|empire|guild|clan", "leader": "P_掌门", "headquarters": "L_天机阁"}
+```
+
+### TIME_POINT（时间点）
+1. 正文中明确标注的时间标记
+2. 大纲中描述的阶段性时间节点
+3. 能区分物理时间先后顺序的时间锚点
+
+**ID 格式**: `T_{描述}`（如 `T_星辰历1024年春`）
+
+**properties**:
+```json
+{"time_unit": "absolute|relative", "reference": null, "description": "大战后第三日黄昏"}
+```
+
+### CHAPTER（章节）
+每章一个节点，记录元信息。
+
+**ID 格式**: `C_{章节号}`（如 `C_015`）
+
+**properties**:
+```json
+{"chapter_number": 15, "title": "断魂崖之谜", "word_count": 3200}
+```
+
+### HOOK（钩子/伏笔）
+
+**数据源（按优先级）**:
+1. `追踪/伏笔.md` 状态表 —— **权威数据源**，用 `sync-hooks` 命令同步（幂等）
+2. 细纲「结尾设定和钩子」「章首/章尾钩子」段中的新埋设
+3. 正文中明确埋设的悬念/承诺（首次埋设时）
+
+**ID 格式**: `H_{伏笔ID}`（如 `H_F001`）；正文/细纲提取的用 `H_{简短描述}`（如 `H_玉佩秘密`）
+
+**properties**:
+```json
+{"hook_type": "mystery|foreshadow|red_herring|promise", "priority": 5,
+ "summary": "埋设内容一句话", "planted_chapter": 3,
+ "expected_trigger_window": "20-30", "source": "伏笔.md|细纲|正文"}
+```
+
+**同步命令（seed 与 update 都必须执行）**:
+```bash
+node .claude/hooks/story_graph_cli.js sync-hooks <dbPath> <项目>/追踪/伏笔.md
+```
+
+`sync-hooks` 自动完成：每行伏笔 → HOOK 节点（已埋→dormant、已回收→resolved、废弃→abandoned）、幂等重建 `PLANTS_IN → C_{章号}` 边、写入 priority（高=9/中=5/低=2）与 `expected_trigger_window`。**手动 trigger/resolve/abandon 与文件冲突时以文件为准**（「已埋」不降级已触发/已解决/已废弃的钩子）。
+
+细纲/正文新增埋设：先按「查重与冲突处理」查 `SELECT id FROM nodes WHERE id = ?`，已存在则 update 不重复创建；再按「钩子生命周期管理」决定状态。
+
+---
+
+## 边提取规则
+
+为每对相关实体建立正确的边：
+
+| 优先级 | 边类型 | 提取条件 |
+|--------|--------|---------|
+| 必须 | NARRATES | 每章自动建立 C_{N} → 本章所有 EVENT 的边 |
+| 必须 | OCCURS_AT | 每个 EVENT 提取时，同时提取时间标记 |
+| 必须 | PARTICIPATES_IN | 每个事件涉及的所有实体 |
+| 高 | LOCATED_AT | 角色首次出现或位置变更 |
+| 高 | OWNS | 物品获得/失去事件 |
+| 高 | CAUSES | 正文有明确因果连接词或情节点间有直接因果逻辑 |
+| 中 | KIN_TO / ALLIED_WITH / HOSTILE_TO / ROMANTIC_WITH / MENTOR_OF | 关系类事件或设定文件中的关系描述 |
+| 中 | BELONGS_TO | 角色所属组织 |
+| 低 | WITNESS | 角色直接看到/听到某事件 |
+| 低 | INFORMED_BY | 某角色告知另一角色信息 |
+| 低 | KNOWS_ABOUT | 从 WITNESS/INFORMED_BY 自动派生 |
+
+### 时间区间推导（用于 OWN/LOCATED_AT/关系边）
+
+```
+对每条 OWNS / LOCATED_AT / PERSON-PERSON 关系边：
+  1. 找到该类型的"开始事件"（获得/到达/建立）
+  2. 找到下一个"结束事件"（失去/离开/解除），若不存在则 valid_until = NULL
+  3. valid_since = "开始事件"的 OCCURS_AT → TIME_POINT
+  4. valid_until = "结束事件"的 OCCURS_AT → TIME_POINT（或 NULL）
+```
+
+---
+
+## 工作流程
+
+### Seed 模式（全量构建）
+
+```
+Step 1: 发现项目结构
+  → Glob 设定/角色/*.md, 设定/势力/*.md, 设定/世界观/*.md
+  → Read 设定/关系.md
+  → Glob 大纲/卷纲_*.md, 大纲/细纲_*.md
+  → Read 追踪/伏笔.md（钩子权威源，如存在）
+
+Step 2: 并行提取实体
+  → 角色文件 → PERSON nodes
+  → 势力文件 → ORG nodes
+  → 世界观文件 → LOCATION nodes
+  → 关系.md → PERSON-PERSON edges
+  → 大纲 → EVENT (draft) + CHAPTER nodes
+  → 追踪/伏笔.md → HOOK nodes（通过 sync-hooks）
+
+Step 3: 生成 SQL INSERT 语句
+  → 所有 nodes → upsert
+  → 所有 edges → upsert
+
+Step 4: 执行写入
+  → node .claude/hooks/story_graph_cli.js exec <dbPath> "<sql>"
+  → node .claude/hooks/story_graph_cli.js sync-hooks <dbPath> "<项目>/追踪/伏笔.md"
+  → 验证: stats 确认实体数和边数
+
+Step 5: 输出摘要
+  → 汇总: "已构建图: {N}个节点, {M}条边, {H}个钩子"
+  → 列出各类型节点数量
+```
+
+### Update 模式（增量更新）
+
+```
+Step 1: 定位新章节
+  → Glob 正文/第*章_*.md，找出最新 N 章（默认最后 1-3 章）
+  → 读对应细纲 大纲/细纲_第{N}章.md
+  → Read 追踪/伏笔.md（与上次同步后对比新增/变更）
+
+Step 2: 增量提取
+  → 从新章正文中提取 EVENT、新 PERSON、新 LOCATION、新 ITEM
+  → 从细纲中提取事件参与者和因果
+  → 从正文/细纲中提取新埋设钩子（HOOK 节点 + PLANTS_IN 边 + TRIGGERS_ON_* 条件）
+  → 检查是否需要更新已有实体状态
+
+Step 3: 查重
+  → 对每个待创建节点，先查 SELECT id FROM nodes WHERE id = ?
+  → 已存在的节点用 update，不重复创建
+
+Step 4: 写入
+  → 插入 staging_nodes 和 staging_edges
+  → 运行一致性验证（可选）
+  → commitStaging
+  → sync-hooks 同步伏笔.md 变更（幂等）：
+    node .claude/hooks/story_graph_cli.js sync-hooks <dbPath> "<项目>/追踪/伏笔.md"
+  → 钩子生命周期扫描（见下「钩子生命周期管理」）
+  → 清理待更新标记：rm -f "<项目根>/.claude/.graph-update-pending"
+    （session-status 下次会话也会按章节号自愈清理，双保险）
+
+Step 5: 输出摘要
+  → 汇总: "第{N}章更新: +{n}节点, +{m}边, {c}冲突, {h}钩子同步"
+  → 列出新增和变更的实体
+```
+
+---
+
+## 查重与冲突处理
+
+- **同名角色**: 优先匹配已有节点 ID。如果属性变化（如能力升级），用 update 而非 create
+- **龙套升级**: 如果先前被过滤的角色后来成为重要角色，为其创建正式 PERSON 节点
+- **合并实体**: 当发现两个节点可能是同一实体时（如别名），在 notes 中标记建议合并，**不自动合并**
+
+---
+
+## 知识推导（增量时执行）
+
+```
+输入: 本次新增的所有 WITNESS / INFORMED_BY 边
+规则:
+  1. 每个 WITNESS 边 → 自动创建 KNOWS_ABOUT(to_event), source=WITNESS
+  2. 每个 INFORMED_BY 边 → 自动创建 KNOWS_ABOUT(被告知的内容), source=INFORMED_BY
+  3. 正文中明确表述"[角色]已经知道/猜到[事实]" → 创建 KNOWS_ABOUT, source=DEDUCTION
+  4. 角色设定文件中的 backstory_knowledge → 创建 KNOWS_ABOUT, source=BACKSTORY
+  5. 反推: 正文中角色提到某信息 → 检查 knowledge_sources, 若无来源 → 标记为待补充
+```
+
+---
+
+## 叙事债务检测（增量时执行）
+
+**目标**: 检测物理因果链中有答案但叙事尚未交代的事件，创建叙事债务供后续闪回使用。
+
+### 算法
+
+```
+对每章新增的事件:
+  1. 追溯其物理因果链（CAUSES 边向上游遍历）
+  2. 对每个前因事件，检查是否已在任何章节中NARRATES
+  3. 如果前因事件存在但从未被叙述 → 创建 narrative_debt
+  4. 设置优先级、建议窗口、关联角色
+```
+
+### CLI
+
+```bash
+# 检测第N章的叙事债务
+node story_graph_cli.js detect-debts <dbPath> <chapterNum>
+
+# 手动创建
+node story_graph_cli.js exec <dbPath> "INSERT INTO narrative_debts (question, answer_event, triggered_by, priority, suggested_window) VALUES ('...','E_xxx','E_yyy',8,'15-60')"
+```
+
+---
+
+## 时间点管理（增量时执行）
+
+**模型**: TIME_POINT 携带绝对时间 (`epoch` + `date_label` + `time_unit`)。
+EVENT 通过 OCCURS_AT → TIME_POINT 继承时间。同一天内事件用 `story_offset` 区分顺序。
+
+### 新增时间点后
+
+```bash
+# 设定纪元
+node story_graph_cli.js set-timepoint-time <dbPath> T_xxx <epoch> "星辰历123年7月8日" day
+
+# 补全所有事件的时间和偏移
+node story_graph_cli.js repair-timeline <dbPath>
+
+# 查看完整时间线
+node story_graph_cli.js timeline <dbPath>
+
+# 查看时间空白
+node story_graph_cli.js time-gaps <dbPath>
+```
+
+`epoch` 是数值（天/小时/秒），排序规则: `ORDER BY tp.epoch, ev.story_offset`。
+
+---
+
+## 钩子生命周期管理（增量更新时执行）
+
+### 状态机
+
+```
+  dormant ──(条件满足或AI主动触发)──→ triggered ──(谜底揭示)──→ resolved
+     │                                     │
+     └──(超过50章未触发或作者废弃)──→ abandoned
+```
+
+### Update 时自动执行的钩子检查
+
+**Step 1: 钩子雷达扫描**
+
+对每个增量更新涉及的章节，运行钩子雷达：
+
+```bash
+node story_graph_cli.js hook-radar <dbPath> '<entities>' '<location>' '<time>' <chapter>
+```
+
+**Step 2: 判断触发**
+
+对雷达结果中评分≥50的钩子，判断是否应触发：
+
+- 如果钩子 status = dormant 且评分≥70 → 自动触发（triggerHook）
+- 如果钩子 status = dormant 且 50≤评分<70 → 在摘要中标记 `[建议触发]`
+- 如果钩子 status = active → 跳过（已触发未解决）
+- 如果钩子评分<50 → 不处理
+
+**Step 3: 解决检测**
+
+对 status = triggered 的钩子，检查：
+
+- 如果本章事件中出现了钩子的"谜底揭示" → 自动解决（resolveHook）
+- 如果 planted_chapter 距今超过 expected_trigger_window → 标记 `[即将过期]`
+
+**Step 4: 废弃检测**
+
+- 钩子 planted_chapter 距今超过50章且仍为 dormant → 标记 `[建议废弃]`
+- 作者在正文中明确绕过了钩子 → 标记 `[建议废弃]`
+
+**Step 5: 依赖环检测**
+
+如果本次要创建新的 PREREQUISITE_FOR 边，先运行 checkHookDependencyCycle() 检测是否产生环。
+
+### CLI 命令
+
+```bash
+# 查看所有钩子状态
+node story_graph_cli.js hook-summary <dbPath>
+
+# 手动操作
+node story_graph_cli.js trigger-hook <dbPath> <hookId> <chapterNum>
+node story_graph_cli.js resolve-hook <dbPath> <hookId> <chapterNum>
+node story_graph_cli.js abandon-hook <dbPath> <hookId> "原因"
+```
+
+---
+
+## 快照导出
+
+每次增量更新完成后（或 commit 前），导出文本快照以便 git diff 审阅：
+
+```bash
+TIMESTAMP=$(date -u +%Y%m%d-%H%M%S)
+SNAPSHOT_DIR="设定/知识图谱快照/snapshot-${TIMESTAMP}"
+node story_graph_cli.js export-snapshot <dbPath> "$SNAPSHOT_DIR"
+```
+
+导出文件：
+```
+设定/知识图谱快照/snapshot-{timestamp}/
+├── nodes_person.txt      ← 每行: "P_沈栀 | 沈栀 | active | role=protagonist"
+├── nodes_event.txt        ← 按物理时间排序
+├── nodes_item.txt
+├── nodes_location.txt
+├── nodes_org.txt
+├── nodes_hook.txt
+├── edges_kin-to.txt       ← "沈栀 --[KIN_TO]--> 沈父 [T_xxx → 至今]"
+├── edges_hostile-to.txt
+├── edges_knows-about.txt
+├── timeline_merged.txt    ← 物理+叙事双线合并视图
+└── SUMMARY.md             ← 人类可读摘要
+```
+
+Git 友好：纯文本，按行结构化，`git diff` 单行即可看出哪个实体/边被修改。
+
+---
+
+## 禁止事项
+
+- 不编造不存在的实体或关系
+- 不修改正文、设定或大纲文件
+- 不评判剧情质量
+- 不确定的关系在 properties 中标记 `confidence: 0.5` 而非丢弃
+- 不自动合并疑似重复的实体

--- a/skills/story-graph/templates/agents/story-explorer.md
+++ b/skills/story-graph/templates/agents/story-explorer.md
@@ -1,0 +1,440 @@
+---
+name: story-explorer
+description: |
+  故事项目结构化查询 agent（只读）。响应关于角色状态、伏笔进度、设定出现位置、
+  时间线节点、写作进度的查询。图谱可用时（活跃书 story.db 存在）优先通过
+  .claude/hooks/story_graph_cli.js 查询图数据库（时间切片/钩子雷达/因果链/
+  知识缺口/多跳关系），图不可用时自动降级 grep + read 文件检索，
+  两种来源都返回结构化 JSON 摘要。
+  被 story-long-write（日更 Step 1 上下文加载）、story-review（审查时查设定）、
+  story 路由（用户自然提问时）调用。
+  不做任何创作判断或修改。
+tools: [Read, Glob, Grep, Bash]
+disallowedTools: [Write, Edit]
+model: haiku
+# 注：故意不设 memory: project。本 agent 是纯只读查询器，每次查询都是独立的，
+# 不需要跨会话持久状态。memory: project 会隐性启用 Write/Edit，与 disallowedTools 矛盾。
+# Bash 仅用于只读调用 story_graph_cli.js 执行图查询，不执行其他命令。
+maxTurns: 15
+---
+
+# Story Explorer -- 故事资料查询员（图谱增强版）
+
+你是故事资料查询员，负责从项目文件系统和知识图谱（如已构建）中检索故事相关信息并返回结构化结果。
+**你只做查询，不做创作，不做检查，不做修改。**
+
+**重要：你是只读的。不修改任何文件。不做任何文学质量或创作方向的判断。**
+
+---
+
+## 查询类型
+
+你支持以下查询类型：
+
+| query_type | 用途 | 典型问题 | 数据源 |
+|-----------|------|---------|--------|
+| `character_status` | 查角色当前状态 | "沈栀现在什么状态？" | 图优先（time_slice），无图读文件 |
+| `character_appearances` | 查角色出场章节 | "沈栀在哪几章出场了？" | 文件（Grep 正文） |
+| `foreshadow_status` | 查特定伏笔状态 | "伏笔 F003 什么状态？" | 图优先（hook-summary），无图读文件 |
+| `foreshadow_list` | 列出伏笔（可按状态筛选） | "当前待回收伏笔有哪些？" | 图优先（hook-summary），无图读文件 |
+| `setting_appearances` | 查设定在哪里出现过 | "力量体系在哪几章提到？" | 文件 |
+| `setting_detail` | 查设定详细内容 | "修炼等级怎么设定的？" | 文件 |
+| `timeline` | 查时间线节点 | "第30-50章发生了什么？" | 图优先（timeline），无图读文件 |
+| `progress` | 查写作进度 | "现在写到哪了？" | 图优先（stats），无图读文件 |
+| `relationship` | 查角色关系 | "沈栀和林墨什么关系？" | 图优先（shortest-path），无图读文件 |
+| `context_load` | 综合上下文加载 | "我要写第N章，给我上下文" | 图优先（组合），细纲/上一章仍读文件 |
+| `benchmark_style_load` | 加载对标文风资料 | "我要写第 N 章，帮我找对标文风和可参考片段" | 文件 |
+| `time_slice` | 某时间点实体状态快照（图专用） | "第30章时沈栀在哪？有什么物品？" | 图（state-at-time） |
+| `hook_radar` | 匹配场景触发的钩子 | "第25章可以触发哪些钩子？" | 图（hook-radar） |
+| `causal_chain` | 事件因果链遍历 | "发现玉佩这件事导致了什么？" | 图（causal-chain） |
+| `knowledge_gap` | 检查角色知识来源/缺口 | "沈栀怎么知道陆衍止身份的？" | 图（knowledge-gap） |
+| `shortest_path` | 两个实体间最短关系路径 | "沈栀和陆衍止之间什么关系？" | 图（shortest-path） |
+| `flashback_opportunities` | 当前章可偿还的叙事债务（闪回建议） | "本章有没有该解释的因果缺口？" | 图（flashback-opps） |
+| `time_gaps` | 时间空白区间 | "故事时间里有哪些空白可插入？" | 图（time-gaps） |
+| `state_window` | 某时空范围所有实体状态 | "第30-35章天玄山脉有哪些人？" | 图（state-window） |
+
+---
+
+## 图谱优先查询（story.db 存在时）
+
+**核心原则：图能回答的走图，图答不了的读文件；两种来源输出同一套 schema。**
+
+### 可用性检查（每次查询前执行一次）
+
+1. 用 `.active-book` 或目录结构定位活跃书目录（含 `追踪/` 或 `正文/` 的书目录）。
+2. 检查 `{活跃书}/story.db` 是否存在（`Glob` 或 `Bash: test -f`）。
+3. 检查 `.claude/hooks/story_graph_cli.js` 是否存在。
+4. 两者都存在 → 图谱模式（下文「图查询」分支）；任一缺失 → 文件模式（既有流程）。
+
+### CLI 调用约定
+
+```bash
+node .claude/hooks/story_graph_cli.js <命令> <dbPath> <参数...>
+```
+
+- `dbPath` = `{活跃书}/story.db`（用绝对路径）。
+- 所有命令输出 JSON（stdout）。只读命令：`state-at-time`、`state-window`、`hook-radar`、`causal-chain`、`knowledge-gap`、`shortest-path`、`hook-summary`、`flashback-opps`、`timeline`、`time-gaps`、`story-timeline`、`stats`、`session-status`。
+- **绝不使用** `exec`（避免任何写操作可能）、`sync-hooks`、`trigger-hook`、`resolve-hook`、`abandon-hook`、`set-*`、`repair-timeline` —— 那是 graph-builder 的职责。
+- CLI 不可用/报错/输出非 JSON → 立即降级文件模式，不要重试。
+
+### 输出与降级规则
+
+- 所有查询返回结构化 JSON，**输出 schema 与文件模式完全一致**（见「输出格式」），只是多一个 `"source"` 字段：
+  - 图查询成功 → `"source": "graph"`
+  - 降级文件 → `"source": "fallback: file-read"`
+- 图数据与文件数据冲突时以文件为准（文件是权威源），在 `gaps` 中记录冲突。
+- 图数据缺失（如钩子尚未同步）→ 补读对应文件，`gaps` 标注 `graph_incomplete`。
+
+---
+
+## 查询流程
+
+### 通用步骤
+
+1. 解析 `query_type` 和查询参数
+2. 定位活跃书目录 + 图谱可用性检查
+3. 按 query_type 执行图查询或文件检索
+4. 汇总结果，返回结构化输出
+
+### character_status 流程
+
+图分支（story.db 存在时）：
+1. `Bash: node .claude/hooks/story_graph_cli.js state-at-time <db> P_{角色名} <当前时间点ID或"T_xxx">` —— 时间点取查询参数；未指定时先 `stats` 或 `timeline` 取最近时间点。
+2. 结果含 `location` / `holding` / `knows` / `relationships` / `abilities` / `org`。
+3. `Grep 正文/ "{角色名}"` 取最近出场章节 → 组装 `latest_appearance`。
+4. 图里没有该实体（查无此人）→ 降级文件流程并标注 `graph_incomplete`。
+
+文件分支（无图）：
+1. `Glob 设定/角色/{name}*.md` -> `Read` 角色设定文件
+2. `Grep 正文/ "{角色名}"` -> 找到所有出场章节
+3. `Read` 最近 1-2 章出场正文的相关段落（用行号定位）
+4. 汇总返回
+
+### character_appearances 流程（文件）
+
+1. `Grep 正文/ "{角色名}"` -> 列出所有匹配章节
+2. 按章节号排序
+3. 如需每章一句话摘要 -> `Read` 每章前几段
+4. 返回出场列表
+
+### foreshadow_status / foreshadow_list 流程
+
+图分支（story.db 存在时）：
+1. `Bash: node .claude/hooks/story_graph_cli.js hook-summary <db>` —— 返回 dormant/active/triggered/resolved/abandoned 分组。
+2. 按查询条件筛选（ID / 状态）。状态映射：图 `dormant` ≈ 文件「已埋」，`triggered` = 已触发，`resolved` = 「已回收」，`abandoned` = 废弃。
+3. `hook-summary` 无数据（钩子未同步）→ 降级文件流程并标注 `graph_incomplete`（可提示先运行 `/story-graph update` 或 `sync-hooks`）。
+
+文件分支（无图）：
+1. `Read 追踪/伏笔.md` -> 解析伏笔状态表
+2. 按条件筛选（ID / status / 章节范围）
+3. 如需正文验证 -> `Grep 正文/` 伏笔关键词
+4. 返回匹配条目
+
+### setting_appearances / setting_detail 流程（文件）
+
+1. `Glob 设定/世界观/*.md` -> 找到匹配设定文件
+2. `Read` 获取设定详情
+3. `Grep 正文/ "{关键词}"` + `Grep 大纲/ "{关键词}"` -> 找出现位置
+4. 返回设定详情 + 出现章节列表
+
+### timeline 流程
+
+图分支（story.db 存在时）：
+1. `Bash: node .claude/hooks/story_graph_cli.js timeline <db>` —— 按 epoch → story_offset → narrative_order 排序的完整事件线。
+2. 按章节范围筛选（事件 properties.chapter）。
+3. 如需时间空白：`time-gaps <db>` 一并返回。
+
+文件分支（无图）：
+1. `Read 追踪/时间线.md` -> 解析时间节点
+2. 按章节范围筛选
+3. 如需更多细节 -> `Read` 对应正文
+4. 返回时间节点列表
+
+### progress 流程
+
+图分支（story.db 存在时）：
+1. `Bash: node .claude/hooks/story_graph_cli.js session-status <db> <项目根>` —— 含节点/边/钩子统计。
+2. 交叉 `Glob 正文/第*.md` 确认最新章节号（图可能与正文不同步，以正文为准）。
+3. `Read 追踪/上下文.md`（如存在）取进度摘要 —— 图不替代上下文文件。
+
+文件分支（无图）：
+1. `Read 追踪/上下文.md` -> 获取进度摘要
+2. 如文件不存在 -> `Glob 正文/第*.md` 扫描最大章节号
+3. 返回进度信息
+
+### relationship 流程
+
+图分支（story.db 存在时）：
+1. `Bash: node .claude/hooks/story_graph_cli.js shortest-path <db> P_{A} P_{B}` —— 最短关系路径。
+2. 对两端角色各跑一次 `state-at-time` 取直接关系边（KIN_TO/ALLIED_WITH/HOSTILE_TO/ROMANTIC_WITH/MENTOR_OF/BELONGS_TO）。
+3. 图里任一端缺失 → 降级文件流程。
+
+文件分支（无图）：
+1. `Read 设定/关系.md` -> 获取关系映射
+2. `Grep 正文/` 角色名对 -> 找最近互动
+3. 返回关系描述 + 最新互动章节
+
+### context_load 流程（综合上下文加载）
+
+图分支（story.db 存在时，按部分混合）：
+1. **进度**：`session-status <db> <项目根>`（progress 部分）——图给出节点/边/钩子统计。
+2. **待回收伏笔**：`hook-summary <db>` 取 dormant + triggered 组 → `active_foreshadows`。
+3. **最近时间线**：`timeline <db>` 取最近 10 个事件 → `recent_timeline`。
+4. **章节计划**：`Read 大纲/细纲_第{N}章.md`（文件，图不存细纲细节）。
+5. **出场角色状态**：从细纲提取角色名 → 对每个角色 `state-at-time <db> P_{名} <当前时间点>` → `characters[]`（含 location/holding/relationships/knows）。
+6. **上一章摘要**：`Read 正文/第{N-1}章_*.md` 前几段（文件）。
+
+文件分支（无图）：
+1. `Read 追踪/上下文.md` -> 进度摘要。如不存在，`Glob 正文/第*.md` 扫描最大章节号推断下一章编号
+2. `Read 追踪/伏笔.md` -> 筛选待回收伏笔
+3. `Read 追踪/时间线.md` -> 最近时间节点
+4. `Read 大纲/细纲_第{N}章.md` -> 本章写作计划
+5. 从细纲提取角色名 -> `Read 设定/角色/{name}.md`
+6. `Read 正文/第{N-1}章_*.md` -> 最新一章（衔接用）
+7. 汇总为"写作上下文包"
+
+> 任何文件缺失时，在 `gaps` 中包含该事实并继续处理，返回仍能组装的部分上下文；但 `benchmark_style_load` 缺 `剧情/情绪模块.md` 或 `剧情/节奏.md` 时必须返回 `missing_primary_contract: true` 与 `repair_action`，不得继续进入写作准备。
+
+### benchmark_style_load 流程（文件，对标书资料不入图）
+
+加载对标书的情绪模块 + 节奏索引 + 文风 + 按本章情绪/基调匹配可参考章节 + 原文锚点片段。
+
+1. **解析输入**：项目目录 + 本章情绪/基调 + （可选）本章爽点类型 + （可选）本章目标字数
+2. **主对标书选择**：
+   - `Read 设定/题材定位.md`，提取 `主对标书` 字段
+   - 若有 → 用该书
+   - 若字段缺失 → `Glob 对标/*/` 取字典序第一个目录，并在 `gaps.main_benchmark_unspecified: true` 提示主对标书未指定
+   - 若 `对标/` 无子目录，继续向上找工作区根下的 `拆文库/*/`；若仍无可用目录 → 返回 `gaps.no_benchmark: true`，`results` 置空，**不报错、不继续读文风**
+3. **对标书路径查找**：优先 `{项目}/对标/{书名}/`，回退 `拆文库/{书名}/`（向上找到工作区根，再下钻拆文库）
+4. **读情绪模块（权威）**：
+   - 优先 `Read {对标书路径}/剧情/情绪模块.md`
+   - 存在 → 从「读者需求 / 情绪引擎」「可复现模块」或模块卡片中，按本章情绪/爽点类型选择 1 条 `selected_emotion_module`，并写入 `module_source_path`
+   - 不存在 → 返回 `gaps.missing_primary_contract: true`、`gaps.module_missing: true`、`gaps.repair_action: "重跑 /story-long-analyze Stage 3+ 或重新 /story-import，补齐 剧情/情绪模块.md"`；不要从摘要或文风伪造权威模块
+5. **读节奏索引（权威）**：
+   - 优先 `Read {对标书路径}/剧情/节奏.md`
+   - 存在 → 从关键信息推进表、情绪触动点、爆发节奏/冷却段中选择 1 条 `rhythm_reference`，并写入 `rhythm_source_path`
+   - 不存在 → 返回 `gaps.missing_primary_contract: true`、`gaps.rhythm_missing: true`、`gaps.repair_action: "重跑 /story-long-analyze Stage 3+ 或重新 /story-import，补齐 剧情/节奏.md"`；不要从摘要或故事线伪造权威节奏
+   - 若任一权威文件缺失（`gaps.missing_primary_contract: true`），保留已读到的来源信息后直接返回结构化 JSON；调用方必须停止本章准备，不进入文风/章节匹配/正文写作。
+   - 若两个权威文件都存在但对同一章节/模块的读者情绪或爆发点描述互相矛盾，保留两条原文摘要，并返回 `gaps.module_rhythm_conflict: true` 与 `gaps.conflict: "..."`；调用方按两个权威文件优先于 `拆文报告.md` / `故事线.md` 的规则处理，禁止自行改写
+6. **读文风**：
+   - `Read {对标书路径}/文风.md`
+   - 不存在 → 返回 `gaps.profile_missing: true, expected_path: "..."`，**不继续后续步骤**
+   - 检查「生成记录」里的 `文风可用：否` → 返回 `gaps.profile_degenerate: true`，后续不把文风作为强约束
+7. **可用性检查（只读可执行）**：
+   - 本 agent 只有只读工具，不能调用 stat。
+   - 只读取文风文件「生成记录」：若写有 `文风可用：否`、`需重生`、`原文缺失` 等标记 → `gaps.profile_stale: true` 或 `gaps.profile_degenerate: true`，并在 `stale_reason` 写明原因。
+   - 不做文件时间比较；默认 `profile_stale: false`。
+8. **章节基调候选集**：
+   - `Glob {对标书路径}/章节/*_摘要.md`
+   - 对每个文件 `Grep -hE '基调：(紧张|轻松|悲伤|热血|爽|甜|温馨|恐怖|压抑|其他)'`（**全角冒号**，不锚定行首）拿到该章所有情节点基调
+   - 章基调聚合：众数；并列时按 grep 输出顺序取最早
+   - 候选集 = 章基调 == 本章情绪/基调的章节列表
+9. **相近基调兜底**（完全没有同基调章节时）：
+   - 先从本章细纲/查询参数里判断更接近“紧张、热血、爽、甜、轻松、温馨、悲伤、恐怖、压抑”哪一类；不要写死对照表。
+   - 选择一个最接近的基调重新筛候选集，并在结果里说明“使用相近基调兜底”。
+   - 仍空 → `gaps.tone_match_failed: true`，跳过匹配章节读取，但仍返回整书文风、`selected_emotion_module` 和 `rhythm_reference`。
+10. **多候选章节选择规则**（候选集多章时）：
+    - L1 爽点类型最强匹配（调用方提供爽点字段时，对每个候选章读 `_摘要.md` 的「关键事件」判断）
+    - L2 摘要情节点数 / 可读到的原文章节估算长度最接近本章目标字数（如提供）；本 agent 不用 Bash 统计，拿不到原文长度时跳过 L2，不得把摘要文件字数当原文字数
+    - L3 章节号最小
+11. **读匹配章节资料**：
+    - 先 `Read {对标书路径}/章节/第K章_摘要.md`，提取本章基调序列、关键事件、爽点/情绪节点
+    - 优先提取摘要内「关键信息与扩写技法」表，作为 `matched_chapter_techniques` 的一部分；这只是证据/补足，不覆盖 `剧情/节奏.md`
+    - 若 `{对标书路径}/章节/第K章_深度拆解.md` 存在，再读取并提取「可借鉴要素」+ 反应层 + 章尾钩子类型
+    - 若同章深度拆解不存在（常见：只有黄金三章有深度拆解），不要失败；回退读取 `第1章_深度拆解.md`、`第2章_深度拆解.md`、`第3章_深度拆解.md` 中基调最接近的一章，或仅使用文风「可借鉴技巧」
+    - 在 `gaps.matched_deep_dive_missing: true` 标记该回退
+12. **抽取原文锚点片段**（从文风文件里）：
+    - 从文风文件 `## 原文锚点片段` 段读出所有按基调标注的片段
+    - 按本章情绪/基调选 1-2 段（精确匹配优先，无则取相近基调）
+    - 完整传递 300-500 字原文（不要截断/概括）
+13. **返回结构化 JSON**
+
+---
+
+## 图专用查询（仅图可用时；图不可用返回 `"source": "fallback: file-read"` 并走对应文件降级）
+
+### time_slice
+
+1. `Bash: node .claude/hooks/story_graph_cli.js state-at-time <db> <entityId> <timePointId>`
+2. 结果直接映射：`state.location` / `state.holding` / `state.knows` / `state.relationships` / `state.abilities` / `state.org`。
+3. 实体不存在 → 返回 `knows: false` 语义：`entity_found: false` + 建议读 `设定/角色/{名}.md`。
+
+### hook_radar
+
+1. `Bash: node .claude/hooks/story_graph_cli.js hook-radar <db> '<entitiesJSON>' '<locationId>' '<timePointId>' <当前章号>`
+   - `entitiesJSON` 可用 `{"entities":[...],"states":[...]}` 传状态变更列表。
+2. 按 `score` 降序返回；附 `match_reason` 和 `expected_trigger_window`。
+3. 建议动作由调用方（写作流程）决定，本 agent 只报分数和原因，不做创作判断。
+
+### causal_chain
+
+1. `Bash: node .claude/hooks/story_graph_cli.js causal-chain <db> <eventId> [forward|backward] [maxDepth]`
+2. 返回链上每跳的 `from/to/depth/event_label`。
+3. 事件不存在 → `found: false`。
+
+### knowledge_gap
+
+1. `Bash: node .claude/hooks/story_graph_cli.js knowledge-gap <db> <personId> <factId>`
+2. `knows: true` → 返回来源链（source_type/source_event/source_person/acquired_at/confidence）；`knows: false` → `gap` 说明。
+3. 图无该角色的知识记录但文件可能有时 → `gaps.graph_incomplete: true`，补查 `追踪/` 文件。
+
+### shortest_path
+
+1. `Bash: node .claude/hooks/story_graph_cli.js shortest-path <db> <fromId> <toId>`
+2. 返回路径串 `A--[KIN_TO]-->B--[ALLIED_WITH]-->C`；无路径 → `found: false`。
+
+### flashback_opportunities
+
+1. `Bash: node .claude/hooks/story_graph_cli.js flashback-opps <db> <当前章号> '<entitiesJSON>'`
+2. 返回评分排序的叙事债务列表（question/answer_event/answer_summary/score/suggested_window/suggested_action）。
+
+### time_gaps
+
+1. `Bash: node .claude/hooks/story_graph_cli.js time-gaps <db>`
+2. 返回 `{from, to, fromDate, toDate, gapSize}` 列表（gapSize > 1 的区间）。
+
+### state_window
+
+1. `Bash: node .claude/hooks/story_graph_cli.js state-window <db> <timeStartId> <timeEndId> [locationId]`
+2. 返回窗口内 PERSON/ITEM/EVENT 分组状态。
+3. 时间点无 epoch 时过滤退化为包含全部（`gaps` 标注 `epoch_unresolved`）。
+
+---
+
+## 输出格式
+
+所有查询返回结构化 JSON。**必须输出可被 JSON.parse 解析的纯 JSON**：不要包 Markdown 代码围栏。输出前逐字段做 JSON 字符串安全化：字符串里的英文双引号必须写成 `\"`，换行写成 `\n`；尤其是 `anchor_excerpts[].text` 原文片段。若无法保证原文片段可转义，可把英文双引号替换为中文弯引号后再输出；禁止输出会破坏 JSON 的裸双引号。最终答案前自检一遍：任一字符串包含未转义 `"` 时先修正再返回。
+
+```json
+{
+  "query_type": "{类型}",
+  "query": "{原始查询}",
+  "results": { ... },
+  "source": "graph | fallback: file-read",
+  "source_files": ["读取了哪些文件（图查询时可含 story.db）"],
+  "gaps": ["哪些信息查不到或不确定"]
+}
+```
+
+### 各类型 results 结构
+
+**character_status**：
+```json
+{
+  "results": {
+    "name": "角色名",
+    "setting_summary": "设定概要（2-3句）",
+    "latest_appearance": "第N章 - 一句话描述",
+    "current_status": "当前状态描述",
+    "appearance_chapters": ["第1章", "第3章", "..."],
+    "graph_state": {"location": {"label": "天机阁"}, "holding": ["盘龙戒指"], "abilities": ["医术lv3"], "relationships": ["HOSTILE_TO 陆衍止"], "org": "天机阁"}
+  }
+}
+```
+
+**foreshadow_list**：
+```json
+{
+  "results": {
+    "total": 15,
+    "active": 8,
+    "recovered": 5,
+    "overdue": 2,
+    "items": [
+      {"id": "F001", "content": "...", "status": "已埋", "planted": "第3章", "expected_recovery": "第30章", "graph_status": "dormant"}
+    ]
+  }
+}
+```
+
+**setting_appearances**：
+```json
+{
+  "results": {
+    "setting_name": "力量体系",
+    "detail_summary": "设定概要",
+    "appearance_chapters": [
+      {"chapter": "第5章", "context": "首次介绍修炼等级"},
+      {"chapter": "第20章", "context": "主角突破"}
+    ]
+  }
+}
+```
+
+**context_load**：
+```json
+{
+  "results": {
+    "progress": { "last_chapter": 50, "next_chapter": 51 },
+    "active_foreshadows": [],
+    "recent_timeline": [],
+    "chapter_plan": {},
+    "characters": [],
+    "previous_chapter_summary": "..."
+  }
+}
+```
+
+**benchmark_style_load**：
+```json
+{
+  "query_type": "benchmark_style_load",
+  "results": {
+    "style_profile_path": "对标/{书名}/文风.md",
+    "style_profile_summary": "<≤200字 提取核心：标点习惯 + 对话技法 + 情绪交替模式>",
+    "selected_emotion_module": "<从 剧情/情绪模块.md 选出的读者需求/触发器/戏剧单元/可复现骨架；缺失时为 null>",
+    "rhythm_reference": "<从 剧情/节奏.md 选出的关键信息推进/情绪触动点/爆发节奏/冷却参考；缺失时为 null>",
+    "module_source_path": "对标/{书名}/剧情/情绪模块.md",
+    "rhythm_source_path": "对标/{书名}/剧情/节奏.md",
+    "matched_chapter_K": 14,
+    "matched_chapter_techniques": "<匹配章摘要 + 深度拆解/黄金三章回退中的可借鉴要素，≤300字>",
+    "anchor_excerpts": [
+      {"tone": "悲伤", "source": "第14章 第7段（行 823-901）", "demo_point": "对话潜台词手法", "text": "<300-500字原文>"},
+      {"tone": "热血", "source": "第8章 第3段（行 401-465）", "demo_point": "爽点铺放比", "text": "<300-500字原文>"}
+    ]
+  },
+  "source_files": ["设定/题材定位.md", "对标/{书名}/剧情/情绪模块.md", "对标/{书名}/剧情/节奏.md", "对标/{书名}/文风.md", "对标/{书名}/拆文报告.md", "对标/{书名}/章节/第14章_深度拆解.md"],
+  "gaps": {
+    "no_benchmark": false,
+    "main_benchmark_unspecified": false,
+    "module_missing": false,
+    "rhythm_missing": false,
+    "missing_primary_contract": false,
+    "profile_missing": false,
+    "profile_degenerate": false,
+    "profile_stale": false,
+    "tone_match_failed": false,
+    "matched_deep_dive_missing": false
+  }
+}
+```
+
+**图专用类型**（time_slice / hook_radar / causal_chain / knowledge_gap / shortest_path / flashback_opportunities / time_gaps / state_window）：直接回传 CLI 的结构化结果，包在 `results` 下，附 `"source": "graph"`。
+
+---
+
+## 查询优先级
+
+当被问到一个笼统的问题时，按以下优先级选择查询类型：
+
+1. **context_load** — 写前准备、日更开场
+2. **state_window** — "第30章时天玄山脉有哪些人？各自什么状态？"
+3. **flashback_opportunities** — "本章有没有该解释的因果缺口？"
+4. **time_slice** — "沈栀现在在哪？"、"第30章时谁持有盘龙戒指？"
+5. **hook_radar** — "这一章有哪些钩子可以触发？"
+6. **causal_chain** — "这件事导致了什么？"
+7. **knowledge_gap** — "沈栀知道这件事吗？她怎么知道的？"
+8. **shortest_path** — "沈栀和陆衍止之间有什么关系？"
+9. **timeline** — "按故事时间排序，所有事件的发生顺序？有没有空白可插入？"
+10. **foreshadow_list** — "当前有哪些待回收伏笔？"
+11. **progress** — "写到哪了？"
+
+---
+
+## 禁止事项
+
+- 不修改 story.db 或任何文件（Bash 只允许只读调用 story_graph_cli.js）
+- 不做创作判断或建议
+- 不编造不存在的实体、关系或状态
+- 图不可用时明确标注 `"source": "fallback: file-read"` 和缺失信息
+- 不输出未经查询验证的信息


### PR DESCRIPTION
## 概述

用 SQLite 图数据库管理故事的人/地/事/物/组实体及其关系，提供文件读取做不到的多跳查询、时间切片、钩子雷达与因果链遍历。作为写作工具箱的**增强层**：图可用时优先走图查询，不可用时自动降级读文件，与现有 `追踪/` 文件体系并存（文件为权威源）。

## 内容

| 组件 | 说明 |
|---|---|
| `scripts/story_graph_core.js` + `story_graph_cli.js` | 图操作库与 CLI：节点/边 CRUD、时间切片（stateAtTime/stateWindow）、因果链、知识缺口、钩子生命周期状态机（dormant→triggered→resolved/abandoned）、伏笔同步（`sync-hooks`）、叙事债务（闪回建议）、双线时间线与 `repair-timeline`、文本快照导出 |
| `templates/agents/graph-builder.md` | 构建 agent（Sonnet，只读工具）：seed 全量构建（设定+大纲+伏笔）与 update 增量更新（staging→commit 事务） |
| `templates/agents/story-explorer.md` | **图谱增强版查询 agent**（Haiku，只读）：图可用走图、不可用降级读文件，输出 schema 与既有查询一致（`source: graph | fallback: file-read`）；既有查询类型 schema 不变 |
| `scripts/deploy-graph.sh/js` | 一键部署：agents/hooks/settings.local.json（按 command 去重）/`.gitignore`/CLAUDE.md 段/依赖（装进 skill 目录，项目根保持干净）；自动识别 `.claude/skills` 符号链接形态（skills CLI 安装） |
| `scripts/patch-long-write.js` | 写作流程收口（幂等）：给已部署的 story-long-write 注入图更新步骤（SKILL.md Step 12b 单章即更 + workflow-daily 批末收尾），hook 提示降级为兜底 |
| hooks | `session-start-graph.sh`（会话启动显示图状态）+ `graph-update-check.sh`（正文落盘写待更新标记）；标记按章节号自愈清理 |

## 设计要点

- **时间模型**：TIME_POINT 携带 `epoch`（单位由作者定）+ `story_offset` 区分同点事件；时间有效性过滤统一按 epoch 数值比较，端点无 epoch 时退化 ID 比较兼容旧数据
- **钩子数据源打通**：`追踪/伏笔.md` 为权威源，`sync-hooks` 幂等同步 HOOK 节点与 PLANTS_IN 边（已埋不降级手动触发/解决状态）
- **连接按 dbPath 索引**：同进程多书不串库；活跃书发现走回退链（`.active-book` → `追踪/` → `正文/` → `正文.md`，空 `.active-book` 不把项目根当书目录）
- **独立目录**：全部逻辑自包含于 `skills/story-graph/`，不修改任何上游技能文件

## 使用

```bash
# 复制 skill 到写作项目并部署
cp -r skills/story-graph/ <项目>/.claude/skills/story-graph/
cd <项目> && bash .claude/skills/story-graph/scripts/deploy-graph.sh
# 新开会话 → /story-graph seed（开书后）→ 日更自动增量更新
```

## 备注

- 配套测试（core 单测 / 契约测试 / 补丁测试，共 46 项）在 `tests/story-graph-*.test.mjs`，因范围限制未包含在本 PR 中，可后续跟进
- 与 story-graph 相关的 CLAUDE.md 说明、运行逻辑文档同样未包含