### PR TITLE
docs(skill): 参考资料解析顺序补 skill root，部署幂等写明（#282 相关）

### DIFF
--- a/skills/story-review/SKILL.md
+++ b/skills/story-review/SKILL.md
@@ -63,13 +63,16 @@ Rubric Source: file | embedded fallback
 
 ### 参考资料解析顺序
 
-可读取参考文件时，按以下顺序尝试：
+可读取参考文件时，按以下顺序尝试，第一个命中即用：
 1. `{项目根}/.claude/skills/{规范路径}`（Claude Code 项目内安装）
 2. `{项目根}/.opencode/skills/{规范路径}`（OpenCode 项目内安装）
 3. `{项目根}/.codex/skills/{规范路径}`（Codex 项目内安装）
 4. `{项目根}/.zcode/skills/{规范路径}`（ZCode 项目内安装）
-5. `{项目根}/skills/{规范路径}`（本仓库开发环境）
-6. 工具自身可访问的全局 skill 搜索路径中同名 `{skill-name}/...` 目录
+5. `{项目根}/skills/{规范路径}`（OpenClaw / Reasonix / generic 部署，也是本仓库开发环境）
+6. `{项目根}/.agents/skills/{规范路径}`（Codex / Reasonix 扫描的项目 skill root，通常是指向 `skills/` 的 symlink）
+7. 当前运行时加载本 skill 的目录，或其可访问的全局 skill 搜索路径中同名 `{skill-name}/...` 目录
+
+> 靠前几层不存在是正常的，不是部署损坏。`/story-setup` 只在 ZCode 的 `.zcode/skills/` 和 OpenClaw / Reasonix / generic 的 `skills/` 下整份复制 skill；Codex 项目部署不复制 skill 本体，本 skill 由 Codex 从 skill root 加载，references 就在其中，通常命中第 6 或第 7 层。不要手工把 `references/` 复制进 `.codex/skills/`——手工副本不受 story-setup 管理，升级后会静默变旧。
 
 规范路径如下；禁止只写裸文件名，禁止跨 skill 误读其他 skill 的 references：
 

--- a/skills/story-setup/SKILL.md
+++ b/skills/story-setup/SKILL.md
@@ -57,6 +57,8 @@ metadata: {"openclaw":{"source":"https://github.com/worldwonderer/oh-story-claud
 
 使用 AskUserQuestion 确认部署位置后，依次执行。
 
+整个 Phase 2 幂等：目录复制、文件写入和下表各合并算法重复执行结果一致。因环境原因（工具不可用、权限被拒、网络失败）中途失败时，直接从头重跑本 Phase，不需要先清理半成品；`create only if absent` 的用户状态文件（见下表 Owner class）不会被二次覆盖。
+
 ### Step 1：部署清单（机械可检查）
 
 | Source path | Target path | Owner class | Merge mode | Validation check |


### PR DESCRIPTION
## 背景

两处用户反馈都不是功能缺陷，但各自暴露了一处文档不准确：

1. 有用户报「Codex 部署层缺少 `story-review/references`，全局别名路径在本机不存在」。核对属实但属设计边界——`/story-setup` 对 Codex 只部署 agent 参考包，不复制 `story-*` skill 本体；skill 由 Codex 从 skill root（`.agents/skills`）加载，references 就在其中。真正的问题是 `story-review` 的解析顺序里**没有** `.agents/skills`，末层还把它笼统写成「全局 skill 搜索路径」，于是模型走到第 3 层落空就把它当成部署缺文件报了上来。
2. #282 的 Bash 全量被拒是 Claude Code 权限分类器不可用（harness 侧），不是本项目配置问题；但部署中途失败时，SKILL.md 从没写过 Phase 2 可以直接重跑——幂等只在 Codex hooks 合并那一条里提过。

## 改动

`skills/story-review/SKILL.md`
- 解析顺序补第 6 层 `{项目根}/.agents/skills/{规范路径}`（Codex / Reasonix 扫描的项目 skill root）
- 末层由「工具自身可访问的全局 skill 搜索路径」改为「当前运行时加载本 skill 的目录，或其可访问的全局 skill 搜索路径」
- 第 5 层 `skills/` 补注 OpenClaw / Reasonix / generic 部署也落在这里
- 加一段说明：靠前几层不存在属正常，不是部署损坏；不要手工把 `references/` 复制进 `.codex/skills/`

`skills/story-setup/SKILL.md`
- Phase 2 开头写明整个 Phase 幂等，中途因工具不可用/权限被拒/网络失败中断可直接重跑，无需清理半成品；`create only if absent` 的用户状态文件不会被二次覆盖

## 影响面

纯文档对齐，不改部署物行为，**不 bump `agents_version`**（改动都在技能目录内）。行为本身此前也没坏：解析顺序是有序尝试列表，全部落空还有内置基准包兜底（`Rubric Source: embedded fallback`）。

> 注：写第一版说明时直接引用了 story-setup 的 agent 参考包路径，被 `static-check.sh` 的 cross-skill-reference 守卫拦下，已改成不跨 skill 的表述。

## 验证

本地全绿：`static-check.sh`（13/13）、`test-static-check.py`、`skill-numbering.py check`、`test-skill-numbering.sh`、`check-current-skill-contracts.sh`、`test-current-skill-contracts.py`、`check-shared-files.sh`、`check-story-setup-deployment.sh`、`check-{claude,codex,opencode,zcode,reasonix}-adapter.sh`、`check-openclaw-skills.sh`、`check-python-invocation.sh`、`check-hook-regex-sync.sh`、`check-hook-locale-safety.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q8A8HW1QwFTnQFT9iUmitW