### PR TITLE
feat(story-cover): use Codex built-in ImageGen before API fallback

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -42,6 +42,8 @@ jobs:
         run: node scripts/test-normalize-punctuation.js
       - name: Scan runtime regression
         run: node scripts/test-scan-runtime.js
+      - name: Story cover Codex ImageGen contract
+        run: bash scripts/test-story-cover-codex-imagegen.sh
       - name: AI-pattern detector regression
         run: bash scripts/test-ai-patterns.sh
       - name: Outline-copy detector regression

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,7 @@ PR 自动运行 `.github/workflows/cross-platform.yml`。static-check job 跑以
 - `scripts/check-opencode-adapter.sh` — OpenCode adapter 同步、commands/agents/config 结构与 plugin 真实行为检查
 - `scripts/check-openclaw-skills.sh` — OpenClaw 单行 frontmatter、`metadata.openclaw` 与可选真实 CLI 发现检查
 - `scripts/check-codex-adapter.sh` — Codex repo skills symlink、custom-agent TOML、hook 生成确定性与 launcher 契约
+- `scripts/test-story-cover-codex-imagegen.sh` — `story-cover` 优先使用 Codex 内置 ImageGen、无需 API Key，并保留跨端 API 回退
 - `scripts/test-codex-hooks.sh` — Codex hooks 合成事件测试
 - `scripts/check-zcode-adapter.sh` — ZCode plugin/marketplace、13 Skills/Commands、受支持 Hook 事件与部署锚点检查
 - `scripts/test-zcode-hooks.sh` — ZCode 严格 JSON Hook 契约、正文守卫、连续性与跨平台 Node runner 测试
@@ -95,6 +96,7 @@ bash scripts/check-shared-files.sh
 python3 scripts/test-shared-assets.py
 node scripts/test-normalize-punctuation.js
 node scripts/test-scan-runtime.js
+bash scripts/test-story-cover-codex-imagegen.sh
 bash scripts/test-ai-patterns.sh
 bash scripts/test-degeneration.sh
 bash scripts/test-prose-backstop-hook.sh

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Windows 上偶尔会看到 `ENOENT ... mkdir` 报错但末尾仍显示 `Done!`�
 | `story-deslop` | `/story-deslop` `/去AI味` | 去AI味 · 检测并清除 AI 写作痕迹 |
 | `story-import` | `/story-import` `/导入小说` | 逆向导入 · 将已有小说反向解析为标准项目结构 |
 | `story-review` | `/story-review` `/审查` | 多视角审查 · 4 Agent 多视角审稿 + 番茄/起点/知乎评分标准 |
-| `story-cover` | `/story-cover` `/封面` | 封面生成 · 书名题材分析 + GPT-Image-2 出图 |
+| `story-cover` | `/story-cover` `/封面` | 封面生成 · 书名题材分析 + GPT-Image-2（Codex 内置用量 / API 回退） |
 | `browser-cdp` | `/browser-cdp` | 浏览器操控 · CDP 协议复用登录态抓取数据 |
 
 > `story-deslop` 的本地检查是写作 lint：blocking 只限确定性句式/标点问题，其他提示按读感判断；朱雀等外部检测只作自测参考，不替代人工读感。

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,4 +1,4 @@
-<!-- Last synced with README.md: 2026-08-13 -->
+<!-- Last synced with README.md: 2026-08-14 -->
 
 **English** | [中文](README.md)
 
@@ -143,7 +143,7 @@ After updating, if a project has already run `/story-setup`, re-run `/story-setu
 | `story-deslop` | `/story-deslop` | De-AI-ify — detect and remove AI writing traces |
 | `story-import` | `/story-import` | Reverse import — parse existing novels into standard project structure |
 | `story-review` | `/story-review` | Multi-perspective review — 4-agent adversarial review + Fanqie/Qidian/Zhihu scoring rubrics |
-| `story-cover` | `/story-cover` | Cover generation — title & genre analysis + GPT-Image-2 image generation |
+| `story-cover` | `/story-cover` | Cover generation — title/genre analysis + GPT-Image-2 via Codex included usage or API fallback |
 | `browser-cdp` | `/browser-cdp` | Browser control — CDP protocol for scraping with reusable login sessions |
 
 > `story-deslop` uses local prose linting: blocking applies only to deterministic style/punctuation issues, while other findings require read-through judgment; external detectors such as Zhuque are self-check references, not replacements for human review.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -42,6 +42,7 @@
 | `test-shared-assets.py` | 共享资产 manifest 的 drift、sync、路径越界、basename 单一 owner 与未登记重复检测 | CI |
 | `test-normalize-punctuation.js` | 标点归一化的只读检查、frontmatter/fence、CRLF、引号模式与幂等性 | CI |
 | `test-scan-runtime.js` | CDP argv 边界/报错/JSON 契约与 7 个 scraper 无副作用 import | CI |
+| `test-story-cover-codex-imagegen.sh` | `story-cover` 的 Codex 内置 ImageGen 优先、免 API Key、产物落盘与 API 回退契约 | CI |
 | `test-opencode-plugin.mjs` | 直接执行 OpenCode TypeScript plugin，验大纲守卫、Bash 绕过、写后检查与 compact 恢复 | 被 `check-opencode-adapter.sh` 调用 |
 | `test-codex-cli-e2e.sh` | 隔离 HOME 后用真实 Codex CLI 检查 repo 13 个 skill 的发现结果 | CLI compatibility CI；需已安装 `codex` |
 | `test-zcode-hooks.sh` | ZCode 严格 JSON Hook、正文守卫与连续性回归 | CI |

--- a/scripts/test-story-cover-codex-imagegen.sh
+++ b/scripts/test-story-cover-codex-imagegen.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# test-story-cover-codex-imagegen.sh — story-cover 的 Codex 内置 ImageGen 通路契约。
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SKILL="$REPO_ROOT/skills/story-cover/SKILL.md"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local needle="$1"
+  grep -F -- "$needle" "$SKILL" >/dev/null 2>&1 || fail "missing story-cover contract: $needle"
+}
+
+assert_contains 'Codex 内置 ImageGen（默认）'
+assert_contains '计入 Codex 通用用量，**无需** `OPENAI_API_KEY` 或 `GPT_IMAGE_API_KEY`'
+assert_contains '只要内置 `image_gen` 工具可用，就直接调用工具，不检查 API Key'
+assert_contains '`story-cover` 必须自行完成工具调用和落盘'
+assert_contains '每个构图方案单独调用一次内置工具'
+assert_contains '读取工具结果返回的生成图片绝对路径'
+assert_contains '保留 `$CODEX_HOME/generated_images/` 下的原文件'
+assert_contains '不要求用户 `export`'
+assert_contains "SRC='<image_gen 工具返回的生成图片绝对路径>'"
+assert_contains "REF_IMAGE='<参考图路径或 URL；没有则留空>'"
+assert_contains '#### API 回退'
+assert_contains ': "${GPT_IMAGE_API_KEY:?请设置 export GPT_IMAGE_API_KEY=你的key}"'
+
+builtin_line=$(grep -n -F '#### Codex 内置 ImageGen（默认）' "$SKILL" | head -1 | cut -d: -f1)
+fallback_line=$(grep -n -F '#### API 回退' "$SKILL" | head -1 | cut -d: -f1)
+[ -n "$builtin_line" ] && [ -n "$fallback_line" ] || fail "could not locate generation route headings"
+[ "$builtin_line" -lt "$fallback_line" ] || fail "Codex built-in route must precede API fallback"
+
+echo "PASS: story-cover prefers Codex built-in ImageGen and keeps the API fallback"

--- a/scripts/test-story-cover-codex-imagegen.sh
+++ b/scripts/test-story-cover-codex-imagegen.sh
@@ -2,35 +2,54 @@
 # test-story-cover-codex-imagegen.sh — story-cover 的 Codex 内置 ImageGen 通路契约。
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-SKILL="$REPO_ROOT/skills/story-cover/SKILL.md"
+SKILL="$(cd "$(dirname "$0")/.." && pwd)/skills/story-cover/SKILL.md"
+ROUTES='/^## 生成通路$/,/^## 输出参数与 API 回退环境变量$/p'
+BUILTIN='/^#### Codex 内置 ImageGen（优先）$/,/^#### API 回退$/p'
+API='/^#### API 回退$/,/^### Step 5：/p'
+EXPORT='/^### Step 5：/,/^### Step 6：/p'
 
-fail() {
-  echo "FAIL: $*" >&2
-  exit 1
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+assert_all() {
+  local range="$1" needle
+  shift
+  for needle in "$@"; do
+    sed -n "$range" "$SKILL" | grep -F -- "$needle" >/dev/null 2>&1 || fail "missing contract: $needle"
+  done
 }
 
-assert_contains() {
-  local needle="$1"
-  grep -F -- "$needle" "$SKILL" >/dev/null 2>&1 || fail "missing story-cover contract: $needle"
+assert_none() {
+  local range="$1" needle
+  shift
+  for needle in "$@"; do
+    ! sed -n "$range" "$SKILL" | grep -F -- "$needle" >/dev/null 2>&1 || fail "unexpected contract: $needle"
+  done
 }
 
-assert_contains 'Codex 内置 ImageGen（默认）'
-assert_contains '计入 Codex 通用用量，**无需** `OPENAI_API_KEY` 或 `GPT_IMAGE_API_KEY`'
-assert_contains '只要内置 `image_gen` 工具可用，就直接调用工具，不检查 API Key'
-assert_contains '`story-cover` 必须自行完成工具调用和落盘'
-assert_contains '每个构图方案单独调用一次内置工具'
-assert_contains '读取工具结果返回的生成图片绝对路径'
-assert_contains '保留 `$CODEX_HOME/generated_images/` 下的原文件'
-assert_contains '不要求用户 `export`'
-assert_contains "SRC='<image_gen 工具返回的生成图片绝对路径>'"
-assert_contains "REF_IMAGE='<参考图路径或 URL；没有则留空>'"
-assert_contains '#### API 回退'
-assert_contains ': "${GPT_IMAGE_API_KEY:?请设置 export GPT_IMAGE_API_KEY=你的key}"'
+assert_all "$ROUTES" \
+  'Codex 内置（优先）' \
+  '计入 Codex 通用用量，无需 `OPENAI_API_KEY` 或 `GPT_IMAGE_API_KEY`' \
+  '`story-cover` 自行调用工具，不让用户另开命令' \
+  '内置调用失败时先报告错误，不静默切换到可能收费的 API'
 
-builtin_line=$(grep -n -F '#### Codex 内置 ImageGen（默认）' "$SKILL" | head -1 | cut -d: -f1)
-fallback_line=$(grep -n -F '#### API 回退' "$SKILL" | head -1 | cut -d: -f1)
-[ -n "$builtin_line" ] && [ -n "$fallback_line" ] || fail "could not locate generation route headings"
-[ "$builtin_line" -lt "$fallback_line" ] || fail "Codex built-in route must precede API fallback"
+assert_all "$BUILTIN" \
+  '比例和安全区写进提示词，不传 `GPT_IMAGE_MODEL`、`GPT_IMAGE_SIZE`、`response_format`' \
+  '本地文件先用图片查看工具载入会话；URL 先下载再载入' \
+  '每个构图方案单独调用一次' '先创建 `BOOK_DIR/封面/`' '`N` 自增且不覆盖旧版' \
+  '保留 `$CODEX_HOME/generated_images/` 原文件' \
+  '同时保存同名 `.prompt.txt`，有参考图再保存 `.ref.txt`' \
+  '确认图片可读，并把原图绝对路径交给 Step 5'
+assert_none "$BUILTIN" 'curl' '${GPT_IMAGE_API_KEY:?'
+
+assert_all "$API" '$BASE_URL/images/generations' '$BASE_URL/images/edits'
+KEY_GUARD=': "${GPT_IMAGE_API_KEY:?请设置 export GPT_IMAGE_API_KEY=你的key}"'
+[ "$(sed -n "$API" "$SKILL" | grep -F -c "$KEY_GUARD")" -eq 2 ] && \
+  [ "$(grep -F -c "$KEY_GUARD" "$SKILL")" -eq 2 ] || \
+  fail 'both API fallback routes must enforce GPT_IMAGE_API_KEY'
+
+assert_all "$EXPORT" \
+  "SRC='<Step 4 生成的原图绝对路径>'" \
+  "TARGET='<Step 1 确定的平台上传尺寸；无则留空>'" \
+  '[ -f "$SRC" ] || { echo "封面原图不存在: $SRC" >&2; exit 1; }'
 
 echo "PASS: story-cover prefers Codex built-in ImageGen and keeps the API fallback"

--- a/skills/story-cover/SKILL.md
+++ b/skills/story-cover/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: story-cover
 version: 1.0.0
-description: "小说封面生成。根据书名、作者名自动分析题材风格，调用 GPT-Image-2 直接生成含标题和署名的专业级网文封面。触发方式：/story-cover、/封面、「帮我做个封面」「生成封面图」「做个小说封面」「封面设计」。"
+description: "小说封面生成。根据书名、作者名自动分析题材风格，调用 GPT-Image-2 生成含标题和署名的专业级网文封面；Codex CLI 优先使用内置 ImageGen，无需单独 API Key。触发方式：/story-cover、/封面、「帮我做个封面」「生成封面图」「做个小说封面」「封面设计」。"
 metadata: {"openclaw":{"requires":{"env":["GPT_IMAGE_API_KEY"],"bins":["curl","jq","base64"]},"primaryEnv":"GPT_IMAGE_API_KEY","source":"https://github.com/worldwonderer/oh-story-claudecode"}}
 ---
 # story-cover：小说封面生成
@@ -12,17 +12,28 @@ metadata: {"openclaw":{"requires":{"env":["GPT_IMAGE_API_KEY"],"bins":["curl","j
 
 ---
 
-## 环境变量
+## 执行通路
+
+按当前会话能力选择，**Codex 内置通路优先**：
+
+| 通路 | 适用条件 | 鉴权 |
+|:-----|:---------|:-----|
+| Codex 内置 ImageGen（默认） | Codex CLI 交互会话中可调用 `$imagegen` / 内置 `image_gen` 工具 | 计入 Codex 通用用量，**无需** `OPENAI_API_KEY` 或 `GPT_IMAGE_API_KEY` |
+| API 回退 | 当前会话没有内置 `image_gen` 工具，或用户明确要求走 OpenAI / 兼容代理 API | 需要 `GPT_IMAGE_API_KEY` |
+
+只要内置 `image_gen` 工具可用，就直接调用工具，不检查 API Key、不要求用户配置 API Key，也不改走 `curl`。`story-cover` 必须自行完成工具调用和落盘，不要把任务甩回给用户让其另行运行 `$imagegen`。内置工具不可用时才进入 API 回退；不得把“当前没有内置工具”误报成“Codex 订阅不能生图”。
+
+## 输出参数与 API 回退环境变量
 
 | 变量 | 必填 | 默认 | 说明 |
 |:-----|:----:|:-----|:-----|
-| `GPT_IMAGE_API_KEY` | ✅ | — | OpenAI 或兼容代理的 API Key |
+| `GPT_IMAGE_API_KEY` | API 回退必填 | — | OpenAI 或兼容代理的 API Key；Codex 内置通路不用 |
 | `GPT_IMAGE_BASE_URL` | | `https://api.openai.com/v1` | 兼容代理时改这个 |
 | `GPT_IMAGE_MODEL` | | `gpt-image-2` | 仅在测试新模型时覆盖 |
-| `GPT_IMAGE_SIZE` | | `1024x1536` | 目标比例提示（番茄 3:4→`768x1024`，默认 2:3→`1024x1536`）。官方 gpt-image-2 认任意 16 倍数尺寸（比例≤3:1），但**很多中转代理会忽略 size、按预设返回约 2:3**（已实测）——平台尺寸不靠它，由「导出平台上传尺寸」步骤兜底 |
+| `GPT_IMAGE_SIZE` | | `1024x1536` | API 回退的目标比例提示（番茄 3:4→`768x1024`，默认 2:3→`1024x1536`）。官方 gpt-image-2 认任意 16 倍数尺寸（比例≤3:1），但**很多中转代理会忽略 size、按预设返回约 2:3**（已实测）——平台尺寸不靠它，由「导出平台上传尺寸」步骤兜底 |
 | `UPLOAD_SIZE` | | — | 平台固定上传像素（番茄 `600x800`）；设置后由「导出平台上传尺寸」步骤居中裁剪+缩放出上传版（不变形、不依赖出图尺寸） |
 | `BOOK_DIR` | ✅ | — | 输出目录，建议 `./covers/<书名>` |
-| `REF_IMAGE` | | — | 参考图本地路径或 URL；设置后走 `images/edits` 图生图 |
+| `REF_IMAGE` | | — | 参考图本地路径或 URL；内置通路先把图片载入会话，API 回退走 `images/edits` 图生图 |
 
 ---
 
@@ -30,7 +41,7 @@ metadata: {"openclaw":{"requires":{"env":["GPT_IMAGE_API_KEY"],"bins":["curl","j
 
 ### Step 1：收集信息
 
-必填：书名、作者名（笔名）、目标平台、输出目录 `BOOK_DIR`（建议 `./covers/<书名>`，调用前 export）
+必填：书名、作者名（笔名）、目标平台、输出目录 `BOOK_DIR`（建议 `./covers/<书名>`；只有 API 回退的 shell 命令需要 export）
 选填：参考图 `REF_IMAGE`（本地路径或 URL，设置后切换到图生图）、风格偏好、尺寸
 
 > **书名和笔名是封面必需信息**：缺任一必须先用 AskUserQuestion 问用户补全，不得编造或留空。
@@ -42,7 +53,7 @@ metadata: {"openclaw":{"requires":{"env":["GPT_IMAGE_API_KEY"],"bins":["curl","j
 | 番茄小说 | 600×800 | 3:4 | `768x1024` |
 | 其他平台（默认竖版） | 按平台规格 | 2:3 | `1024x1536` |
 
-`export GPT_IMAGE_SIZE` 给目标比例（官方按它出图，很多代理会忽略、返回约 2:3）；平台有固定上传像素再 `export UPLOAD_SIZE`（番茄 `600x800`）。**平台尺寸最终由「导出平台上传尺寸」步骤居中裁剪+缩放保证，不依赖代理认不认 size。** 平台与题材风格见 [references/cover-styles.md](references/cover-styles.md)。
+内置通路把目标比例写进提示词；API 回退再 `export GPT_IMAGE_SIZE`（很多代理会忽略、返回约 2:3）。平台有固定上传像素时设置 `UPLOAD_SIZE`（番茄 `600x800`）。**平台尺寸最终由「导出平台上传尺寸」步骤居中裁剪+缩放保证，不依赖实际出图尺寸。** 平台与题材风格见 [references/cover-styles.md](references/cover-styles.md)。
 
 ### Step 2：题材判定
 
@@ -137,7 +148,45 @@ Professional book cover, high detail digital painting, portrait [平台比例：
 - 光效是指定光源方向 + 颜色（如 `dramatic golden light from above`）
 - 用 `digital painting style` 而非 `photo`，避免真人照片感
 
-### Step 4：调用 API 并保存
+### Step 4：生成并保存
+
+先检查当前会话是否暴露 `$imagegen` / 内置 `image_gen` 工具：可用就走「Codex 内置 ImageGen」；不可用才走「API 回退」。
+
+#### Codex 内置 ImageGen（默认）
+
+1. 用 Step 3 的完整提示词直接调用内置 `image_gen` 工具。不要运行 `curl`，不要索要或检查 `OPENAI_API_KEY` / `GPT_IMAGE_API_KEY`。内置工具不接收 `GPT_IMAGE_MODEL`、`GPT_IMAGE_SIZE`、`response_format` 等 API 参数，目标平台比例和安全区必须写在提示词里。
+2. 有 `REF_IMAGE` 时，将它作为编辑目标或参考图载入会话：本地文件先用图片查看工具载入；URL 先下载到临时文件再载入。明确告诉 `image_gen` 哪张图是编辑目标、哪些内容必须保持不变，不要把任意本地路径直接塞进工具提示词冒充已附图。
+3. 每个构图方案单独调用一次内置工具。读取工具结果返回的生成图片绝对路径，逐张复制到 `BOOK_DIR/封面/封面_vN.png`；保留 `$CODEX_HOME/generated_images/` 下的原文件，不覆盖既有版本。
+4. 把同次调用的完整提示词保存为同名 `.prompt.txt`；使用参考图时另存 `.ref.txt`。复制完成后用 `file` 或平台图片工具确认产物存在且可读。
+
+工具返回图片路径后，用下面的 shell 模板落盘。四个占位值由当前 agent 在同一次 shell 调用里安全赋值，不要求用户 `export`：
+
+```bash
+set -euo pipefail
+BOOK_DIR='<Step 1 的输出目录>'
+SRC='<image_gen 工具返回的生成图片绝对路径>'
+REF_IMAGE='<参考图路径或 URL；没有则留空>'
+PROMPT=$(cat <<'STORY_COVER_PROMPT'
+<Step 3 的完整提示词原文>
+STORY_COVER_PROMPT
+)
+
+mkdir -p "$BOOK_DIR/封面"
+i=1
+while [ -f "$BOOK_DIR/封面/封面_v${i}.png" ]; do i=$((i+1)); done
+OUT="$BOOK_DIR/封面/封面_v${i}.png"
+
+cp "$SRC" "$OUT"
+printf '%s\n' "$PROMPT" > "${OUT%.png}.prompt.txt"
+if [ -n "${REF_IMAGE:-}" ]; then
+  printf '%s\n' "$REF_IMAGE" > "${OUT%.png}.ref.txt"
+fi
+
+file "$OUT"
+ls -lt "$BOOK_DIR/封面/"
+```
+
+#### API 回退
 
 `gpt-image-2` 始终返回 base64，请求体不要带 `response_format`（旧 DALL-E 参数，gpt-image 系列不支持）。`$PROMPT` 为「构建提示词」步骤拼出的完整提示词。
 
@@ -261,7 +310,7 @@ ls -lt "$BOOK_DIR/封面/"
 设了 `UPLOAD_SIZE`（番茄 600×800）就把原图**居中裁剪+缩放**成上传尺寸——不论出图是 2:3 还是 3:4 都裁成平台精确像素，不变形，避免平台再裁切掉书名/笔名。原图保留、另存 `_上传` 版：
 
 ```bash
-SRC="${OUT:-$(ls -t "${BOOK_DIR:-.}"/封面/封面_v*.png 2>/dev/null | grep -v _上传 | head -1)}"  # 复用「调用 API 并保存」步骤的 $OUT；新 shell 里从 BOOK_DIR 找最新原图
+SRC="${OUT:-$(ls -t "${BOOK_DIR:-.}"/封面/封面_v*.png 2>/dev/null | grep -v _上传 | head -1)}"  # 复用「生成并保存」步骤的 $OUT；新 shell 里从 BOOK_DIR 找最新原图
 TARGET="${UPLOAD_SIZE:-}"   # 番茄=600x800；未设则跳过
 if [ -n "$TARGET" ] && [ -f "$SRC" ]; then
   UP="${SRC%.png}_上传.png"; W="${TARGET%x*}"; H="${TARGET#*x}"

--- a/skills/story-cover/SKILL.md
+++ b/skills/story-cover/SKILL.md
@@ -12,16 +12,10 @@ metadata: {"openclaw":{"requires":{"env":["GPT_IMAGE_API_KEY"],"bins":["curl","j
 
 ---
 
-## 执行通路
+## 生成通路
 
-按当前会话能力选择，**Codex 内置通路优先**：
-
-| 通路 | 适用条件 | 鉴权 |
-|:-----|:---------|:-----|
-| Codex 内置 ImageGen（默认） | Codex CLI 交互会话中可调用 `$imagegen` / 内置 `image_gen` 工具 | 计入 Codex 通用用量，**无需** `OPENAI_API_KEY` 或 `GPT_IMAGE_API_KEY` |
-| API 回退 | 当前会话没有内置 `image_gen` 工具，或用户明确要求走 OpenAI / 兼容代理 API | 需要 `GPT_IMAGE_API_KEY` |
-
-只要内置 `image_gen` 工具可用，就直接调用工具，不检查 API Key、不要求用户配置 API Key，也不改走 `curl`。`story-cover` 必须自行完成工具调用和落盘，不要把任务甩回给用户让其另行运行 `$imagegen`。内置工具不可用时才进入 API 回退；不得把“当前没有内置工具”误报成“Codex 订阅不能生图”。
+- **Codex 内置（优先）**：当前 Codex CLI 会话可调用 `$imagegen` / `image_gen` 时，直接生成并落盘；计入 Codex 通用用量，无需 `OPENAI_API_KEY` 或 `GPT_IMAGE_API_KEY`，也不运行 `curl`。`story-cover` 自行调用工具，不让用户另开命令。
+- **API 回退**：仅在会话没有内置工具或用户明确指定 API 时使用，需要 `GPT_IMAGE_API_KEY`。工具缺失不等于 Codex 订阅不支持生图；内置调用失败时先报告错误，不静默切换到可能收费的 API。
 
 ## 输出参数与 API 回退环境变量
 
@@ -41,7 +35,7 @@ metadata: {"openclaw":{"requires":{"env":["GPT_IMAGE_API_KEY"],"bins":["curl","j
 
 ### Step 1：收集信息
 
-必填：书名、作者名（笔名）、目标平台、输出目录 `BOOK_DIR`（建议 `./covers/<书名>`；只有 API 回退的 shell 命令需要 export）
+必填：书名、作者名（笔名）、目标平台、输出目录 `BOOK_DIR`（建议 `./covers/<书名>`；API 回退用环境变量，内置通路直接使用当前任务值）
 选填：参考图 `REF_IMAGE`（本地路径或 URL，设置后切换到图生图）、风格偏好、尺寸
 
 > **书名和笔名是封面必需信息**：缺任一必须先用 AskUserQuestion 问用户补全，不得编造或留空。
@@ -150,41 +144,11 @@ Professional book cover, high detail digital painting, portrait [平台比例：
 
 ### Step 4：生成并保存
 
-先检查当前会话是否暴露 `$imagegen` / 内置 `image_gen` 工具：可用就走「Codex 内置 ImageGen」；不可用才走「API 回退」。
+#### Codex 内置 ImageGen（优先）
 
-#### Codex 内置 ImageGen（默认）
-
-1. 用 Step 3 的完整提示词直接调用内置 `image_gen` 工具。不要运行 `curl`，不要索要或检查 `OPENAI_API_KEY` / `GPT_IMAGE_API_KEY`。内置工具不接收 `GPT_IMAGE_MODEL`、`GPT_IMAGE_SIZE`、`response_format` 等 API 参数，目标平台比例和安全区必须写在提示词里。
-2. 有 `REF_IMAGE` 时，将它作为编辑目标或参考图载入会话：本地文件先用图片查看工具载入；URL 先下载到临时文件再载入。明确告诉 `image_gen` 哪张图是编辑目标、哪些内容必须保持不变，不要把任意本地路径直接塞进工具提示词冒充已附图。
-3. 每个构图方案单独调用一次内置工具。读取工具结果返回的生成图片绝对路径，逐张复制到 `BOOK_DIR/封面/封面_vN.png`；保留 `$CODEX_HOME/generated_images/` 下的原文件，不覆盖既有版本。
-4. 把同次调用的完整提示词保存为同名 `.prompt.txt`；使用参考图时另存 `.ref.txt`。复制完成后用 `file` 或平台图片工具确认产物存在且可读。
-
-工具返回图片路径后，用下面的 shell 模板落盘。四个占位值由当前 agent 在同一次 shell 调用里安全赋值，不要求用户 `export`：
-
-```bash
-set -euo pipefail
-BOOK_DIR='<Step 1 的输出目录>'
-SRC='<image_gen 工具返回的生成图片绝对路径>'
-REF_IMAGE='<参考图路径或 URL；没有则留空>'
-PROMPT=$(cat <<'STORY_COVER_PROMPT'
-<Step 3 的完整提示词原文>
-STORY_COVER_PROMPT
-)
-
-mkdir -p "$BOOK_DIR/封面"
-i=1
-while [ -f "$BOOK_DIR/封面/封面_v${i}.png" ]; do i=$((i+1)); done
-OUT="$BOOK_DIR/封面/封面_v${i}.png"
-
-cp "$SRC" "$OUT"
-printf '%s\n' "$PROMPT" > "${OUT%.png}.prompt.txt"
-if [ -n "${REF_IMAGE:-}" ]; then
-  printf '%s\n' "$REF_IMAGE" > "${OUT%.png}.ref.txt"
-fi
-
-file "$OUT"
-ls -lt "$BOOK_DIR/封面/"
-```
+1. 用 Step 3 的完整提示词调用 `image_gen`。比例和安全区写进提示词，不传 `GPT_IMAGE_MODEL`、`GPT_IMAGE_SIZE`、`response_format` 等 API 参数。
+2. 有 `REF_IMAGE` 时，本地文件先用图片查看工具载入会话；URL 先下载再载入。说明它是编辑目标还是风格参考，并列出必须保持的内容。
+3. 每个构图方案单独调用一次。先创建 `BOOK_DIR/封面/`，再把工具返回的图片复制为 `封面_vN.png`，`N` 自增且不覆盖旧版；保留 `$CODEX_HOME/generated_images/` 原文件，同时保存同名 `.prompt.txt`，有参考图再保存 `.ref.txt`。确认图片可读，并把原图绝对路径交给 Step 5。
 
 #### API 回退
 
@@ -307,11 +271,12 @@ ls -lt "$BOOK_DIR/封面/"
 
 ### Step 5：导出平台上传尺寸（平台有固定像素时）
 
-设了 `UPLOAD_SIZE`（番茄 600×800）就把原图**居中裁剪+缩放**成上传尺寸——不论出图是 2:3 还是 3:4 都裁成平台精确像素，不变形，避免平台再裁切掉书名/笔名。原图保留、另存 `_上传` 版：
+平台有固定上传像素（番茄 600×800）时，把原图**居中裁剪+缩放**成上传尺寸——不论出图是 2:3 还是 3:4 都裁成平台精确像素，不变形，避免平台再裁切掉书名/笔名。原图保留、另存 `_上传` 版；`SRC` 和 `TARGET` 直接使用前序步骤的任务值，不依赖跨 shell 的临时变量：
 
 ```bash
-SRC="${OUT:-$(ls -t "${BOOK_DIR:-.}"/封面/封面_v*.png 2>/dev/null | grep -v _上传 | head -1)}"  # 复用「生成并保存」步骤的 $OUT；新 shell 里从 BOOK_DIR 找最新原图
-TARGET="${UPLOAD_SIZE:-}"   # 番茄=600x800；未设则跳过
+SRC='<Step 4 生成的原图绝对路径>'
+TARGET='<Step 1 确定的平台上传尺寸；无则留空>'
+[ -f "$SRC" ] || { echo "封面原图不存在: $SRC" >&2; exit 1; }
 if [ -n "$TARGET" ] && [ -f "$SRC" ]; then
   UP="${SRC%.png}_上传.png"; W="${TARGET%x*}"; H="${TARGET#*x}"
   if command -v magick >/dev/null 2>&1; then M=magick


### PR DESCRIPTION
## 目标

让有 Codex 订阅额度的 Codex CLI 用户直接使用内置 ImageGen 生成小说封面，不再被 `story-cover` 强制要求配置 API Key；其他 CLI / 兼容代理继续使用现有 API 回退。

官方依据：[Codex Image generation](https://learn.chatgpt.com/docs/image-generation) 说明交互会话可用 `$imagegen`，内置生成使用 `gpt-image-2` 并计入 Codex 通用用量；大批量才建议改走 `OPENAI_API_KEY` 的 API 路径。

## 改动

- `story-cover` 新增“Codex 内置 ImageGen 优先 / API 回退”分流
- 内置通路不检查、不索要 `OPENAI_API_KEY` / `GPT_IMAGE_API_KEY`
- 支持参考图先载入会话再走内置编辑
- 将工具返回的图片复制为 `BOOK_DIR/封面/封面_vN.png`，保留默认生成文件并保存 `.prompt.txt` / `.ref.txt`
- 保留现有文生图、图生图 API 调用及平台尺寸导出流程
- 新增 CI 契约测试，防止后续退回到强制 API Key
- 同步 README 中英文能力说明

## 实跑

在当前 Codex CLI 会话中确认 `OPENAI_API_KEY` 与 `GPT_IMAGE_API_KEY` 均未设置，直接调用内置 ImageGen：

- 成功生成《长夜渡星河》仙侠封面
- 输出 PNG：1086×1448（3:4）
- 中文书名“长夜渡星河”和署名“青灯客 著”均正确渲染
- 工具返回 `$CODEX_HOME/generated_images/...png` 绝对路径，随后复制、版本化和提示词落盘流程验证通过

## 验证

- `bash scripts/test-story-cover-codex-imagegen.sh`
- `bash scripts/static-check.sh`
- `python3 scripts/skill-numbering.py check`
- `bash scripts/check-doc-budget.sh`
- `bash scripts/check-shared-files.sh`
- `bash scripts/check-story-setup-deployment.sh`
- `bash scripts/check-codex-adapter.sh`
- `bash scripts/check-openclaw-skills.sh`
- `bash scripts/test-codex-cli-e2e.sh`（Codex CLI 0.147.0，13 skills 全部发现）
- CONTRIBUTING.md 所列本地完整 CI 守卫全部通过
