### PR TITLE
fix(story-setup): 部署清单不再把 agent-references 复制进自身

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Windows 上偶尔会看到 `ENOENT ... mkdir` 报错但末尾仍显示 `Done!`�
 
 **Web AI / 通用 Agent 用户：** 平台能读取 GitHub 仓库或项目文件时，可让 Agent 读取 `skills/*/SKILL.md` 与对应 `references/`；需要本地副本时，`story-setup` 可选 `target_cli=generic`，只写通用 `AGENTS.md` 和 `skills/`。无本项目 hooks/custom agents 的环境按 skill 内软约束或 solo/direct fallback 执行。
 
+**OpenClaw / Reasonix / 通用路径需手动清一次目录残留：** 这三条路径的 skill 副本在项目 `skills/` 里，重跑 `/story-setup` 执行的就是项目里那份旧文件，自动清理到不了。重跑前先删掉 `skills/story-setup/references/agent-references/agent-references/`（可能嵌了多层）和 `skills/story-setup/skills/`，再重新安装本项目并重跑 `/story-setup`。
+
 </details>
 
 升级后如果项目里已经跑过 `/story-setup`，建议在项目根重跑一次 `/story-setup`，同步 hooks / agents / references。每版变更见 [CHANGELOG.md](CHANGELOG.md) 与 [Releases](https://github.com/worldwonderer/oh-story-claudecode/releases)。

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Windows 上偶尔会看到 `ENOENT ... mkdir` 报错但末尾仍显示 `Done!`�
 
 **Web AI / 通用 Agent 用户：** 平台能读取 GitHub 仓库或项目文件时，可让 Agent 读取 `skills/*/SKILL.md` 与对应 `references/`；需要本地副本时，`story-setup` 可选 `target_cli=generic`，只写通用 `AGENTS.md` 和 `skills/`。无本项目 hooks/custom agents 的环境按 skill 内软约束或 solo/direct fallback 执行。
 
-**OpenClaw / Reasonix / 通用路径需手动清一次目录残留：** 这三条路径的 skill 副本在项目 `skills/` 里，重跑 `/story-setup` 执行的就是项目里那份旧文件，自动清理到不了。重跑前先删掉 `skills/story-setup/references/agent-references/agent-references/`（可能嵌了多层）和 `skills/story-setup/skills/`，再重新安装本项目并重跑 `/story-setup`。
+**OpenClaw / Reasonix / 通用路径需手动清一次目录残留：** 这三条路径的 skill 副本在项目 `skills/` 里，重跑 `/story-setup` 执行的就是项目里那份，自动清理到不了。手动删掉 `skills/story-setup/references/agent-references/agent-references/`（可能嵌了多层）与 `skills/story-setup/skills/`。要让项目里的 skill 文本本身更新，还需要重新安装本项目后，用新包覆盖项目 `skills/` 下这 13 个目录。
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Windows 上偶尔会看到 `ENOENT ... mkdir` 报错但末尾仍显示 `Done!`�
 
 **Web AI / 通用 Agent 用户：** 平台能读取 GitHub 仓库或项目文件时，可让 Agent 读取 `skills/*/SKILL.md` 与对应 `references/`；需要本地副本时，`story-setup` 可选 `target_cli=generic`，只写通用 `AGENTS.md` 和 `skills/`。无本项目 hooks/custom agents 的环境按 skill 内软约束或 solo/direct fallback 执行。
 
-**OpenClaw / Reasonix / 通用路径需手动清一次目录残留：** 这三条路径的 skill 副本在项目 `skills/` 里，重跑 `/story-setup` 执行的就是项目里那份，自动清理到不了。手动删掉 `skills/story-setup/references/agent-references/agent-references/`（可能嵌了多层）与 `skills/story-setup/skills/`。要让项目里的 skill 文本本身更新，还需要重新安装本项目后，用新包覆盖项目 `skills/` 下这 13 个目录。
+**OpenClaw / Reasonix / 通用路径的目录残留要手动清：** 这三条路径的 skill 副本在项目 `skills/` 里，重跑 `/story-setup` 执行的就是项目里那份，自动清理到不了。项目里若出现 `skills/story-setup/references/agent-references/agent-references/`（可能嵌了多层）或 `skills/story-setup/skills/`，手动删掉。要让项目里的 skill 文本本身更新，还需要重新安装本项目后，用新包覆盖项目 `skills/` 下这 13 个目录。
 
 </details>
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -120,7 +120,7 @@ After `$story-setup` deploys into a writing project, it creates `.codex/agents/*
 
 **Generic Web AI / agent users:** If your platform can read a GitHub repo or project files, have the agent read `skills/*/SKILL.md` plus the relevant `references/`. For local project copies, run `story-setup` with `target_cli=generic`; it only writes a generic `AGENTS.md` and `skills/`. Without this project's hooks/custom agents, checks run as skill-level soft constraints or solo/direct fallbacks.
 
-**OpenClaw / Reasonix / generic paths need a one-time manual cleanup:** these three keep their skill copy inside the project's `skills/`, so re-running `/story-setup` executes that project-local copy and the automatic cleanup never reaches them. Delete `skills/story-setup/references/agent-references/agent-references/` (it may be nested several levels deep) and `skills/story-setup/skills/` by hand. To update the skill text itself, reinstall this project and overwrite the 13 skill directories under the project's `skills/` from the new package.
+**OpenClaw / Reasonix / generic paths need manual cleanup of nested directories:** these three keep their skill copy inside the project's `skills/`, so re-running `/story-setup` executes that project-local copy and the automatic cleanup never reaches them. If the project contains `skills/story-setup/references/agent-references/agent-references/` (possibly nested several levels deep) or `skills/story-setup/skills/`, delete them by hand. To update the skill text itself, reinstall this project and overwrite the 13 skill directories under the project's `skills/` from the new package.
 
 </details>
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,4 +1,4 @@
-<!-- Last synced with README.md: 2026-08-14 -->
+<!-- Last synced with README.md: 2026-08-21 -->
 
 **English** | [中文](README.md)
 
@@ -119,6 +119,8 @@ After `$story-setup` deploys into a writing project, it creates `.codex/agents/*
 **Reasonix users:** Current support is Skills + a native plugin manifest. Reasonix natively scans project skill roots (`.agents/skills` etc., a symlink to `skills/`) and discovers all 13 skills — verify with `reasonix doctor capabilities`; you can also `reasonix plugin install` via the root `reasonix-plugin.json`. When `story-setup` targets `target_cli=reasonix`, it copies the skills into project `skills/` and writes a Reasonix `AGENTS.md`; hooks/custom agents are intentionally deferred, so skills needing specialist agents fall back to solo/direct. If Windows symlinks are disabled, use the native plugin instead.
 
 **Generic Web AI / agent users:** If your platform can read a GitHub repo or project files, have the agent read `skills/*/SKILL.md` plus the relevant `references/`. For local project copies, run `story-setup` with `target_cli=generic`; it only writes a generic `AGENTS.md` and `skills/`. Without this project's hooks/custom agents, checks run as skill-level soft constraints or solo/direct fallbacks.
+
+**OpenClaw / Reasonix / generic paths need a one-time manual cleanup:** these three keep their skill copy inside the project's `skills/`, so re-running `/story-setup` executes that older project-local copy and the automatic cleanup never reaches them. Before re-running, delete `skills/story-setup/references/agent-references/agent-references/` (it may be nested several levels deep) and `skills/story-setup/skills/`, then reinstall this project and run `/story-setup` again.
 
 </details>
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -120,7 +120,7 @@ After `$story-setup` deploys into a writing project, it creates `.codex/agents/*
 
 **Generic Web AI / agent users:** If your platform can read a GitHub repo or project files, have the agent read `skills/*/SKILL.md` plus the relevant `references/`. For local project copies, run `story-setup` with `target_cli=generic`; it only writes a generic `AGENTS.md` and `skills/`. Without this project's hooks/custom agents, checks run as skill-level soft constraints or solo/direct fallbacks.
 
-**OpenClaw / Reasonix / generic paths need a one-time manual cleanup:** these three keep their skill copy inside the project's `skills/`, so re-running `/story-setup` executes that older project-local copy and the automatic cleanup never reaches them. Before re-running, delete `skills/story-setup/references/agent-references/agent-references/` (it may be nested several levels deep) and `skills/story-setup/skills/`, then reinstall this project and run `/story-setup` again.
+**OpenClaw / Reasonix / generic paths need a one-time manual cleanup:** these three keep their skill copy inside the project's `skills/`, so re-running `/story-setup` executes that project-local copy and the automatic cleanup never reaches them. Delete `skills/story-setup/references/agent-references/agent-references/` (it may be nested several levels deep) and `skills/story-setup/skills/` by hand. To update the skill text itself, reinstall this project and overwrite the 13 skill directories under the project's `skills/` from the new package.
 
 </details>
 

--- a/scripts/check-story-setup-deployment.sh
+++ b/scripts/check-story-setup-deployment.sh
@@ -223,6 +223,9 @@ import sys
 path = sys.argv[1]
 lines = open(path, encoding='utf-8').read().splitlines()
 bad = []
+in_manifest = False
+# 「复制 A 到 B」里两个路径之间只隔几个字；隔得远的是叙述句，不是复制指令。
+MAX_GAP = 16
 
 
 def norm(cell):
@@ -231,23 +234,31 @@ def norm(cell):
 
 for idx, line in enumerate(lines, 1):
     stripped = line.strip()
-    if stripped.startswith('|') and stripped.count('|') >= 6 and '---' not in stripped:
+    is_row = stripped.startswith('|') and stripped.endswith('|')
+    if is_row and 'Source path' in stripped and 'Target path' in stripped:
+        in_manifest = True
+        continue
+    if not is_row:
+        in_manifest = False
+    elif in_manifest:
+        if set(stripped) <= set('|-: '):
+            continue
         cells = [c.strip() for c in stripped.strip('|').split('|')]
-        source, target = cells[0], cells[1]
         # 源写成 `repository ...` 时显式声明了它在仓库/skill 包一侧，与项目根一侧的
         # 目标不同名，自然不会相等；裸写成同一个字符串的才是复制进自身。
-        if norm(source) == norm(target):
-            bad.append((idx, f'manifest row copies {source} onto itself'))
+        if len(cells) >= 2 and norm(cells[0]) == norm(cells[1]):
+            bad.append((idx, f'manifest row copies {cells[0]} onto itself'))
         continue
     if '复制' not in stripped and '拷贝' not in stripped:
         continue
-    # 只看紧邻的一对反引号路径：中间夹着「到」而两侧同路径，就是复制进自身。
-    # 两次出现之间还夹着别的路径时不算——那是「从 A 复制到 B，A 是唯一来源」这类正常句子。
-    spans = [(m.start(), m.group(1)) for m in re.finditer(r'`([^`]+)`', stripped)]
-    for (start, left), (end, right) in zip(spans, spans[1:]):
+    # 只看紧邻的一对反引号路径：中间只隔一个「到」而两侧同路径，就是复制进自身。
+    # 两次出现之间夹着别的路径或大段叙述时不算——那是「从 A 复制到 B，A 是唯一来源」这类正常句子。
+    spans = [(m.start(), m.end(), m.group(1)) for m in re.finditer(r'`([^`]+)`', stripped)]
+    for (_, left_end, left), (right_start, _, right) in zip(spans, spans[1:]):
+        gap = stripped[left_end:right_start]
         if '/' not in left or norm(left) != norm(right):
             continue
-        if '到' in stripped[start:end]:
+        if '到' in gap and len(gap) <= MAX_GAP:
             bad.append((idx, f'copy instruction names `{left}` as both source and target'))
 
 for idx, msg in bad:
@@ -263,6 +274,16 @@ cat > "$TMP_DIR/self-copy-fixtures.md" <<'FIXTURE'
 - 复制 `a/b/` 到 `a/b`。
 - 将 `skills/story-setup/references/agent-references/` 下所有 `.md` 复制到项目内 `.claude/skills/story-setup/references/agent-references/`。
 - `a/b/` 与 `a/b/` 都要存在；提到复制但两者之间没有「到」。
+- 拆文结果被复制进 `对标/`，用户看到的就是对标内容和自己设定一样；只有外部作品才进 `对标/`。
+- 复制 `p/q/` 到 `r/s/`，`p/q/` 保留。
+- 复制章节时 `第N章` 到 `第N章` 的编号不变。
+
+| 角色 A | 角色 B | 关系类型 | 情感倾向 | 当前状态 | 起始章节 |
+|--------|--------|---------|---------|---------|---------|
+| {名} | {名} | {类型} | {倾向} | {描述} | 第{N}章 |
+
+| Source path | Target path | Owner class | Merge mode | Validation check |
+|-------------|-------------|-------------|------------|------------------|
 | `a/b/` | `a/b` | story-setup managed | replace | resolves | 条件 |
 | repository `a/b/` | `a/b/` | story-setup managed | replace | resolves | 条件 |
 | `a/b/` | `.codex/a/b/` | story-setup managed | replace | resolves | 条件 |
@@ -271,8 +292,8 @@ FIXTURE
 # 探测器有发现时退出码为 1；`|| true` 必须在管道内，否则 pipefail 会让赋值直接中止脚本，
 # 连下面的 fail 消息都来不及打。
 fixture_hits="$({ python3 "$TMP_DIR/detect-self-copy.py" "$TMP_DIR/self-copy-fixtures.md" 2>&1 >/dev/null || true; } | sed 's/.*fixtures\.md:\([0-9]*\):.*/\1/' | tr '\n' ',')"
-[ "$fixture_hits" = "2,3,5,8," ] \
-  || fail "self-copy detector fixtures regressed: expected lines 2,3,5,8 got [$fixture_hits]"
+[ "$fixture_hits" = "2,3,5,18," ] \
+  || fail "self-copy detector fixtures regressed: expected lines 2,3,5,18 got [$fixture_hits]"
 
 python3 "$TMP_DIR/detect-self-copy.py" "$SKILL_FILE" \
   || fail "story-setup declares a copy whose source and target are the same path"

--- a/scripts/check-story-setup-deployment.sh
+++ b/scripts/check-story-setup-deployment.sh
@@ -12,6 +12,7 @@ AGENT_REFS_DIR="$SKILL_DIR/references/agent-references"
 SKILL_FILE="$SKILL_DIR/SKILL.md"
 SETTINGS_FILE="$SKILL_DIR/references/templates/settings-hooks.json"
 CLAUDE_MERGE="$SKILL_DIR/scripts/merge-claude-settings.py"
+COPY_PATH_SAFETY="$SKILL_DIR/scripts/copy-path-safety.py"
 TMP_DIR="$(mktemp -d)"
 CURRENT_AGENTS_VERSION="$(node -e 'process.stdout.write(String(require(process.argv[1]).agents_version))' "$SCRIPT_DIR/current-contract.json")"
 PREVIOUS_AGENTS_VERSION=$((CURRENT_AGENTS_VERSION - 1))
@@ -213,8 +214,82 @@ assert_grep 'target_cli' "$SKILL_FILE" "sentinel target_cli must be documented"
 
 # 部署清单的 Source 相对 skill 包、Target 相对项目根，两个基准目录在 skills-only 端会重合。
 # 任何一行写成裸相同路径，执行方就会把目录复制进自身。
-assert_grep '相同即 no-op，禁止复制' "$SKILL_FILE" "deployment manifest must forbid copying when source and target resolve to the same directory"
+assert_grep 'copy-path-safety\.py' "$SKILL_FILE" "deployment must invoke the recursive-copy path safety helper"
+assert_grep 'Path\.resolve.*realpath' "$SKILL_FILE" "deployment must canonicalize copy paths through symlinks"
+assert_grep 'samefile' "$SKILL_FILE" "deployment must compare existing source/target filesystem identity"
+assert_grep 'target-descendant|目标位于源目录内' "$SKILL_FILE" "deployment must reject recursive-copy targets inside their source"
 assert_grep '清理自嵌套残留' "$SKILL_FILE" "story-setup must clean self-nested copies before deploying"
+assert_file "$COPY_PATH_SAFETY"
+
+# 执行真实 helper 验证 symlink alias、同目录、子目录和安全 sibling；不能只锁 SKILL.md 措辞。
+path_fixture="$TMP_DIR/copy-path-safety"
+mkdir -p "$path_fixture/project/skills/story-setup/references/agent-references" \
+  "$path_fixture/project/.agents" "$path_fixture/source" "$path_fixture/sibling"
+
+python3 - "$COPY_PATH_SAFETY" "$path_fixture" <<'PY' || fail "copy path safety helper behavior regressed"
+import json
+import importlib.util
+import subprocess
+import sys
+from unittest import mock
+from pathlib import Path
+
+helper = sys.argv[1]
+root = Path(sys.argv[2])
+
+
+def run(source, target):
+    proc = subprocess.run(
+        [sys.executable, helper, str(source), str(target)],
+        text=True,
+        capture_output=True,
+    )
+    payload = json.loads(proc.stdout)
+    return proc.returncode, payload
+
+
+project = root / "project"
+alias = project / ".agents/skills/story-setup/references/agent-references"
+direct = project / "skills/story-setup/references/agent-references"
+try:
+    (project / ".agents/skills").symlink_to("../skills", target_is_directory=True)
+except OSError as exc:
+    # Windows runners without symlink privileges still exercise the other real helper paths.
+    print("SKIP: symlink alias fixture unavailable: {}".format(exc))
+else:
+    code, payload = run(alias, direct)
+    assert code == 0
+    assert payload["status"] == "same"
+    assert payload["copy_allowed"] is False
+    assert payload["source_realpath"] == payload["target_realpath"]
+
+source = root / "source"
+code, payload = run(source, source / "nested/target")
+assert code != 0
+assert payload["status"] == "unsafe_target_within_source"
+assert payload["copy_allowed"] is False
+assert not (source / "nested").exists()
+
+code, payload = run(source, root / "sibling/target")
+assert code == 0
+assert payload["status"] == "safe"
+assert payload["copy_allowed"] is True
+assert not (root / "sibling/target").exists()
+
+code, payload = run(root / "missing", root / "sibling/target")
+assert code != 0
+assert payload["status"] == "source_missing"
+assert payload["copy_allowed"] is False
+
+spec = importlib.util.spec_from_file_location("copy_path_safety", helper)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+with mock.patch.object(module.os.path, "samefile", side_effect=OSError("identity unavailable")):
+    payload = module.classify_copy(source, root / "sibling")
+assert payload["status"] == "filesystem_identity_error"
+assert payload["copy_allowed"] is False
+assert module.status_exit_code(payload["status"]) != 0
+PY
 # 探测器只写一份，先跑正负 fixture 自检，再扫真实 SKILL.md。
 cat > "$TMP_DIR/detect-self-copy.py" <<'PY'
 import re

--- a/scripts/check-story-setup-deployment.sh
+++ b/scripts/check-story-setup-deployment.sh
@@ -215,7 +215,8 @@ assert_grep 'target_cli' "$SKILL_FILE" "sentinel target_cli must be documented"
 # 任何一行写成裸相同路径，执行方就会把目录复制进自身。
 assert_grep '相同即 no-op，禁止复制' "$SKILL_FILE" "deployment manifest must forbid copying when source and target resolve to the same directory"
 assert_grep '清理自嵌套残留' "$SKILL_FILE" "story-setup must clean self-nested copies before deploying"
-python3 - "$SKILL_FILE" <<'PY' || fail "story-setup declares a copy whose source and target are the same path"
+# 探测器只写一份，先跑正负 fixture 自检，再扫真实 SKILL.md。
+cat > "$TMP_DIR/detect-self-copy.py" <<'PY'
 import re
 import sys
 
@@ -223,27 +224,58 @@ path = sys.argv[1]
 lines = open(path, encoding='utf-8').read().splitlines()
 bad = []
 
+
+def norm(cell):
+    return cell.strip().strip('`').rstrip('/')
+
+
 for idx, line in enumerate(lines, 1):
     stripped = line.strip()
     if stripped.startswith('|') and stripped.count('|') >= 6 and '---' not in stripped:
         cells = [c.strip() for c in stripped.strip('|').split('|')]
         source, target = cells[0], cells[1]
-        # `repository` 前缀显式声明源在仓库/skill 包一侧，不算裸同路径。
-        if source.startswith('repository '):
-            continue
-        if source.startswith('`') and source == target:
+        # 源写成 `repository ...` 时显式声明了它在仓库/skill 包一侧，与项目根一侧的
+        # 目标不同名，自然不会相等；裸写成同一个字符串的才是复制进自身。
+        if norm(source) == norm(target):
             bad.append((idx, f'manifest row copies {source} onto itself'))
         continue
-    if '复制' in stripped:
-        tokens = re.findall(r'`([^`]+)`', stripped)
-        dupes = {t for t in tokens if tokens.count(t) > 1 and '/' in t}
-        for t in sorted(dupes):
-            bad.append((idx, f'copy instruction names `{t}` as both source and target'))
+    if '复制' not in stripped and '拷贝' not in stripped:
+        continue
+    # 只看紧邻的一对反引号路径：中间夹着「到」而两侧同路径，就是复制进自身。
+    # 两次出现之间还夹着别的路径时不算——那是「从 A 复制到 B，A 是唯一来源」这类正常句子。
+    spans = [(m.start(), m.group(1)) for m in re.finditer(r'`([^`]+)`', stripped)]
+    for (start, left), (end, right) in zip(spans, spans[1:]):
+        if '/' not in left or norm(left) != norm(right):
+            continue
+        if '到' in stripped[start:end]:
+            bad.append((idx, f'copy instruction names `{left}` as both source and target'))
 
 for idx, msg in bad:
     print(f'{path}:{idx}: {msg}', file=sys.stderr)
 sys.exit(1 if bad else 0)
 PY
+
+cat > "$TMP_DIR/self-copy-fixtures.md" <<'FIXTURE'
+- 将 `references/opencode/agents/` 下所有文件复制到 `.opencode/agents/`；`references/opencode/agents/` 是唯一来源。
+- 复制 `a/b/` 到 `a/b/`。
+- 将 `a/b/` 同步复制到 `a/b/`。
+- 复制 `x/y/` 到 `.codex/x/y/`。
+- 复制 `a/b/` 到 `a/b`。
+- 将 `skills/story-setup/references/agent-references/` 下所有 `.md` 复制到项目内 `.claude/skills/story-setup/references/agent-references/`。
+- `a/b/` 与 `a/b/` 都要存在；提到复制但两者之间没有「到」。
+| `a/b/` | `a/b` | story-setup managed | replace | resolves | 条件 |
+| repository `a/b/` | `a/b/` | story-setup managed | replace | resolves | 条件 |
+| `a/b/` | `.codex/a/b/` | story-setup managed | replace | resolves | 条件 |
+FIXTURE
+
+# 探测器有发现时退出码为 1；`|| true` 必须在管道内，否则 pipefail 会让赋值直接中止脚本，
+# 连下面的 fail 消息都来不及打。
+fixture_hits="$({ python3 "$TMP_DIR/detect-self-copy.py" "$TMP_DIR/self-copy-fixtures.md" 2>&1 >/dev/null || true; } | sed 's/.*fixtures\.md:\([0-9]*\):.*/\1/' | tr '\n' ',')"
+[ "$fixture_hits" = "2,3,5,8," ] \
+  || fail "self-copy detector fixtures regressed: expected lines 2,3,5,8 got [$fixture_hits]"
+
+python3 "$TMP_DIR/detect-self-copy.py" "$SKILL_FILE" \
+  || fail "story-setup declares a copy whose source and target are the same path"
 
 # Claude Code 的 Bash 正文写入必须进入同一 pre-guard；只注册 Write/Edit 会让 cat>/tee/cp 绕过。
 python3 - "$SKILL_DIR/references/templates/settings-hooks.json" <<'PY' || fail "Claude Bash prose pre-guard is not registered"

--- a/scripts/check-story-setup-deployment.sh
+++ b/scripts/check-story-setup-deployment.sh
@@ -211,6 +211,40 @@ assert_grep 'references_dir' "$SKILL_FILE" "sentinel references_dir must be docu
 assert_grep 'resolver_strategy' "$SKILL_FILE" "sentinel resolver_strategy must be documented"
 assert_grep 'target_cli' "$SKILL_FILE" "sentinel target_cli must be documented"
 
+# 部署清单的 Source 相对 skill 包、Target 相对项目根，两个基准目录在 skills-only 端会重合。
+# 任何一行写成裸相同路径，执行方就会把目录复制进自身。
+assert_grep '相同即 no-op，禁止复制' "$SKILL_FILE" "deployment manifest must forbid copying when source and target resolve to the same directory"
+assert_grep '清理自嵌套残留' "$SKILL_FILE" "story-setup must clean self-nested copies before deploying"
+python3 - "$SKILL_FILE" <<'PY' || fail "story-setup declares a copy whose source and target are the same path"
+import re
+import sys
+
+path = sys.argv[1]
+lines = open(path, encoding='utf-8').read().splitlines()
+bad = []
+
+for idx, line in enumerate(lines, 1):
+    stripped = line.strip()
+    if stripped.startswith('|') and stripped.count('|') >= 6 and '---' not in stripped:
+        cells = [c.strip() for c in stripped.strip('|').split('|')]
+        source, target = cells[0], cells[1]
+        # `repository` 前缀显式声明源在仓库/skill 包一侧，不算裸同路径。
+        if source.startswith('repository '):
+            continue
+        if source.startswith('`') and source == target:
+            bad.append((idx, f'manifest row copies {source} onto itself'))
+        continue
+    if '复制' in stripped:
+        tokens = re.findall(r'`([^`]+)`', stripped)
+        dupes = {t for t in tokens if tokens.count(t) > 1 and '/' in t}
+        for t in sorted(dupes):
+            bad.append((idx, f'copy instruction names `{t}` as both source and target'))
+
+for idx, msg in bad:
+    print(f'{path}:{idx}: {msg}', file=sys.stderr)
+sys.exit(1 if bad else 0)
+PY
+
 # Claude Code 的 Bash 正文写入必须进入同一 pre-guard；只注册 Write/Edit 会让 cat>/tee/cp 绕过。
 python3 - "$SKILL_DIR/references/templates/settings-hooks.json" <<'PY' || fail "Claude Bash prose pre-guard is not registered"
 import json, sys

--- a/skills/story-setup/SKILL.md
+++ b/skills/story-setup/SKILL.md
@@ -72,7 +72,7 @@ metadata: {"openclaw":{"source":"https://github.com/worldwonderer/oh-story-claud
 
 **两列基准目录不同**：`Source path` 相对正在执行的这份 skill 包，`Target path` 相对用户项目根。执行每一行（以及下面各端部署算法里的每个复制步骤）之前，先把两侧各自解析成绝对路径，**相同即 no-op，禁止复制**。OpenClaw / Reasonix / generic 的项目副本是整份 skill 拷贝，重跑时执行的就是项目里那份，两侧会落到同一个目录；照字面复制会把目录嵌进自身，重复几次即撑满磁盘。
 
-**部署前清理自嵌套残留**：删除项目里把目录嵌进自身的产物——各端 references 根下的 `agent-references/agent-references/`（可能有多层）与 `skills/story-setup/skills/`，删完再部署，并在安装报告里列出删掉的路径。
+**部署前清理自嵌套残留**：`{.claude,.codex,.zcode}/skills/story-setup/references/agent-references/` 与项目根 `skills/story-setup/references/agent-references/` 里若多出 `agent-references/` 层（可能嵌了多层），以及 `skills/story-setup/skills/`，整段删掉再部署，并在安装报告里列出删掉的路径。
 
 ### Step 1：部署清单（机械可检查）
 

--- a/skills/story-setup/SKILL.md
+++ b/skills/story-setup/SKILL.md
@@ -14,7 +14,7 @@ metadata: {"openclaw":{"source":"https://github.com/worldwonderer/oh-story-claud
 
 ## Phase 1：检测项目状态
 
-**先自检参考目录**：以正在执行的本 `SKILL.md` 所在目录为准，列出与它同级的 `references/` 下的子目录，核对下面 8 个名字是否都在**且都非空**——`agent-references`、`templates`、`opencode`、`codex`、`zcode`、`openclaw`、`reasonix`、`generic`；同级 `scripts/merge-claude-settings.py` 与 `scripts/merge-codex-hooks.py` 也必须存在（Claude/Codex hooks 合并算法依赖它们）。有缺即 skill 包没装全，**立即停止，不写任何部署文件**，报告里区分「缺目录」和「目录为空」，并给修复指令：「story-setup 参考资料包不完整，缺 {目录名}。按你的安装方式重装 oh-story-claudecode（命令行装的重跑 `npx skills add worldwonderer/oh-story-claudecode -y -g`，marketplace / Plugin Management 装的在面板里重装），再执行 /story-setup。」
+**先自检参考目录**：以正在执行的本 `SKILL.md` 所在目录为准，列出与它同级的 `references/` 下的子目录，核对下面 8 个名字是否都在**且都非空**——`agent-references`、`templates`、`opencode`、`codex`、`zcode`、`openclaw`、`reasonix`、`generic`；同级 `scripts/merge-claude-settings.py`、`scripts/merge-codex-hooks.py` 与 `scripts/copy-path-safety.py` 也必须存在（Claude/Codex hooks 合并和递归复制安全检查依赖它们）。有缺即 skill 包没装全，**立即停止，不写任何部署文件**，报告里区分「缺目录」「目录为空」和「缺脚本」，并给修复指令：「story-setup 参考资料包不完整，缺 {路径}。按你的安装方式重装 oh-story-claudecode（命令行装的重跑 `npx skills add worldwonderer/oh-story-claudecode -y -g`，marketplace / Plugin Management 装的在面板里重装），再执行 /story-setup。」
 
 > 判据是「有没有 `SKILL.md`」：只看正在执行的 `SKILL.md` 同级的 `references/`。项目内 `.claude/skills/story-setup/`、`.codex/skills/story-setup/` 和 OpenCode 的 `skills/story-setup/` 只有 `references/agent-references/`、不含 `SKILL.md`，不会是执行目录，也不要拿它们核对。ZCode / OpenClaw / Reasonix / generic 的项目副本是整份 skill 拷贝、自带 `SKILL.md`，8 个子目录本就齐全，照常核对即可。
 
@@ -70,7 +70,7 @@ metadata: {"openclaw":{"source":"https://github.com/worldwonderer/oh-story-claud
 
 整个 Phase 2 幂等：目录复制、文件写入和下表各合并算法重复执行结果一致。因环境原因（工具不可用、权限被拒、网络失败）中途失败时，直接从头重跑本 Phase，不需要先清理半成品；`create only if absent` 的用户状态文件（见下表 Owner class）不会被二次覆盖。
 
-**两列基准目录不同**：`Source path` 相对正在执行的这份 skill 包，`Target path` 相对用户项目根。执行每一行（以及下面各端部署算法里的每个复制步骤）之前，先把两侧各自解析成绝对路径，**相同即 no-op，禁止复制**。OpenClaw / Reasonix / generic 的项目副本是整份 skill 拷贝，重跑时执行的就是项目里那份，两侧会落到同一个目录；照字面复制会把目录嵌进自身，重复几次即撑满磁盘。
+**两列基准目录不同**：`Source path` 相对正在执行的这份 skill 包，`Target path` 相对用户项目根。执行每一行（以及下面各端部署算法里的每个递归复制步骤）之前，先把通配符具体化为单个源/目标，再用本 `SKILL.md` 同级的 `scripts/copy-path-safety.py` 检查。该脚本按 `Path.resolve` / `realpath` 语义跟随已有 symlink，并在两侧都存在时用 `samefile` 核对文件系统对象；**只转绝对路径或比较字符串不算检查完成**。读取其 JSON：`status: same` 时 no-op，禁止复制；仅 `copy_allowed: true` 时可以复制；`source_missing`、`unsafe_target_within_source` 或 `filesystem_identity_error` 必须停止该步骤并报告。无法运行脚本时只能用当前环境的文件系统 API 做完全相同的 canonical realpath、same-object 与 target-descendant 检查；无法确认就停止，不得尝试复制。OpenClaw / Reasonix / generic 的项目副本是整份 skill 拷贝，重跑时执行的就是项目里那份；Reasonix / Codex 还可能经 `.agents/skills → ../skills` symlink 加载，路径文本不同也可能指向同一目录，照字面复制会把目录嵌进自身并撑满磁盘。
 
 **部署前清理自嵌套残留**：`{.claude,.codex,.zcode}/skills/story-setup/references/agent-references/` 与项目根 `skills/story-setup/references/agent-references/` 里若多出 `agent-references/` 层（可能嵌了多层），以及 `skills/story-setup/skills/`，整段删掉再部署，并在安装报告里列出删掉的路径。
 
@@ -85,6 +85,7 @@ metadata: {"openclaw":{"source":"https://github.com/worldwonderer/oh-story-claud
 | `skills/story-setup/references/agent-references/*.md` | `.claude/skills/story-setup/references/agent-references/*.md` | story-setup managed | replace | every `story-setup/references/agent-references/*.md` reference resolves |
 | `skills/story-setup/references/templates/settings-hooks.json` | `.claude/settings.local.json` | user+managed | replace managed registrations by stable hook identity | hook JSON valid；旧 matcher 注册已迁移、当前模板命令各一份、用户 hook 保留 |
 | `skills/story-setup/scripts/merge-claude-settings.py` | 部署时执行，不复制到项目 | story-setup helper | execute | 替换已知 story hook 注册、保留用户 hooks/顶层字段，v24→v25 迁移与重复执行幂等 |
+| `skills/story-setup/scripts/copy-path-safety.py` | 每个递归复制步骤前执行，不复制到项目专用目录 | story-setup helper | execute | JSON 仅 `copy_allowed: true` 时允许复制；symlink 同对象 no-op；target 位于 source 内时停止 |
 | generated sentinel | `.story-deployed` | story-setup managed | replace | contains `agents_version`, `setup_skill_version`, `target_cli`, `resolver_strategy`, `references_dir` |
 | `skills/story-setup/references/opencode/AGENTS.md.tmpl` | `AGENTS.md` | user+managed | marker/section merge | contains story skill routing sections | target_cli 含 opencode |
 | `skills/story-setup/references/opencode/agents/` | `.opencode/agents/` | story-setup managed | replace | 7 agent files exist（replace 前按「配置 OpenCode Agent 模型」中的「保留已有模型配置」缓存现有 `model:`，避免覆盖用户已配模型） | target_cli 含 opencode |

--- a/skills/story-setup/SKILL.md
+++ b/skills/story-setup/SKILL.md
@@ -70,6 +70,10 @@ metadata: {"openclaw":{"source":"https://github.com/worldwonderer/oh-story-claud
 
 整个 Phase 2 幂等：目录复制、文件写入和下表各合并算法重复执行结果一致。因环境原因（工具不可用、权限被拒、网络失败）中途失败时，直接从头重跑本 Phase，不需要先清理半成品；`create only if absent` 的用户状态文件（见下表 Owner class）不会被二次覆盖。
 
+**两列基准目录不同**：`Source path` 相对正在执行的这份 skill 包，`Target path` 相对用户项目根。执行每一行（以及下面各端部署算法里的每个复制步骤）之前，先把两侧各自解析成绝对路径，**相同即 no-op，禁止复制**。OpenClaw / Reasonix / generic 的项目副本是整份 skill 拷贝，重跑时执行的就是项目里那份，两侧会落到同一个目录；照字面复制会把目录嵌进自身，重复几次即撑满磁盘。
+
+**部署前清理自嵌套残留**：删除项目里把目录嵌进自身的产物——各端 references 根下的 `agent-references/agent-references/`（可能有多层）与 `skills/story-setup/skills/`，删完再部署，并在安装报告里列出删掉的路径。
+
 ### Step 1：部署清单（机械可检查）
 
 | Source path | Target path | Owner class | Merge mode | Validation check |
@@ -88,7 +92,7 @@ metadata: {"openclaw":{"source":"https://github.com/worldwonderer/oh-story-claud
 | `skills/story-setup/references/opencode/story_hook_core.js` | `.opencode/plugins/lib/story_hook_core.js` | story-setup managed | replace | Node syntax valid；与 ZCode 副本字节一致；被 story-hooks.ts import | target_cli 含 opencode |
 | `skills/story-setup/references/opencode/commands/` | `.opencode/commands/` | story-setup managed | replace | 13 command files exist | target_cli 含 opencode |
 | `skills/story-setup/references/opencode/opencode.json.patch` | merge into `opencode.json` | user+managed | merge by plugin/permission key | plugin entry registered | target_cli 含 opencode |
-| `skills/story-setup/references/agent-references/` | `skills/story-setup/references/agent-references/` | story-setup managed | replace | every reference resolves | target_cli 含 opencode |
+| repository `skills/story-setup/references/agent-references/` | `skills/story-setup/references/agent-references/` | story-setup managed | replace | every reference resolves | target_cli 含 opencode |
 | `skills/story-setup/references/opencode/pre-commit.sh` | `.git/hooks/pre-commit` | user+managed | append or create | file exists and is executable；含 marker 块则替换块内容，不含则检测 exit 0 位置智能插入 | target_cli 含 opencode |
 | `skills/story-setup/references/codex/AGENTS.md.tmpl` | `AGENTS.md` | user+managed | marker/section merge | contains Codex story skill routing sections | target_cli 含 codex |
 | `skills/story-setup/references/codex/agents/` | `.codex/agents/` | story-setup managed | replace | 7 TOML agent files parse and contain `name`/`description`/`developer_instructions` | target_cli 含 codex |
@@ -106,7 +110,7 @@ metadata: {"openclaw":{"source":"https://github.com/worldwonderer/oh-story-claud
 | `skills/story-setup/references/generic/AGENTS.md.tmpl` | `AGENTS.md` | user+managed | marker/section merge | contains generic story skill routing sections | target_cli 含 generic |
 | `skills/story-setup/references/reasonix/AGENTS.md.tmpl` | `AGENTS.md` | user+managed | marker/section merge | contains Reasonix story skill routing sections and solo/direct fallback | target_cli 含 reasonix |
 | repository `skills/{browser-cdp,story*}/` | `skills/{browser-cdp,story*}/` | story-setup managed for known skill names | replace known skill dirs only | 13 `SKILL.md` files exist; OpenClaw-compatible frontmatter | target_cli 含 openclaw 或 generic 或 reasonix |
-| `skills/story-setup/references/agent-references/` | `skills/story-setup/references/agent-references/` | story-setup managed | replace via full skill copy | every reference resolves | target_cli 含 openclaw 或 generic 或 reasonix |
+| repository `skills/story-setup/references/agent-references/` | 随上一行整份 skill 拷贝落地，本行 no-op | story-setup managed | 不单独复制 | every reference resolves | target_cli 含 openclaw 或 generic 或 reasonix |
 
 ### opencode.json 合并算法
 
@@ -316,9 +320,8 @@ Reasonix（DeepSeek-Reasonix CLI）当前只部署 skills 与 `AGENTS.md`，不�
 1. 读取仓库当前 `skills/` 下所有包含 `SKILL.md` 的 story skill 目录（13 个：`browser-cdp` 与 `story*`）到目标项目 `skills/{skill-name}/`；仅替换这些 story-setup 管理的已知 skill 目录，保留用户其他目录。
 2. 在项目根创建 `.agents/skills → ../skills` 相对 symlink（与 Codex 共用的 skill root），使 Reasonix 原生扫描 `.agents/skills` 时发现这些 skill；若已是指向 `skills/` 的 symlink 则保留，若被占用为普通目录则不覆盖并在安装报告提示。Windows 未启用 symlink 时跳过本步，改走根 `reasonix-plugin.json` 的 `reasonix plugin install`。
 3. 复制 `skills/story-setup/references/reasonix/AGENTS.md.tmpl` 到项目 `AGENTS.md`，按「AGENTS.md 合并策略」合并。
-4. 复制 `skills/story-setup/references/agent-references/` 到 `skills/story-setup/references/agent-references/`，保证 narrative-writer / story-architect 等角色说明里的参考路径可解析。
-5. `.story-deployed` 的 `target_cli` 写入 `reasonix` 或多端组合；`references_dir` 对 Reasonix 写 `skills/story-setup/references/agent-references`。
-6. 安装报告提示项见 Phase 3 第 12 步。
+4. `.story-deployed` 的 `target_cli` 写入 `reasonix` 或多端组合；`references_dir` 对 Reasonix 写 `skills/story-setup/references/agent-references`。
+5. 安装报告提示项见 Phase 3 第 12 步。
 
 ### 通用 Web AI / 其他 Agent 部署算法（target_cli 含 generic 时）
 
@@ -326,9 +329,8 @@ Reasonix（DeepSeek-Reasonix CLI）当前只部署 skills 与 `AGENTS.md`，不�
 
 1. 复制仓库当前 `skills/` 下所有包含 `SKILL.md` 的 story skill 目录（13 个：`browser-cdp` 与 `story*`）到目标项目 `skills/{skill-name}/`；仅替换这些 story-setup 管理的已知 skill 目录，保留用户其他目录。
 2. 复制 `skills/story-setup/references/generic/AGENTS.md.tmpl` 到项目 `AGENTS.md`，按「AGENTS.md 合并策略」合并。
-3. 复制 `skills/story-setup/references/agent-references/` 到 `skills/story-setup/references/agent-references/`，保证 narrative-writer / story-architect 等角色说明里的参考路径可解析。
-4. `.story-deployed` 的 `target_cli` 写入 `generic` 或多端组合；`references_dir` 对 generic 写 `skills/story-setup/references/agent-references`。
-5. 安装报告提示项见 Phase 3 第 11 步。
+3. `.story-deployed` 的 `target_cli` 写入 `generic` 或多端组合；`references_dir` 对 generic 写 `skills/story-setup/references/agent-references`。
+4. 安装报告提示项见 Phase 3 第 11 步。
 
 ### Step 7：创建部署标记
 

--- a/skills/story-setup/UPGRADING.md
+++ b/skills/story-setup/UPGRADING.md
@@ -17,6 +17,12 @@
 
 推荐始终重新运行 story-setup，让部署器按 owner class 处理文件。
 
+### 自嵌套残留
+
+部署清单的 Source 相对 skill 包、Target 相对项目根，两个基准目录在 skills-only 端会重合。按字面复制会把目录嵌进自身，留下 `agent-references/agent-references/`（可能多层）或 `skills/story-setup/skills/`。重新部署会先删掉这类残留。
+
+OpenClaw / Reasonix / generic 三条路径的 skill 副本在项目 `skills/` 里，重跑时执行的就是项目里那份旧文件，自动清理到不了：先手动删掉上述目录，再更新 oh-story-claudecode 并重跑 story-setup。
+
 ## 文件所有权
 
 ### story-setup 管理，可替换

--- a/skills/story-setup/UPGRADING.md
+++ b/skills/story-setup/UPGRADING.md
@@ -21,7 +21,7 @@
 
 部署清单的 Source 相对 skill 包、Target 相对项目根，两个基准目录在 skills-only 端会重合。按字面复制会把目录嵌进自身，留下 `agent-references/agent-references/`（可能多层）或 `skills/story-setup/skills/`。重新部署会先删掉这类残留。
 
-OpenClaw / Reasonix / generic 三条路径的 skill 副本在项目 `skills/` 里，重跑时执行的就是项目里那份旧文件，自动清理到不了：先手动删掉上述目录，再更新 oh-story-claudecode 并重跑 story-setup。
+OpenClaw / Reasonix / generic 三条路径的 skill 副本在项目 `skills/` 里，重跑时执行的就是项目里那份，自动清理到不了：先手动删掉上述目录。要让项目里的 skill 文本本身更新，还需要更新 oh-story-claudecode 后，用新包覆盖项目 `skills/` 下这 13 个目录。
 
 ## 文件所有权
 

--- a/skills/story-setup/UPGRADING.md
+++ b/skills/story-setup/UPGRADING.md
@@ -19,7 +19,7 @@
 
 ### 自嵌套残留
 
-部署清单的 Source 相对 skill 包、Target 相对项目根，两个基准目录在 skills-only 端会重合。按字面复制会把目录嵌进自身，留下 `agent-references/agent-references/`（可能多层）或 `skills/story-setup/skills/`。重新部署会先删掉这类残留。
+部署清单的 Source 相对 skill 包、Target 相对项目根，两个基准目录在 skills-only 端会重合；经 `.agents/skills → ../skills` 等 symlink 加载时，路径文字不同也可能指向同一目录。部署器会先按 realpath / samefile 语义拒绝同对象与「目标位于源目录内」的递归复制，再删掉已有的 `agent-references/agent-references/`（可能多层）或 `skills/story-setup/skills/` 残留。
 
 OpenClaw / Reasonix / generic 三条路径的 skill 副本在项目 `skills/` 里，重跑时执行的就是项目里那份，自动清理到不了：先手动删掉上述目录。要让项目里的 skill 文本本身更新，还需要更新 oh-story-claudecode 后，用新包覆盖项目 `skills/` 下这 13 个目录。
 
@@ -32,6 +32,7 @@ OpenClaw / Reasonix / generic 三条路径的 skill 副本在项目 `skills/` �
 - `.claude/agents/` — 所有 agent 定义
 - `.claude/rules/` — 所有 path-scoped 规则
 - `.claude/skills/story-setup/references/agent-references/` — Agent 参考资料副本
+- `skills/{13 known skills}/` — OpenClaw / Reasonix / generic 的项目 skill 副本，仅覆盖 oh-story 已知名称
 - `.zcode/skills/{13 known skills}/`、`.zcode/commands/{13 known commands}.md` — 仅覆盖 oh-story 已知名称
 - `.zcode/hooks/story_zcode_hook.js` — ZCode 专用 Hook runner
 

--- a/skills/story-setup/scripts/copy-path-safety.py
+++ b/skills/story-setup/scripts/copy-path-safety.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Classify a recursive deployment copy before any filesystem mutation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+
+def canonical_path(raw_path: str) -> Path:
+    """Return an absolute path with existing symlinks resolved."""
+
+    return Path(os.path.realpath(os.path.abspath(os.path.expanduser(raw_path))))
+
+
+def stat_path(path: Path) -> Tuple[Optional[bool], Optional[OSError]]:
+    try:
+        path.stat()
+    except FileNotFoundError:
+        return False, None
+    except OSError as exc:
+        return None, exc
+    return True, None
+
+
+def is_descendant(path: Path, parent: Path) -> bool:
+    path_key = os.path.normcase(str(path))
+    parent_key = os.path.normcase(str(parent))
+    if path_key == parent_key:
+        return False
+    try:
+        return os.path.commonpath((path_key, parent_key)) == parent_key
+    except ValueError:
+        # Different Windows drives cannot contain one another.
+        return False
+
+
+def classify_copy(source_raw: str, target_raw: str) -> Dict[str, object]:
+    source = canonical_path(source_raw)
+    target = canonical_path(target_raw)
+    result: Dict[str, object] = {
+        "source_realpath": str(source),
+        "target_realpath": str(target),
+        "copy_allowed": False,
+    }
+
+    source_exists, source_error = stat_path(source)
+    if source_error is not None:
+        result["status"] = "filesystem_identity_error"
+        result["error"] = str(source_error)
+        return result
+    if not source_exists:
+        result["status"] = "source_missing"
+        return result
+
+    source_key = os.path.normcase(str(source))
+    target_key = os.path.normcase(str(target))
+    if source_key == target_key:
+        result["status"] = "same"
+        return result
+
+    target_exists, target_error = stat_path(target)
+    if target_error is not None:
+        result["status"] = "filesystem_identity_error"
+        result["error"] = str(target_error)
+        return result
+    if target_exists:
+        try:
+            same_object = os.path.samefile(source, target)
+        except OSError as exc:
+            result["status"] = "filesystem_identity_error"
+            result["error"] = str(exc)
+            return result
+        if same_object:
+            result["status"] = "same"
+            return result
+
+    if is_descendant(target, source):
+        result["status"] = "unsafe_target_within_source"
+        return result
+
+    result["status"] = "safe"
+    result["copy_allowed"] = True
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Resolve symlinks and reject recursive deployment copies."
+    )
+    parser.add_argument("source")
+    parser.add_argument("target")
+    args = parser.parse_args()
+
+    result = classify_copy(args.source, args.target)
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return status_exit_code(str(result["status"]))
+
+
+def status_exit_code(status: str) -> int:
+    return 0 if status in {"safe", "same"} else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #363

## 问题

`skills/story-setup/SKILL.md` 里 4 处的 Source 与 Target 是同一个字符串：部署清单第 91、109 行，Reasonix 部署算法第 4 步，通用（generic）部署算法第 3 步。执行方照字面复制会把目录嵌进自身，报告人实测 `agent-references/` 从 58 个文件涨到 36,796 个 / 556 MB（Windows 11）。

## 根因

清单的两列基准目录不同、但从没写明：`Source path` 相对**正在执行的 skill 包**，`Target path` 相对**用户项目根**。第 100 / 108 行的源写了 `repository` 前缀来消歧，91 / 109 没写。两条触发路径：

1. **第 91 行（OpenCode）**：首次部署后项目里就有了 `skills/story-setup/references/agent-references/`。再跑一次时裸相对源在项目 cwd 下命中自己刚部署的那份，源与目标塌成同一个目录。只有 agent-references 膨胀——正是报告里「58 → 36,796」的形状。
2. **第 109 / 319 / 329 行（OpenClaw / Reasonix / generic）**：这三端的项目副本是整份 skill 拷贝、自带 `SKILL.md`（SKILL.md 第 19 行有写），`generic/AGENTS.md.tmpl` 又明写「Agent 应先读对应 `SKILL.md`」。重跑时执行的就是项目里那份，源根 == 项目根是恒等而非歧义，连算法第 1 步的整棵 13 skill 树也会自嵌套。

POSIX `cp -R` 自带防护（实测 BSD cp 只嵌一层就停），所以这个坑在 macOS / Linux 上基本看不出来。

## 与 issue 建议修法的差异

issue 建议把 OpenCode 的 Target 改成 `.opencode/skills/...`。**这条要驳回**，它会打挂三处既有契约：

- `references/opencode/agents/*.md` 里写的是 `{项目根}/skills/story-setup/references/agent-references/{文件名}`
- `scripts/check-current-skill-contracts.py` 的 `opencode-old-reference-prefix` 规则专门禁止 `.opencode/skills/story-setup/references/agent-references/`
- `scripts/check-opencode-adapter.sh:359` 同样断言；`SKILL.md:152` 把 OpenCode 前缀钉死为 `skills/`

Target 是对的，错的是 Source 没写清基准目录。issue 的另外两条建议（109 行标 no-op、删掉 Reasonix / generic 的自复制步）采纳。

## 改动

**SKILL.md**

- 清单前写明两列基准目录，并规定**两侧解析成绝对路径相同即 no-op、禁止复制**——这条同时兜住 skills-only 端第 1 步的整树自拷
- 部署前清理自嵌套残留（四个 references 根下的 `agent-references/agent-references/`、`skills/story-setup/skills/`），在安装报告里列出删掉的路径
- 第 91 行的源补 `repository` 前缀，对齐第 100 / 108 行的既有写法
- 第 109 行改成显式 no-op；Reasonix 第 4 步与 generic 第 3 步删除——与各自第 1 步的整份 skill 拷贝重复，OpenClaw 算法本就没有这一步

**守卫**（`check-story-setup-deployment.sh`）

新增自复制探测器，两条规则：部署清单表内任何一行不得出现裸相同 Source/Target；正文不得出现两侧同路径的复制短语。探测器只写一份，先跑正负 fixture 自检再扫 `SKILL.md`。

**文档**

README / README_EN / UPGRADING 说明 skills-only 三端的手动清理——那三端执行的是项目里那份 `SKILL.md`，自动清理到不了；同时说清「重跑 setup 不会把新包内容带进项目」，要更新 skill 文本得用新包覆盖项目 `skills/` 下这 13 个目录。

不 bump `agents_version`：改动全在技能目录内与守卫脚本，不涉及部署物行为。

## 验证

**探测能力**：对 main 上的原文件精确报出 4 处，行号 91 / 109 / 319 / 329。

**精度**：对全仓 396 个 tracked `.md` 零误报。这一条是复核时才达到的——第一版探测器在 CHANGELOG（`被复制进 \`对标/\`，用户看到的……只有外部作品才进 \`对标/\``）和两个角色关系模板表（`| {名} | {名} |`）上都会误报，已分别用「只在部署清单表内判表格行」和「复制短语 16 字窗口」修掉。

**变异测试**：fixture 每一行都做过变异验证，九种变异全部被断言拦下——去「到」邻接、去尾斜杠归一、放宽窗口、邻接改任意对、去表内限定、归一掉 `repository` 前缀、跳过散文分支、跳过表格分支、去「/」判据。

复核中另外修掉的两个自身缺陷：探测器有发现时退出码为 1，在 `set -e` + `pipefail` 下会让赋值直接中止脚本，CI 变红但不打任何 FAIL 消息；manifest 分支里的 `repository` 前缀豁免是永远命中不到的死代码。

**本地跑绿**：`static-check` / `test-static-check` / `skill-numbering check` / `test-skill-numbering` / `check-current-skill-contracts` / `test-current-skill-contracts` / `check-doc-budget` / `check-hook-regex-sync` / `check-shared-files` / `test-shared-assets` / `check-scan-runtime-policy` / `test-scan-runtime-policy` / `check-story-setup-deployment` / `check-claude-adapter` / `check-codex-adapter` / `check-opencode-adapter` / `check-openclaw-skills` / `check-zcode-adapter` / `check-python-invocation` / `check-hook-locale-safety` / `test-hook-encoding-portable` / `test-prose-net-parity` / `test-degeneration` / `test-codex-hooks`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117Upe8dzkdSbg9BZZeheph
