### PR TITLE
security: harden dashboard JSON responses

### DIFF
--- a/skills/story/scripts/dashboard-server.mjs
+++ b/skills/story/scripts/dashboard-server.mjs
@@ -584,7 +584,24 @@ function responseHeaders(contentType) {
 
 function sendJson(response, status, payload) {
   response.writeHead(status, responseHeaders("application/json; charset=utf-8"));
-  response.end(JSON.stringify(payload));
+  // Keep JSON safe even if a response is ever embedded in an HTML context.
+  // The endpoint already sends application/json with nosniff and a strict CSP;
+  // escaping HTML-significant characters adds defense in depth for user input.
+  const body = JSON.stringify(payload).replace(/[<>&\u2028\u2029]/g, (character) => {
+    switch (character) {
+      case "<":
+        return "\\u003c";
+      case ">":
+        return "\\u003e";
+      case "&":
+        return "\\u0026";
+      case "\u2028":
+        return "\\u2028";
+      default:
+        return "\\u2029";
+    }
+  });
+  response.end(body);
 }
 
 async function readWorkspaceFile(root, requestedPath) {

--- a/tests/dashboard-server.test.mjs
+++ b/tests/dashboard-server.test.mjs
@@ -459,6 +459,22 @@ describe("HTTP API", () => {
     assert.equal(hiddenDirectory.status, 403);
   });
 
+  test("escapes HTML-significant characters in JSON responses", async () => {
+    const root = await createWorkspace();
+    const baseUrl = await startServer(root);
+    const query = "<script>alert(1)</script>&\u2028\u2029";
+
+    const response = await fetch(
+      `${baseUrl}/api/search?q=${encodeURIComponent(query)}&scope=projects`,
+    );
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("content-type"), "application/json; charset=utf-8");
+
+    const rawBody = await response.text();
+    assert.doesNotMatch(rawBody, /[<>&\u2028\u2029]/u);
+    assert.equal(JSON.parse(rawBody).query, query.trim());
+  });
+
   test("loads and atomically saves an editable file", async () => {
     const root = await createWorkspace();
     const baseUrl = await startServer(root);


### PR DESCRIPTION
## Summary

- escape HTML-significant characters in JSON responses
- preserve normal JSON parsing while adding defense in depth
- add a focused regression test for reflected input

Closes the initial CodeQL reflected-XSS alert without weakening the scanner.

## Validation

- `node --check skills/story/scripts/dashboard-server.mjs`
- focused dashboard server regression test
- `git diff --check`