### PR TITLE
fix(outline): 细纲不存在或不可读时显式失败

### DIFF
--- a/scripts/test-outline-copy.sh
+++ b/scripts/test-outline-copy.sh
@@ -53,6 +53,12 @@ expect_contains() {
   esac
 }
 
+# Git Bash 会把传给 Node 的 /tmp/... 参数转换成 Windows 原生路径。
+# 按同一公共进程边界取得预期路径，不把 POSIX 拼写当作 CLI 输出契约。
+expect_path() {
+  expect_contains "$(node -p 'process.argv[1]' "$1")"
+}
+
 expect_missing() {
   case "$OUTPUT" in
   *"$1"*) fail "expected output NOT to contain: $1" ;;
@@ -186,12 +192,14 @@ run --outline "$TMP_DIR/o9.md" "$TMP_DIR/p9.md"
 expect_status 0
 [ -z "$OUTPUT" ] || fail "expected silent output on a clean chapter"
 
-# --- 10. 缺细纲：不可判定时静默退出 0，不得误报 ---
+# --- 10. 自动发现不到细纲：明确跳过但不阻断普通独立正文 ---
 CASE="missing-outline"
 printf '%s。\n' "$COPIED" >"$TMP_DIR/orphan.md"
 run "$TMP_DIR/orphan.md"
 expect_status 0
-[ -z "$OUTPUT" ] || fail "expected silence when no outline can be located"
+expect_contains "跳过"
+expect_path "$TMP_DIR/orphan.md"
+expect_contains "未自动发现细纲"
 
 # --- 11. 收尾复扫按通配传多章：每章各自比对，不得把第二个正文当成细纲 ---
 CASE="multi-prose-batch"
@@ -217,4 +225,124 @@ run "$TMP_DIR/批/正文/第006章_天明.md" "$TMP_DIR/批/正文/第005章_雨
 expect_status 1
 expect_contains "第005章_雨夜.md"
 
-echo "PASS: check-outline-copy.js (12 cases)"
+# --- 13. 显式细纲不存在：不是「干净」，必须准确报错并退 2 ---
+CASE="explicit-missing-outline"
+run --outline "$TMP_DIR/不存在的细纲.md" "$TMP_DIR/p9.md"
+expect_status 2
+expect_contains "无法读取显式细纲"
+expect_path "$TMP_DIR/不存在的细纲.md"
+expect_contains "不存在"
+
+# --- 14. 正文不存在：必须准确报出正文路径并退 2 ---
+CASE="missing-prose"
+run --outline "$TMP_DIR/o9.md" "$TMP_DIR/不存在的正文.md"
+expect_status 2
+expect_contains "无法读取正文"
+expect_path "$TMP_DIR/不存在的正文.md"
+expect_contains "不存在"
+
+# --- 15. 参数错误：缺少 --outline 值、未知选项、没有正文都退 2 ---
+CASE="outline-option-without-value"
+run --outline
+expect_status 2
+expect_contains "--outline 缺少路径"
+
+CASE="unknown-option"
+run --unknown "$TMP_DIR/p9.md"
+expect_status 2
+expect_contains "未知选项: --unknown"
+
+CASE="no-prose"
+run --outline "$TMP_DIR/o9.md"
+expect_status 2
+expect_contains "缺少正文路径"
+
+# --- 16. 目录不是可读文本文件：跨平台稳定拒绝，不能依赖 EISDIR 文案 ---
+CASE="outline-is-directory"
+mkdir -p "$TMP_DIR/目录细纲"
+run --outline "$TMP_DIR/目录细纲" "$TMP_DIR/p9.md"
+expect_status 2
+expect_contains "无法读取显式细纲"
+expect_path "$TMP_DIR/目录细纲"
+expect_contains "不是普通文件"
+
+CASE="prose-is-directory"
+mkdir -p "$TMP_DIR/目录正文"
+run --outline "$TMP_DIR/o9.md" "$TMP_DIR/目录正文"
+expect_status 2
+expect_contains "无法读取正文"
+expect_path "$TMP_DIR/目录正文"
+expect_contains "不是普通文件"
+
+# --- 17. 非预期异常：顶层不得吞掉异常后伪装成成功 ---
+CASE="unexpected-exception"
+printf '%s。\n' "$COPIED" >"$TMP_DIR/explode.md"
+cat >"$TMP_DIR/throw-on-basename.js" <<'EOF'
+const path = require('path')
+const originalBasename = path.basename
+path.basename = function basename(file, ...args) {
+  if (originalBasename.call(this, file, ...args) === 'explode.md') throw new Error('synthetic unexpected failure')
+  return originalBasename.call(this, file, ...args)
+}
+EOF
+set +e
+OUTPUT="$(node --require "$TMP_DIR/throw-on-basename.js" "$SCRIPT" "$TMP_DIR/explode.md" 2>&1)"
+STATUS=$?
+set -e
+expect_status 2
+expect_contains "细纲照搬检测异常"
+expect_contains "synthetic unexpected failure"
+
+# --- 21. 自动发现权限错误不能伪装成没有细纲 ---
+CASE="auto-outline-permission-error"
+cat >"$TMP_DIR/throw-on-readdir.js" <<'JS'
+const fs = require('fs')
+const original = fs.readdirSync
+fs.readdirSync = function (dir, ...args) {
+  if (String(dir).endsWith('大纲')) {
+    const error = new Error(`EACCES: cannot read ${dir}`)
+    error.code = 'EACCES'
+    throw error
+  }
+  return original.call(this, dir, ...args)
+}
+JS
+set +e
+OUTPUT="$(node --require "$TMP_DIR/throw-on-readdir.js" "$SCRIPT" "$TMP_DIR/批/正文/第005章_雨夜.md" 2>&1)"
+STATUS=$?
+set -e
+expect_status 2
+expect_contains "EACCES"
+expect_contains "大纲"
+
+# --- 22. 找到路径后读取失败仍然是输入错误，不得跳过 ---
+CASE="discovered-outline-read-error"
+cat >"$TMP_DIR/throw-on-outline-read.js" <<'JS'
+const fs = require('fs')
+const original = fs.readFileSync
+fs.readFileSync = function (file, ...args) {
+  if (String(file).endsWith('细纲_第005章.md')) {
+    const error = new Error(`EACCES: cannot read ${file}`)
+    error.code = 'EACCES'
+    throw error
+  }
+  return original.call(this, file, ...args)
+}
+JS
+set +e
+OUTPUT="$(node --require "$TMP_DIR/throw-on-outline-read.js" "$SCRIPT" "$TMP_DIR/批/正文/第005章_雨夜.md" 2>&1)"
+STATUS=$?
+set -e
+expect_status 2
+expect_contains "EACCES"
+expect_contains "细纲_第005章.md"
+
+# --- 23. 自动发现的目标是目录同样拒绝 ---
+CASE="discovered-outline-is-directory"
+mkdir -p "$TMP_DIR/非文件细纲/小节大纲.md"
+printf '%s。\n' "$COPIED" >"$TMP_DIR/非文件细纲/正文.md"
+run "$TMP_DIR/非文件细纲/正文.md"
+expect_status 2
+expect_contains "不是普通文件"
+
+echo "PASS: check-outline-copy.js (23 cases)"

--- a/scripts/test-outline-copy.sh
+++ b/scripts/test-outline-copy.sh
@@ -53,8 +53,7 @@ expect_contains() {
   esac
 }
 
-# Git Bash 会把传给 Node 的 /tmp/... 参数转换成 Windows 原生路径。
-# 按同一公共进程边界取得预期路径，不把 POSIX 拼写当作 CLI 输出契约。
+# 通过 Node 获取 Git Bash 转换后的 Windows 路径。
 expect_path() {
   expect_contains "$(node -p 'process.argv[1]' "$1")"
 }
@@ -225,7 +224,7 @@ run "$TMP_DIR/批/正文/第006章_天明.md" "$TMP_DIR/批/正文/第005章_雨
 expect_status 1
 expect_contains "第005章_雨夜.md"
 
-# --- 13. 显式细纲不存在：不是「干净」，必须准确报错并退 2 ---
+# --- 13. 显式细纲不存在：报路径并退 2 ---
 CASE="explicit-missing-outline"
 run --outline "$TMP_DIR/不存在的细纲.md" "$TMP_DIR/p9.md"
 expect_status 2
@@ -233,7 +232,7 @@ expect_contains "无法读取显式细纲"
 expect_path "$TMP_DIR/不存在的细纲.md"
 expect_contains "不存在"
 
-# --- 14. 正文不存在：必须准确报出正文路径并退 2 ---
+# --- 14. 正文不存在：报路径并退 2 ---
 CASE="missing-prose"
 run --outline "$TMP_DIR/o9.md" "$TMP_DIR/不存在的正文.md"
 expect_status 2
@@ -241,7 +240,7 @@ expect_contains "无法读取正文"
 expect_path "$TMP_DIR/不存在的正文.md"
 expect_contains "不存在"
 
-# --- 15. 参数错误：缺少 --outline 值、未知选项、没有正文都退 2 ---
+# --- 15–17. 参数错误：缺少 --outline 值、未知选项、没有正文都退 2 ---
 CASE="outline-option-without-value"
 run --outline
 expect_status 2
@@ -257,7 +256,7 @@ run --outline "$TMP_DIR/o9.md"
 expect_status 2
 expect_contains "缺少正文路径"
 
-# --- 16. 目录不是可读文本文件：跨平台稳定拒绝，不能依赖 EISDIR 文案 ---
+# --- 18–19. 目录输入：各平台统一报「不是普通文件」 ---
 CASE="outline-is-directory"
 mkdir -p "$TMP_DIR/目录细纲"
 run --outline "$TMP_DIR/目录细纲" "$TMP_DIR/p9.md"
@@ -274,7 +273,7 @@ expect_contains "无法读取正文"
 expect_path "$TMP_DIR/目录正文"
 expect_contains "不是普通文件"
 
-# --- 17. 非预期异常：顶层不得吞掉异常后伪装成成功 ---
+# --- 20. 非预期异常：报错并退 2 ---
 CASE="unexpected-exception"
 printf '%s。\n' "$COPIED" >"$TMP_DIR/explode.md"
 cat >"$TMP_DIR/throw-on-basename.js" <<'EOF'

--- a/skills/story-long-write/scripts/check-outline-copy.js
+++ b/skills/story-long-write/scripts/check-outline-copy.js
@@ -31,8 +31,9 @@
  * 收尾复扫用 `正文/第XXX章_*.md` 这类通配传多章时，多出来的正文不能被当成细纲吞掉
  * ——那会让首个文件比错对象、其余文件根本不检，静默退 0 报「干净」。
  *
- * 退出码：0 = 干净或无法判定（缺细纲/非分章正文）；1 = 有重合待复核。
- * 无发现时完全静默，不污染上下文。
+ * 退出码：0 = 干净或未自动发现细纲而跳过；1 = 有重合待复核；
+ * 2 = 参数错误、输入不可读（含已发现的细纲）或非预期异常。
+ * 干净时静默；自动发现不到细纲时明确报告跳过，避免与「已检查且干净」混淆。
  */
 
 'use strict'
@@ -42,12 +43,26 @@ const path = require('path')
 const MIN_RUN = 16 // 判定阈值：连续重合 >15 字，即 >=16
 const REPORT_TOP = 8 // 最多列出的片段数
 
-function read(p) {
+function readTextFile(p) {
   try {
-    return fs.readFileSync(p, 'utf8').replace(/^﻿/, '')
-  } catch {
-    return null
+    const stat = fs.statSync(p)
+    if (!stat.isFile()) return { ok: false, reason: '不是普通文件' }
+    return { ok: true, text: fs.readFileSync(p, 'utf8').replace(/^﻿/, '') }
+  } catch (error) {
+    if (error && error.code === 'ENOENT') return { ok: false, reason: '不存在' }
+    if (error && error.code) return { ok: false, reason: `无法读取（${error.code}）` }
+    return { ok: false, reason: `无法读取：${error instanceof Error ? error.message : String(error)}` }
   }
+}
+
+function reportInputError(kind, file, reason) {
+  process.stderr.write(`错误: 无法读取${kind} "${file}"：${reason}。\n`)
+}
+
+function reportUsageError(message) {
+  process.stderr.write(`错误: ${message}。\n`)
+  process.stderr.write('用法: node check-outline-copy.js [--outline <细纲路径>] <正文路径...>\n')
+  return 2
 }
 
 /** 只留汉字——剥掉标点/加粗/【】后比对，防止细纲标注造成假阴性 */
@@ -129,7 +144,9 @@ function findOutline(proseFile) {
       const fm = file.match(/^细纲_第0*(\d+)章.*\.md$/)
       if (fm && fm[1] === chapter) return path.join(dir, file)
     }
-  } catch {}
+  } catch (error) {
+    if (error.code !== 'ENOENT') throw error
+  }
   return null
 }
 
@@ -137,30 +154,52 @@ function main() {
   const proseFiles = []
   let explicitOutline = null
   const argv = process.argv.slice(2)
+  let positionalOnly = false
   for (let k = 0; k < argv.length; k++) {
-    if (argv[k] === '--outline') explicitOutline = argv[++k] || null
-    else proseFiles.push(argv[k])
+    const arg = argv[k]
+    if (!positionalOnly && arg === '--') {
+      positionalOnly = true
+    } else if (!positionalOnly && arg === '--outline') {
+      if (explicitOutline !== null) return reportUsageError('--outline 不能重复指定')
+      const value = argv[k + 1]
+      if (!value || value.startsWith('--')) return reportUsageError('--outline 缺少路径')
+      explicitOutline = value
+      k++
+    } else if (!positionalOnly && arg.startsWith('--')) {
+      return reportUsageError(`未知选项: ${arg}`)
+    } else {
+      proseFiles.push(arg)
+    }
   }
-  if (!proseFiles.length) {
-    process.stderr.write('用法: node check-outline-copy.js [--outline <细纲路径>] <正文路径...>\n')
-    return 0
-  }
-  // 逐个文件独立判定；任一文件有重合即整体退 1
+  if (!proseFiles.length) return reportUsageError('缺少正文路径')
+
+  // 逐个文件独立判定；输入错误优先于重合发现
   let status = 0
   for (const proseFile of proseFiles) {
-    if (checkOne(proseFile, explicitOutline)) status = 1
+    status = Math.max(status, checkOne(proseFile, explicitOutline))
   }
   return status
 }
 
 function checkOne(proseFile, explicitOutline) {
-  const prose = read(proseFile)
-  if (prose === null) return 0
+  const proseResult = readTextFile(proseFile)
+  if (!proseResult.ok) {
+    reportInputError('正文', proseFile, proseResult.reason)
+    return 2
+  }
+  const prose = proseResult.text
 
   const outlineFile = explicitOutline || findOutline(proseFile)
-  if (!outlineFile) return 0
-  const outline = read(outlineFile)
-  if (outline === null) return 0
+  if (!outlineFile) {
+    process.stdout.write(`细纲照搬检测：跳过 "${proseFile}"（未自动发现细纲）。\n`)
+    return 0
+  }
+  const outlineResult = readTextFile(outlineFile)
+  if (!outlineResult.ok) {
+    reportInputError(explicitOutline ? '显式细纲' : '自动发现的细纲', outlineFile, outlineResult.reason)
+    return 2
+  }
+  const outline = outlineResult.text
 
   // 正文去掉标题行后比对
   const P = hanOnly(prose.replace(/^#.*$/gm, ''))
@@ -236,6 +275,8 @@ function checkOne(proseFile, explicitOutline) {
 
 try {
   process.exit(main())
-} catch {
-  process.exit(0)
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error)
+  process.stderr.write(`错误: 细纲照搬检测异常：${message}。\n`)
+  process.exit(2)
 }

--- a/skills/story-short-write/scripts/check-outline-copy.js
+++ b/skills/story-short-write/scripts/check-outline-copy.js
@@ -31,8 +31,9 @@
  * 收尾复扫用 `正文/第XXX章_*.md` 这类通配传多章时，多出来的正文不能被当成细纲吞掉
  * ——那会让首个文件比错对象、其余文件根本不检，静默退 0 报「干净」。
  *
- * 退出码：0 = 干净或无法判定（缺细纲/非分章正文）；1 = 有重合待复核。
- * 无发现时完全静默，不污染上下文。
+ * 退出码：0 = 干净或未自动发现细纲而跳过；1 = 有重合待复核；
+ * 2 = 参数错误、输入不可读（含已发现的细纲）或非预期异常。
+ * 干净时静默；自动发现不到细纲时明确报告跳过，避免与「已检查且干净」混淆。
  */
 
 'use strict'
@@ -42,12 +43,26 @@ const path = require('path')
 const MIN_RUN = 16 // 判定阈值：连续重合 >15 字，即 >=16
 const REPORT_TOP = 8 // 最多列出的片段数
 
-function read(p) {
+function readTextFile(p) {
   try {
-    return fs.readFileSync(p, 'utf8').replace(/^﻿/, '')
-  } catch {
-    return null
+    const stat = fs.statSync(p)
+    if (!stat.isFile()) return { ok: false, reason: '不是普通文件' }
+    return { ok: true, text: fs.readFileSync(p, 'utf8').replace(/^﻿/, '') }
+  } catch (error) {
+    if (error && error.code === 'ENOENT') return { ok: false, reason: '不存在' }
+    if (error && error.code) return { ok: false, reason: `无法读取（${error.code}）` }
+    return { ok: false, reason: `无法读取：${error instanceof Error ? error.message : String(error)}` }
   }
+}
+
+function reportInputError(kind, file, reason) {
+  process.stderr.write(`错误: 无法读取${kind} "${file}"：${reason}。\n`)
+}
+
+function reportUsageError(message) {
+  process.stderr.write(`错误: ${message}。\n`)
+  process.stderr.write('用法: node check-outline-copy.js [--outline <细纲路径>] <正文路径...>\n')
+  return 2
 }
 
 /** 只留汉字——剥掉标点/加粗/【】后比对，防止细纲标注造成假阴性 */
@@ -129,7 +144,9 @@ function findOutline(proseFile) {
       const fm = file.match(/^细纲_第0*(\d+)章.*\.md$/)
       if (fm && fm[1] === chapter) return path.join(dir, file)
     }
-  } catch {}
+  } catch (error) {
+    if (error.code !== 'ENOENT') throw error
+  }
   return null
 }
 
@@ -137,30 +154,52 @@ function main() {
   const proseFiles = []
   let explicitOutline = null
   const argv = process.argv.slice(2)
+  let positionalOnly = false
   for (let k = 0; k < argv.length; k++) {
-    if (argv[k] === '--outline') explicitOutline = argv[++k] || null
-    else proseFiles.push(argv[k])
+    const arg = argv[k]
+    if (!positionalOnly && arg === '--') {
+      positionalOnly = true
+    } else if (!positionalOnly && arg === '--outline') {
+      if (explicitOutline !== null) return reportUsageError('--outline 不能重复指定')
+      const value = argv[k + 1]
+      if (!value || value.startsWith('--')) return reportUsageError('--outline 缺少路径')
+      explicitOutline = value
+      k++
+    } else if (!positionalOnly && arg.startsWith('--')) {
+      return reportUsageError(`未知选项: ${arg}`)
+    } else {
+      proseFiles.push(arg)
+    }
   }
-  if (!proseFiles.length) {
-    process.stderr.write('用法: node check-outline-copy.js [--outline <细纲路径>] <正文路径...>\n')
-    return 0
-  }
-  // 逐个文件独立判定；任一文件有重合即整体退 1
+  if (!proseFiles.length) return reportUsageError('缺少正文路径')
+
+  // 逐个文件独立判定；输入错误优先于重合发现
   let status = 0
   for (const proseFile of proseFiles) {
-    if (checkOne(proseFile, explicitOutline)) status = 1
+    status = Math.max(status, checkOne(proseFile, explicitOutline))
   }
   return status
 }
 
 function checkOne(proseFile, explicitOutline) {
-  const prose = read(proseFile)
-  if (prose === null) return 0
+  const proseResult = readTextFile(proseFile)
+  if (!proseResult.ok) {
+    reportInputError('正文', proseFile, proseResult.reason)
+    return 2
+  }
+  const prose = proseResult.text
 
   const outlineFile = explicitOutline || findOutline(proseFile)
-  if (!outlineFile) return 0
-  const outline = read(outlineFile)
-  if (outline === null) return 0
+  if (!outlineFile) {
+    process.stdout.write(`细纲照搬检测：跳过 "${proseFile}"（未自动发现细纲）。\n`)
+    return 0
+  }
+  const outlineResult = readTextFile(outlineFile)
+  if (!outlineResult.ok) {
+    reportInputError(explicitOutline ? '显式细纲' : '自动发现的细纲', outlineFile, outlineResult.reason)
+    return 2
+  }
+  const outline = outlineResult.text
 
   // 正文去掉标题行后比对
   const P = hanOnly(prose.replace(/^#.*$/gm, ''))
@@ -236,6 +275,8 @@ function checkOne(proseFile, explicitOutline) {
 
 try {
   process.exit(main())
-} catch {
-  process.exit(0)
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error)
+  process.stderr.write(`错误: 细纲照搬检测异常：${message}。\n`)
+  process.exit(2)
 }


### PR DESCRIPTION
细纲或正文读取失败时，照搬检测器过去会静默返回成功。现在长、短篇检测器对参数错误、不可读输入及异常返回 exit 2，并报告路径和原因；正常无重合返回 0，发现重合返回 1。自动找不到细纲仍允许跳过，并明确提示未检查。

验证：23 场景检测器回归、13 项 storyctl 测试、共享副本与当前契约检查通过。main/候选同输入对照覆盖缺失文件、目录和真实 chmod(0) 权限错误，确认旧版返回 0、修复后返回 2。公开 storyctl 入口的细纲读取错误仍被前置检查拦截。
