### PR TITLE
fix(story-setup): check 参数在 OpenCode/ZCode 正确路由，并校正 Phase 3 项数说明

### DIFF
--- a/skills/story-setup/SKILL.md
+++ b/skills/story-setup/SKILL.md
@@ -389,7 +389,7 @@ Reasonix（DeepSeek-Reasonix CLI）当前只部署 skills 与 `AGENTS.md`，不�
 
 ## Phase 3：验证安装
 
-按 `.story-deployed.target_cli` 选择对应端的检查；第 1–4 项仅用于 Claude Code，第 5 项是所有端共有的部署标记检查。仅检查模式也复用这些验证项，不执行部署或创建标记。
+按 `.story-deployed.target_cli` 选择对应端的检查：第 1–4 项仅用于 Claude Code，第 5 项是所有端共有的部署标记检查，第 6 项是部署报告，第 7–13 项按目标端各选其一。仅检查模式复用第 1–5 项与对应端的第 7–13 项，跳过第 6 项，且其中要求实际执行 hook 或写入 fixture 的子项改为只做静态校验（文件存在、语法有效、注册项齐全），不运行会写入项目的 hook，也不创建部署标记。
 
 1. 验证 hooks 注册：
    - 检查 `.claude/settings.local.json` 中的 hooks 字段是否正确

--- a/skills/story-setup/references/opencode/commands/story-setup.md
+++ b/skills/story-setup/references/opencode/commands/story-setup.md
@@ -1,5 +1,7 @@
 ---
-description: 网文写作环境部署。一键部署 hooks、rules、agents、项目指令等基础设施。
+description: 网文写作环境部署与检查。部署 hooks、rules、agents、项目指令等基础设施；传入 check 只检查不改动。
 ---
 
-请使用 story-setup skill，帮助我部署网文写作工具集的基础设施。
+请使用 story-setup skill 处理网文写作工具集的基础设施：没有参数时部署，参数为 `check` 时只检查并报告。
+
+用户参数：$ARGUMENTS

--- a/skills/story-setup/references/zcode/commands/story-setup.md
+++ b/skills/story-setup/references/zcode/commands/story-setup.md
@@ -1,8 +1,8 @@
 ---
-description: 为当前项目部署 ZCode 网文 Skills、Commands、Hooks 与 AGENTS.md。
+description: 为当前项目部署或检查 ZCode 网文 Skills、Commands、Hooks 与 AGENTS.md。
 skills: story-setup
 ---
 
-调用 `$story-setup`，以 `target_cli=zcode` 部署当前写作项目；保留用户已有配置并进行安全合并。
+调用 `$story-setup`，以 `target_cli=zcode` 处理当前写作项目：没有参数时部署，保留用户已有配置并进行安全合并；参数为 `check` 时只检查并报告，不改动项目。
 
 用户参数：$ARGUMENTS


### PR DESCRIPTION
修 #407 的两条，都是 #405 审查时发现的。

## 1. OpenCode 上 `/story-setup check` 会走成部署

`skills/story-setup/references/opencode/commands/story-setup.md` 没有 `$ARGUMENTS` 占位符，正文写死「请使用 story-setup skill，帮助我部署网文写作工具集的基础设施」。用户敲 `/story-setup check`，参数被丢掉、正文又是一条部署请求，agent 走部署分支。README 与 README_EN 都把「给 story-setup 传入 `check` 参数」写成通用入口。

ZCode 那份带了 `$ARGUMENTS`，但正文同样只说「部署当前写作项目」，`check` 到达时语义仍偏部署。

两份都改成中性表述：没有参数时部署，参数为 `check` 时只检查并报告。frontmatter 的 description 同步。

## 2. Phase 3 项数说明不完整

`story-setup/SKILL.md` 原文：「第 1–4 项仅用于 Claude Code，第 5 项是所有端共有的部署标记检查。」

Phase 3 实际有 **13** 个编号项。第 6 项是部署报告（检查模式不该跑），第 7–13 项是 opencode / codex / antigravity / zcode / openclaw / generic / reasonix 的按端验证——而 `references/diagnostics.md` 第 2 节正是靠「Phase 3 对应目标端的验证项」来复用它们。按原措辞读者会以为 Phase 3 只有 5 项。

顺带把 #407 里提的只读风险写进同一句：Phase 3 第 9 项（Antigravity）要求「用 fixture 验证：PreToolUse 缺纲/追踪时 deny…PostToolUse 把正文 findings 写进 session artifact…Stop 对未处理 findings 最多 continue 一次」，那是在跑会写 session artifact 和 pending state 的 hook。`diagnostics.md` 另有一句「不主动运行可能写入项目的 hook」兜着，但要靠 agent 自己判断哪些项会写。现在直接写明：仅检查模式跳过第 6 项，且要求实际执行 hook 或写入 fixture 的子项降级为静态校验（文件存在、语法有效、注册项齐全）。

## agents_version

**不 bump。** 这是已部署文本的措辞修正，不改变 hook / agent 模板 / 项目模板的行为；自然语言入口（「用 story-setup 检查写作环境」）在所有端本来就能走通，因为触发词在 skill description 里。为一个 slash 命令参数逼所有已部署项目重跑 setup 不成比例。已部署的 OpenCode/ZCode 项目会在下次因其它原因重跑 `/story-setup` 时拿到修正。

## 顺带发现的、本 PR 没做的

`.opencode/commands/` 下 13 个命令里有 **12 个**都没有 `$ARGUMENTS`（只有 `story.md` 有），也就是说 `/story-long-write 第5章`、`/story-deslop 正文.md` 这类带参调用在 OpenCode 上同样丢参数。ZCode 那 13 份则都带。这是同一类缺陷但影响面更大，没有塞进本 PR——留给单独 triage，决定是全部补齐还是确认 OpenCode 有别的传参路径。

## 验证

本地 45/45 守卫全绿（含 `check-opencode-adapter.sh`、`check-zcode-adapter.sh`、`check-story-setup-deployment.sh`、`static-check.sh`、`check-doc-budget.sh`）。

Closes #407

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUaZK27w5RuMukGz45NdxN
