### PR TITLE
fix(opencode): 13 个 slash command 全部显式放 $ARGUMENTS，并加守卫锁死

### DIFF
--- a/scripts/check-opencode-adapter.sh
+++ b/scripts/check-opencode-adapter.sh
@@ -646,9 +646,21 @@ for p in sorted(Path('skills/story-setup/references/opencode/commands').glob('*.
     fm = text.split('---', 2)[1]
     assert 'description:' in fm, f'{p}: missing description'
     assert f'请使用 {p.stem} skill' in text, f'{p}: command body must route to same skill'
+    # OpenCode 只在模板不含 $ARGUMENTS 且不含 $1..$N 时才把用户参数追加到末尾，
+    # 这个回退行为官方文档没有写（opencode.ai/docs/commands 只描述占位符），
+    # 实测 1.14.32 会追加成一行裸文本。显式写占位符才与 ZCode 一致，也不依赖未文档化行为。
+    assert '$ARGUMENTS' in text, f'{p}: command template must place $ARGUMENTS explicitly'
+
+# 两个有 command 面的适配层保持一致，任一侧漏写都拦下来
+zcode_dir = Path('skills/story-setup/references/zcode/commands')
+if zcode_dir.is_dir():
+    zcode_names = {p.stem for p in zcode_dir.glob('*.md')}
+    assert zcode_names == command_names, f'opencode/zcode command sets differ: only_zcode={zcode_names-command_names}, only_opencode={command_names-zcode_names}'
+    for p in sorted(zcode_dir.glob('*.md')):
+        assert '$ARGUMENTS' in p.read_text(), f'{p}: command template must place $ARGUMENTS explicitly'
 PY
 
-echo "  OK slash command templates"
+echo "  OK slash command templates (含 \$ARGUMENTS 占位符与 ZCode 对齐)"
 
 assert_grep 'experimental\.session\.compacting' "$ROOT/plugin.ts" "OpenCode plugin must inject pre-compact context"
 assert_grep 'tool\.execute\.before' "$ROOT/plugin.ts" "OpenCode plugin must guard tool writes"

--- a/skills/story-setup/references/opencode/commands/browser-cdp.md
+++ b/skills/story-setup/references/opencode/commands/browser-cdp.md
@@ -3,3 +3,5 @@ description: 浏览器操控。通过 CDP 协议控制 Chrome，复用已有登�
 ---
 
 请使用 browser-cdp skill，帮助我通过浏览器 CDP 协议执行自动化操作，如抓取数据或控制浏览器。
+
+用户参数：$ARGUMENTS

--- a/skills/story-setup/references/opencode/commands/story-cover.md
+++ b/skills/story-setup/references/opencode/commands/story-cover.md
@@ -3,3 +3,5 @@ description: 网文封面生成。分析书名题材，生成专业封面图。
 ---
 
 请使用 story-cover skill，帮助我分析和生成网文封面图。
+
+用户参数：$ARGUMENTS

--- a/skills/story-setup/references/opencode/commands/story-deslop.md
+++ b/skills/story-setup/references/opencode/commands/story-deslop.md
@@ -3,3 +3,5 @@ description: 网文去AI味。检测并清除文本中的AI写作痕迹，让文
 ---
 
 请使用 story-deslop skill，帮助我检测和清除文本中的 AI 写作痕迹。
+
+用户参数：$ARGUMENTS

--- a/skills/story-setup/references/opencode/commands/story-import.md
+++ b/skills/story-setup/references/opencode/commands/story-import.md
@@ -3,3 +3,5 @@ description: 逆向导入已有小说。将已写好的小说反向解析为标�
 ---
 
 请使用 story-import skill，帮助我将已有小说导入为标准的写作项目结构。
+
+用户参数：$ARGUMENTS

--- a/skills/story-setup/references/opencode/commands/story-long-analyze.md
+++ b/skills/story-setup/references/opencode/commands/story-long-analyze.md
@@ -3,3 +3,5 @@ description: 长篇网文拆文。深度拆解爆款长篇小说的黄金三章�
 ---
 
 请使用 story-long-analyze skill，帮助我拆解长篇小说。
+
+用户参数：$ARGUMENTS

--- a/skills/story-setup/references/opencode/commands/story-long-scan.md
+++ b/skills/story-setup/references/opencode/commands/story-long-scan.md
@@ -3,3 +3,5 @@ description: 长篇网文扫榜。分析起点、番茄、晋江等平台排行�
 ---
 
 请使用 story-long-scan skill，帮助我扫描和分析长篇网文榜单数据。
+
+用户参数：$ARGUMENTS

--- a/skills/story-setup/references/opencode/commands/story-long-write.md
+++ b/skills/story-setup/references/opencode/commands/story-long-write.md
@@ -3,3 +3,5 @@ description: 长篇网文写作。从大纲到正文，辅助长篇网络小说�
 ---
 
 请使用 story-long-write skill，帮助我进行长篇网文写作。
+
+用户参数：$ARGUMENTS

--- a/skills/story-setup/references/opencode/commands/story-review.md
+++ b/skills/story-setup/references/opencode/commands/story-review.md
@@ -3,3 +3,5 @@ description: 多视角对抗式审查。使用多个 Agent 对作品进行多维
 ---
 
 请使用 story-review skill，帮助我对作品进行多视角审查和评分。
+
+用户参数：$ARGUMENTS

--- a/skills/story-setup/references/opencode/commands/story-short-analyze.md
+++ b/skills/story-setup/references/opencode/commands/story-short-analyze.md
@@ -3,3 +3,5 @@ description: 短篇网文拆文。拆解爆款短篇的故事核、结构、情�
 ---
 
 请使用 story-short-analyze skill，帮助我拆解短篇小说。
+
+用户参数：$ARGUMENTS

--- a/skills/story-setup/references/opencode/commands/story-short-scan.md
+++ b/skills/story-setup/references/opencode/commands/story-short-scan.md
@@ -3,3 +3,5 @@ description: 短篇网文扫榜。分析知乎盐言、番茄短篇等平台热�
 ---
 
 请使用 story-short-scan skill，帮助我扫描和分析短篇网文榜单数据。
+
+用户参数：$ARGUMENTS

--- a/skills/story-setup/references/opencode/commands/story-short-write.md
+++ b/skills/story-setup/references/opencode/commands/story-short-write.md
@@ -3,3 +3,5 @@ description: 短篇网文写作。辅助短篇小说创作，从构思到成稿�
 ---
 
 请使用 story-short-write skill，帮助我进行短篇网文写作。
+
+用户参数：$ARGUMENTS


### PR DESCRIPTION
修 #409。同时更正我在那条 issue 里的错误判断。

## 更正：参数不会丢

#409 写的是「带参调用会丢参数」。**这个前提是错的**，用真机测过之后更正。

OpenCode 的命令解析逻辑（1.14.32 二进制内）：

```js
let e  = p.match(Dn) ?? []                       // $1 $2 ... 匹配
let R_ = p.replaceAll(Dn, ...)                   // 位置参数替换
let H_ = p.includes("$ARGUMENTS")
let Z_ = R_.replaceAll("$ARGUMENTS", U.arguments)
if (e.length === 0 && !H_ && U.arguments.trim())
    Z_ = Z_ + "\n" + U.arguments                 // ← 既没占位符也没 $N 时，追加
```

起 headless server、`POST /session/{id}/command` 实测两种模板：

| 模板 | 输入 | 实际送给模型的 prompt |
|---|---|---|
| 无占位符 | `/noph 第5章` | `请使用 … 写长篇网文。`<br>`第5章` |
| 有 `$ARGUMENTS` | `/withph 第5章` | `请使用 … 写长篇网文。`<br>`用户参数：第5章` |

参数照常到达，只是没有标签、裸挂在末尾。按仓库的 issue 分诊表，这本来是「纯文档粒度」那一档。

## 那为什么还是改

两条实际理由，都不是「会丢参数」：

1. **那个追加回退官方文档没有写。** [opencode.ai/docs/commands](https://opencode.ai/docs/commands/) 只描述 `$ARGUMENTS` / `$1` / `$2` 三种占位符，对「没有占位符时参数去哪」只字未提。依赖未文档化行为，OpenCode 版本一升就可能静默失效，而且失效时没有任何守卫会响。
2. **两个 command 面本来就该一致。** ZCode 那 13 份全部带 `$ARGUMENTS`，OpenCode 只有 2 份带。带标签的「用户参数：第5章」也比裸挂一行明确。

## 改了什么

- 给 OpenCode 其余 11 份命令补 `用户参数：$ARGUMENTS`（`story.md`、`story-setup.md` 本来就有），13/13 齐。
- `check-opencode-adapter.sh` 加断言：OpenCode 与 ZCode 两侧每一份命令模板都必须显式含 `$ARGUMENTS`，且两侧命令名集合一致。**能用守卫锁住的不写成文字**——只手工对齐一次而不加断言，等于安排下一次漂移。

## 验证

**真机端到端**（opencode 1.14.32，非结构代理）：把修好的 13 份部署进探针项目，起 `opencode serve`，实跑三条带参命令：

```
/story-long-write 第5章 回炉重写   -> 用户参数：第5章 回炉重写
/story-deslop 正文/第12章.md      -> 用户参数：正文/第12章.md
/story-short-analyze 拆文库/某篇.txt -> 用户参数：拆文库/某篇.txt
```

**守卫负例**：分别抹掉 opencode 与 zcode 各一份的占位符，断言都报错并指名文件；恢复后转绿。

本地 45/45 守卫全绿。纯已部署文本改动，不 bump `agents_version`。

## 同时更正 #408

#408 的说明里写了「OpenCode 参数被丢掉、agent 走部署分支」，前半句同样是错的——`check` 会被追加到末尾，不会丢。#408 真正修对的是正文措辞：原文写死「帮助我部署」，与 `check` 请求冲突。结论不变，理由需要更正。

Closes #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUaZK27w5RuMukGz45NdxN
