### PR TITLE
docs: 拆文/导入前用 cue-omni-reader 收非网页正文素材

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ claude plugin install oh-story@oh-story-skills
 
 **作者习惯会跨会话延续：** 对 `/story` 说“记住我的写作习惯”，稳定偏好会进入工作区 `.story/作者记忆/`；看到 `Author Memory Receipt` 才算写入成功。普通写作只查询本次相关的已确认条目，输出硬上限 2KB，不把完整画像、候选和历史塞进正文 prompt。它与每本书的剧情追踪分开，当前要求、本书设定和硬性门禁始终优先。
 
+**要拆/要导的材料还不是文本时：** 扫榜看到的网页、想导入的旧稿、参考 PDF 或访谈录音这类原始材料，先交给 [cue-omni-reader](https://github.com/sensedeal/cue-skills/tree/main/cue-omni-reader) 收成 Markdown，再进拆文或 `/story-import`。它把网页（含页内视频/附件）与已授权的本地文档/音频/视频解析成 Markdown，一次可选多个本地文件。安装：`npx skills add sensedeal/cue-skills --skill cue-omni-reader`（MIT，可能计费）。
+
 ## Skills
 
 | Skill | 触发 | 说明 |

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ claude plugin install oh-story@oh-story-skills
 
 **作者习惯会跨会话延续：** 对 `/story` 说“记住我的写作习惯”，稳定偏好会进入工作区 `.story/作者记忆/`；看到 `Author Memory Receipt` 才算写入成功。普通写作只查询本次相关的已确认条目，输出硬上限 2KB，不把完整画像、候选和历史塞进正文 prompt。它与每本书的剧情追踪分开，当前要求、本书设定和硬性门禁始终优先。
 
-**要拆/要导的材料还不是文本时：** 扫榜看到的网页、想导入的旧稿、参考 PDF 或访谈录音这类原始材料，先交给 [cue-omni-reader](https://github.com/sensedeal/cue-skills/tree/main/cue-omni-reader) 收成 Markdown，再进拆文或 `/story-import`。它把网页（含页内视频/附件）与已授权的本地文档/音频/视频解析成 Markdown，一次可选多个本地文件。安装：`npx skills add sensedeal/cue-skills --skill cue-omni-reader`（MIT，可能计费）。
+**要拆/要导的材料还不全是网页正文时：** 扫榜的网页正文你们已用 WebFetch 抓链接；[cue-omni-reader](https://github.com/sensedeal/cue-skills/tree/main/cue-omni-reader) 补的是网页正文之外的素材——PDF、访谈录音、页内视频/附件、一次多个本地文件——统一收成 Markdown 后，再进拆文或 `/story-import`。安装：`npx skills add sensedeal/cue-skills --skill cue-omni-reader`（MIT，可能计费）。
 
 ## Skills
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -149,6 +149,8 @@ After updating, if a project has already run `/story-setup`, re-run `/story-setu
 
 **Author preferences persist across sessions:** tell `/story` to remember a writing habit; the write counts as successful only when it returns an `Author Memory Receipt`. Normal writing queries only relevant confirmed items with a hard 2 KB output cap, rather than injecting the full profile, candidates, and history into the prose prompt. This memory stays separate from per-book continuity tracking, and current instructions, book settings, and hard gates always take priority.
 
+**When the material to analyze or import isn't text yet:** web pages you scouted, an old manuscript you want to bring in, a reference PDF, or an interview recording — run them through [cue-omni-reader](https://github.com/sensedeal/cue-skills/tree/main/cue-omni-reader) first to get Markdown, then feed the result into analysis or `/story-import`. It turns web pages (including in-page video/attachments) and authorized local documents, audio, or video into Markdown; you can select multiple local files at once. Install: `npx skills add sensedeal/cue-skills --skill cue-omni-reader` (MIT; may bill).
+
 ## Skills
 
 | Skill | Trigger | Description |

--- a/README_EN.md
+++ b/README_EN.md
@@ -149,7 +149,7 @@ After updating, if a project has already run `/story-setup`, re-run `/story-setu
 
 **Author preferences persist across sessions:** tell `/story` to remember a writing habit; the write counts as successful only when it returns an `Author Memory Receipt`. Normal writing queries only relevant confirmed items with a hard 2 KB output cap, rather than injecting the full profile, candidates, and history into the prose prompt. This memory stays separate from per-book continuity tracking, and current instructions, book settings, and hard gates always take priority.
 
-**When the material to analyze or import isn't text yet:** web pages you scouted, an old manuscript you want to bring in, a reference PDF, or an interview recording — run them through [cue-omni-reader](https://github.com/sensedeal/cue-skills/tree/main/cue-omni-reader) first to get Markdown, then feed the result into analysis or `/story-import`. It turns web pages (including in-page video/attachments) and authorized local documents, audio, or video into Markdown; you can select multiple local files at once. Install: `npx skills add sensedeal/cue-skills --skill cue-omni-reader` (MIT; may bill).
+**When the material to analyze or import isn't just web-page text:** for scouting you already pull web pages with WebFetch; [cue-omni-reader](https://github.com/sensedeal/cue-skills/tree/main/cue-omni-reader) fills the gap *beyond* web-page text — PDFs, interview recordings, in-page video/attachments, or several local files at once — collected into Markdown before analysis or `/story-import`. Install: `npx skills add sensedeal/cue-skills --skill cue-omni-reader` (MIT; may bill).
 
 ## Skills
 


### PR DESCRIPTION
> **利益披露：** 我是 [sensedeal/cue-skills](https://github.com/sensedeal/cue-skills)（MIT）的维护者。本 PR 在 README 中添加一条记录指向 cue-omni-reader，它是我参与维护的工具。

# README：提示用户把「网页正文之外的素材」先收成 Markdown（cue-omni-reader）

## 为什么合这一页

拆文、`/story-import` 导入旧稿都假设素材已是文本。扫榜的网页正文仓库已用 WebFetch 抓取；真正缺的是网页正文之外的素材：要导入的 PDF 旧稿、访谈录音、页内视频/附件、一次多个本地文件。这些进拆文或导入前，缺一步「收成 Markdown」。

## 做了什么

在 `README.md`（中文）与 `README_EN.md`（英文）的「导入续写 / 作者习惯」叙述之后，各加一条同格式的提示：需要时用 **cue-omni-reader** 把这类素材收成 Markdown，再进拆文或 `/story-import`；点明网页正文已有 WebFetch，不重复。一行安装、MIT。

中英成对同步。只改了这两个 README，未新增技能、未拷贝技能正文、未改任何 skill 目录。

## 安装入口

```sh
npx skills add sensedeal/cue-skills --skill cue-omni-reader
```
