### PR TITLE
docs(readme): FAQ from recurring Issues and Discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,41 @@ Agent 按需加载 `references/` 中的写作理论（角色设计、对话技�
 
 这套 skill 现在能让我度过找工作的过渡期 :joy:，希望也能帮到有需要的朋友。
 
+## 常见问题
+
+### 能在 Codex、Google Antigravity、OpenCode 里用吗，还是只支持 Claude Code？
+
+oh-story-claudecode 内置适配 Claude Code、Google Antigravity、OpenCode、ZCode、OpenClaw、Codex CLI 和 Reasonix。Codex 会直接扫描仓库内 `.agents/skills` 发现 13 个 skill，用 `$story-setup` 调用；Antigravity 用 `/skills` 或自然语言运行 `story-setup` 并选择 `target_cli=antigravity`；能读取项目文件的 Web AI / Agent 环境也可以按通用 skills 路径使用。
+
+### 需要 GPU 或自己部署模型吗？
+
+不需要。oh-story-claudecode 是一组 skill，运行在你已经在用的编程 Agent 里，写作用的模型就是该 Agent 的模型；本地只跑确定性的检查脚本（Node / Python）。唯一的例外是 `story-cover` 封面生成，它调用 GPT-Image-2（Codex 内置用量或 API 回退）。
+
+### 每章字数不统一、字数对不上怎么办？
+
+从 v0.7.7 起，长篇正文只用一个机器统计的字数口径：每份细纲必须写明合法的「字数目标」，缺少时会停止而不是回退到 3000；欠字不会自动加戏，超字最多压缩一次。写入后 `check-prose-after-write.sh` 会提醒字数欠账。升级旧项目后重跑 `/story-setup` 并新开会话即可生效。
+
+### 去AI味之后，朱雀等 AI 检测还是判定为 AI 怎么办？
+
+`story-deslop`（`/去AI味`）是写作 lint：它确定性地检测并清除已知的 AI 句式、标点和退化痕迹，目标是读感，不是绕过检测器。朱雀等外部检测只作自测参考，不替代人工读感；oh-story-claudecode 不承诺通过任何 AI 检测。
+
+### 已经写了一部分的小说，能导入后继续写吗？
+
+可以。先在写作项目根运行 `/story-setup`，新开或刷新会话后运行 `/story-import`（`/导入小说`）把已有小说反向解析成标准项目结构，再用 `/story-long-write 日更` 或 `/story-long-write 写第N章` 续写。
+
+### Windows 上安装报 `ENOENT ... mkdir`，但末尾显示 Done，正常吗？
+
+这是有技能没装全。无论有没有报错，重跑同一条安装命令即可修复；如果参考资料目录缺了一块，`/story-setup` 会提示参考资料包不完整。Codex 用户在 Windows 上还需要为 git 打开 `core.symlinks`。
+
+### 升级到新版本后要做什么？
+
+重跑 `/story-setup` 并新开会话。7 个专业 agent（story-architect、narrative-writer、consistency-checker 等）由 `/story-setup` 写入项目目录，必须先部署再新开会话，多 agent 协作才会生效。
+
+### 短篇和长篇的入口有什么区别？
+
+长篇：`/story-long-scan`（扫榜）→ `/story-long-analyze`（拆文）→ `/story-long-write`（写作，含大纲、卷纲、细纲、正文）。短篇：`/story-short-scan` → `/story-short-analyze` → `/story-short-write`。两条线共用 `/story-setup`、`/story-deslop`、`/story-review` 和 `/story-cover`。
+
+
 ## 贡献
 
 欢迎贡献新 skill、补充知识库、更新市场数据。详见 [CONTRIBUTING.md](CONTRIBUTING.md)。

--- a/README_EN.md
+++ b/README_EN.md
@@ -400,6 +400,41 @@ Real output samples are in [demo/](demo/): short-form deconstruction 《曾将�
 
 I built this skill pack to help me through a job-hunting transition :joy:, and I hope it can help others too.
 
+## FAQ
+
+### Does it work in Codex, Google Antigravity or OpenCode, or only in Claude Code?
+
+oh-story-claudecode ships adapters for Claude Code, Google Antigravity, OpenCode, ZCode, OpenClaw, Codex CLI and Reasonix. Codex discovers the 13 skills by scanning `.agents/skills` in the repo and invokes them with `$story-setup`; in Antigravity run `story-setup` via `/skills` or natural language and choose `target_cli=antigravity`. Any Web AI or agent environment that can read project files can use the generic skills path.
+
+### Do I need a GPU or to host a model?
+
+No. oh-story-claudecode is a set of skills that runs inside the coding agent you already use, so the writing model is that agent's model; only deterministic check scripts (Node / Python) run locally. The one exception is `story-cover`, which calls GPT-Image-2 (Codex built-in quota or an API fallback).
+
+### Chapter lengths are inconsistent or the word count is off. What do I do?
+
+Since v0.7.7 long-form prose uses a single machine-counted length metric: every chapter blueprint must state a valid word target, and a missing target stops the run instead of falling back to 3,000; under-length chapters are not padded with new plot, and over-length chapters get at most one compression pass. `check-prose-after-write.sh` flags length debt after each write. Rerun `/story-setup` and start a new session after upgrading an older project.
+
+### After de-AI editing, detectors such as Zhuque still flag the text as AI. Why?
+
+`story-deslop` (`/去AI味`) is a writing lint: it deterministically detects and removes known AI sentence patterns, punctuation habits and degeneration artifacts. Its target is how the prose reads, not evading detectors. External detectors are a self-check reference only, and oh-story-claudecode makes no promise of passing any AI detector.
+
+### I already have part of a novel written. Can I import it and continue?
+
+Yes. Run `/story-setup` in the project root, start or refresh a session, run `/story-import` to reverse-parse the existing novel into the standard project layout, then continue with `/story-long-write 日更` or `/story-long-write 写第N章`.
+
+### On Windows the install prints `ENOENT ... mkdir` but ends with Done. Is that normal?
+
+It means some skills were not fully installed. Rerun the same install command, with or without the error, and it repairs itself; if a reference-material directory is missing, `/story-setup` reports the reference pack as incomplete. Codex users on Windows also need `core.symlinks` enabled in git.
+
+### What do I do after upgrading?
+
+Rerun `/story-setup` and start a new session. The seven agents (story-architect, narrative-writer, consistency-checker and others) are written into the project by `/story-setup`; multi-agent collaboration only takes effect after deploying and opening a fresh session.
+
+### What is the difference between the short-form and long-form entry points?
+
+Long-form: `/story-long-scan` (chart scanning) → `/story-long-analyze` (deconstruction) → `/story-long-write` (outline, volume outline, chapter blueprints, prose). Short-form: `/story-short-scan` → `/story-short-analyze` → `/story-short-write`. Both share `/story-setup`, `/story-deslop`, `/story-review` and `/story-cover`.
+
+
 ## Contributing
 
 Contributions are welcome — new skills, knowledge base additions, market data updates. See [CONTRIBUTING.md](CONTRIBUTING.md) (Chinese only).


### PR DESCRIPTION
Adds a **常见问题 / FAQ** section (8 Q&As, 中文 + English) before 贡献 / Contributing.

Questions are the ones people actually open Issues and Discussions for: Codex / Antigravity / OpenCode support (#23, #251, discussion #248), GPU / hosting, inconsistent chapter length (#361, #58), de-AI editing vs. Zhuque detection (#205, #271), importing an existing novel (#213), Windows `ENOENT` on install, what to do after upgrading, short- vs long-form entry points (#153).

Each answer is self-contained and names the subject rather than saying "it", and restates what the README, usage notes and CHANGELOG already say — no new claims. Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZW7Q9fSdjvVSzyrWxxTa2